### PR TITLE
chore: Fix can not open resource in qtcreator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /.vscode/
+meson.build.user

--- a/src/dde-cooperation/meson.build
+++ b/src/dde-cooperation/meson.build
@@ -55,10 +55,12 @@ dde_cooperation_moc_headers = files('''
   Android/AndroidMainWindow.h
 '''.split())
 
+ui_res = files('''
+  Android/resources.qrc
+'''.split())
+
 dde_cooperation_sources += qt5.preprocess(
-  qresources: [
-    'Android/resources.qrc',
-  ],
+  qresources: ui_res,
   moc_headers: dde_cooperation_moc_headers,
 )
 


### PR DESCRIPTION
The meson build opened by qtcreater, but it can not open the resource file, because it can not find this resource path.

Log: Fix can not open resource in qtcreator