### PR TITLE
fix: Remove submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-﻿[submodule "coost"]
-    path = 3rdparty/coost
-    url = https://github.com/idealvin/coost.git

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,20 @@
+dde-cooperation (0.2.2-5) unstable; urgency=medium
+
+  * Remove submodules.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 28 Sep 2023 10:05:55 +0800
+
 dde-cooperation (0.2.1-4) unstable; urgency=medium
 
   * First test package.
 
- -- re2zero <yangwu@uniontech.com>  Thu, 27 Sep 2023 18:05:07 +0800
+ -- re2zero <yangwu@uniontech.com>  Wed, 27 Sep 2023 18:05:07 +0800
 
 dde-cooperation (0.2.0-3) unstable; urgency=medium
 
   * First build package.
 
- -- re2zero <yangwu@uniontech.com>  Thu, 27 Sep 2023 15:05:07 +0800
+ -- re2zero <yangwu@uniontech.com>  Wed, 27 Sep 2023 15:05:07 +0800
 
 dde-cooperation (0.1.0-2) unstable; urgency=medium
 


### PR DESCRIPTION
The submodule sources will be excluded which has been defined in the .gitmodules, this block CRP build that is in internal network.

Log: remove submodules define.