### PR TITLE
chore: Detach coroutine for unsupported platform.

### DIFF
--- a/3rdparty/coost/src/CMakeLists.txt
+++ b/3rdparty/coost/src/CMakeLists.txt
@@ -9,7 +9,7 @@ if(MSVC)
     endif()
     set_property(SOURCE ${ASM_FILES} PROPERTY LANGUAGE ASM_MASM)
 else()
-    set(ASM_FILES co/context/context.S)
+    set(ASM_FILES co/context/context.S co/context/context.cc)
 endif()
 list(APPEND CO_SRC_FILES ${ASM_FILES})
 

--- a/3rdparty/coost/src/co/context/arch.h
+++ b/3rdparty/coost/src/co/context/arch.h
@@ -53,6 +53,17 @@
       defined(__mips__)
   #define ARCH_MIPS
 
+#elif defined(loongarch) || \
+      defined(_loongarch) || \
+      defined(_loongarch64) || \
+      defined(__loongarch__)
+  #define ARCH_LOONGARCH
+
+#elif defined(sw64) || \
+      defined(_sw64) || \
+      defined(__sw64__)
+  #define ARCH_SW
+
 #else
   #error unknown arch
 #endif
@@ -115,6 +126,7 @@
     defined(__PPC64__) || \
     defined(__ppc64__) || \
     defined(__powerpc64__) || \
+    defined(__loongarch64) || \
     defined(_M_X64) || \
     defined(_M_AMD64) || \
     defined(_M_IA64) || \

--- a/3rdparty/coost/src/co/context/context.cc
+++ b/3rdparty/coost/src/co/context/context.cc
@@ -1,0 +1,55 @@
+/*!The Treasure Box Library
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2009-present, TBOOX Open Source Group.
+ *
+ * @author      ruki
+ * @file        context.c
+ * @ingroup     platform
+ */
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * includes
+ */
+#include "context.h"
+#include "arch.h"
+#include "co/log.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * implementation
+ */
+#if defined(ARCH_LOONGARCH) || defined(ARCH_SW)
+tb_context_t tb_context_make(char* stackdata, size_t stacksize, tb_context_func_t func)
+{
+    CHECK(false) << "corutine 'go' NOT supported, use 'UNIGO' instead";
+    return nullptr;
+}
+tb_context_from_t tb_context_jump(tb_context_t ctx, const void* priv)
+{
+    // noimpl
+    CHECK(false) << "corutine 'go' NOT supported, use 'UNIGO' instead";
+
+    // return emtry context
+    tb_context_from_t from = {0};
+    return from;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/3rdparty/coost/src/co/io_event.cc
+++ b/3rdparty/coost/src/co/io_event.cc
@@ -1,15 +1,19 @@
 #include "hook.h"
 #include "sched.h"
+#include "co/context/arch.h"
 
 namespace co {
 
 #ifndef _WIN32
 
 io_event::~io_event() {
+#if !defined(ARCH_LOONGARCH) && !defined(ARCH_SW)
     if (_added) xx::gSched->del_io_event(_fd, _ev);
+#endif
 }
 
 bool io_event::wait(uint32 ms) {
+#if !defined(ARCH_LOONGARCH) && !defined(ARCH_SW)
     auto sched = xx::gSched;
     if (!_added) {
         _added = sched->add_io_event(_fd, _ev);
@@ -26,6 +30,9 @@ bool io_event::wait(uint32 ms) {
         sched->yield();
         return true;
     }
+#else
+    return false;
+#endif
 }
 
 #else

--- a/3rdparty/zrpc/src/net/tcpconnection.cpp
+++ b/3rdparty/zrpc/src/net/tcpconnection.cpp
@@ -147,7 +147,7 @@ void TcpConnection::input()
 
         // DLOG << "m_read_buffer size=" << m_read_buffer->getBufferVector().size()
         //      << " rd=" << m_read_buffer->readIndex() << " wd=" << m_read_buffer->writeIndex();
-        size_t rt = read_hook(&(m_read_buffer->m_buffer[write_index]), read_count);
+        int rt = read_hook(&(m_read_buffer->m_buffer[write_index]), read_count);
         if (rt > 0) {
             m_read_buffer->recycleWrite(rt);
         }

--- a/src/common/constant.h
+++ b/src/common/constant.h
@@ -131,5 +131,19 @@ typedef enum rpc_result_t {
     INVOKE_DONE = 1,
 } RpcResult;
 
+#if defined(__sw64__) || defined(__loongarch__)
+  #define NON_COROUTINE
+#endif
+
+// use thread replace the coroutine
+#if defined(NON_COROUTINE)
+    #define UNIGO(...) \
+        do { \
+            std::thread coThread(__VA_ARGS__); \
+            coThread.detach(); \
+        } while(0)
+#else
+    #define UNIGO go
+#endif
 
 #endif // CONSTANT_H

--- a/src/plugins/daemon/core/service/searchlight.cpp
+++ b/src/plugins/daemon/core/service/searchlight.cpp
@@ -8,6 +8,7 @@
 #include "co/time.h"
 #include "co/co.h"
 #include "co/log.h"
+#include "common/constant.h"
 
 DEF_int32(max_idle, 3000, "max_idle");
 DEF_string(udp_ip, "0.0.0.0", "udp_ip");
@@ -76,7 +77,7 @@ void Discoverer::start()
 
     _timer.restart();
     // 定时更新发现设备
-    go([this](){
+    UNIGO([this](){
         while (!_stop) {
             sleep::ms(1000); //co::sleep(1000);
             if (remove_idle_services()) {
@@ -92,8 +93,10 @@ void Discoverer::start()
         memset(buffer, 0, sizeof(buffer));
         int recv_len = co::recvfrom(sockfd, buffer, sizeof(buffer), &cli, &len);
         if (recv_len < 0) {
-            LOG << "discoverer server recvfrom error: " << co::strerror();
-            break;
+//            LOG << "discoverer server recvfrom error: " << co::strerror();
+            co::sleep(100);
+            continue;
+//            break;
         }
 
         fastring msg(buffer, recv_len);

--- a/src/plugins/daemon/core/service/servicemanager.h
+++ b/src/plugins/daemon/core/service/servicemanager.h
@@ -48,7 +48,7 @@ public slots:
 private:
     void localIPCStart();
 
-    bool handleRemoteRequestJob(co::Json &info);
+    bool handleRemoteRequestJob(fastring json);
     bool handleFSData(co::Json &info, fastring buf);
     bool handleFSInfo(co::Json &info);
     bool handleCancelJob(co::Json &info);

--- a/src/plugins/daemon/core/service/session.h
+++ b/src/plugins/daemon/core/service/session.h
@@ -7,6 +7,7 @@
 
 #include <QObject>
 #include <co/co.h>
+#include <co/rpc.h>
 
 class Session : public QObject
 {
@@ -23,7 +24,7 @@ public:
     void addJob(int jobid);
     bool removeJob(int jobid);
     int hasJob(int jobid);
-    co::pool* clientPool();
+    rpc::Client* client();
 
 signals:
 
@@ -35,8 +36,9 @@ private:
     int _cb_port = 0;
     co::vector<int> _jobs;
 
-    co::pool *_client_pool = nullptr;
+    std::shared_ptr<rpc::Client> coClient { nullptr };
 
+    bool _initPing = false;
     bool _pingOK = false;
 };
 

--- a/src/plugins/daemon/core/service/transferjob.cpp
+++ b/src/plugins/daemon/core/service/transferjob.cpp
@@ -105,7 +105,7 @@ fastring TransferJob::getAppName()
 void TransferJob::cancel()
 {
     if (_writejob) {
-        go ([this] {
+        UNIGO([this] {
             FileTransJobCancel *cancel = new FileTransJobCancel();
             FileTransUpdate update;
 
@@ -202,7 +202,7 @@ void TransferJob::readFileBlock(const char *filepath, int fileid, const fastring
     if (nullptr == filepath || fileid < 0) {
         return;
     }
-    go ([this, filepath, fileid, subname]() {
+    UNIGO([this, filepath, fileid, subname]() {
         size_t block_size = BLOCK_SIZE;
         int64 file_size = fs::fsize(filepath);
         int64 read_size = 0;
@@ -267,7 +267,7 @@ void TransferJob::readFileBlock(const char *filepath, int fileid, const fastring
 void TransferJob::handleBlockQueque()
 {
     // 定时获取状态并通知，检测是否结束
-    go ([this]() {
+    UNIGO([this]() {
         bool exit = false;
         bool next_exit = false;
         int _max_count = 5; // 接收文件最长时间 x秒，认为异常（网络断开或对端退出）
@@ -376,7 +376,7 @@ void TransferJob::handleBlockQueque()
 
 void TransferJob::handleUpdate(FileTransRe result, const char *path, const char *emsg)
 {
-    go ([this, result, path, emsg] {
+    UNIGO([this, result, path, emsg] {
         FileTransJobReport *report = new FileTransJobReport();
         FileTransUpdate update;
 

--- a/src/plugins/data-transfer/core/utils/transferworker.h
+++ b/src/plugins/data-transfer/core/utils/transferworker.h
@@ -72,7 +72,7 @@ public:
 private:
     TransferWoker();
 
-    co::pool *_gPool = nullptr;
+    std::shared_ptr<rpc::Client> coClient { nullptr };
     fastring _session_id = "";
 };
 


### PR DESCRIPTION
On some HW platform, it does not support context swap for coroutine, use thread instead go.

Log: detach coroutine.