### PR TITLE
Fix: [win] fix process can not exit

### DIFF
--- a/3rdparty/coost/src/so/rpc.cc
+++ b/3rdparty/coost/src/so/rpc.cc
@@ -78,7 +78,10 @@ public:
         _url = url;
         atomic_store(&_started, true, mo_relaxed);
         _tcp_serv.on_connection(&ServerImpl::on_connection, this);
-        _tcp_serv.on_exit([this]() { co::del(this); });
+        _tcp_serv.on_exit([this]() {
+            atomic_store(&_started, false, mo_relaxed);
+            co::del(this);
+        });
         _tcp_serv.start(ip, port, key, ca);
     }
 

--- a/3rdparty/coost/src/so/tcp.cc
+++ b/3rdparty/coost/src/so/tcp.cc
@@ -350,6 +350,7 @@ void ServerImpl::loop() {
     LOG << "server stopped: " << _ip << ':' << _port;
     co::close(_fd); _fd = (sock_t)-1;
     atomic_store(&_status, 2);
+    atomic_store(&_started, false);
     this->unref();
 }
 

--- a/src/apps/data-transfer/main.cpp
+++ b/src/apps/data-transfer/main.cpp
@@ -107,5 +107,10 @@ int main(int argc, char *argv[])
     int ret = app.exec();
 
     app.closeServer();
+
+#ifdef WIN32
+    // FIXME: windows上使用socket，即使线程资源全释放，进程也无法正常退出
+    abort();
+#endif
     return ret;
 }

--- a/src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp
+++ b/src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp
@@ -4,6 +4,8 @@
 #include <QToolButton>
 #include <QPainter>
 #include <QtSvg/QSvgRenderer>
+#include <QPainterPath>
+
 CustomMessageBox::CustomMessageBox(const QString &mainTitle, const QString &subTitle,
                                    QWidget *parent)
     : QDialog(parent), message1(mainTitle), message2(subTitle)

--- a/src/plugins/data-transfer/core/utils/transferworker.cpp
+++ b/src/plugins/data-transfer/core/utils/transferworker.cpp
@@ -152,7 +152,17 @@ void TransferHandle::localIPCStart()
     // start ipc services
     ipc::FrontendImpl *frontendimp = new ipc::FrontendImpl();
     frontendimp->setInterface(_frontendIpcService);
-    rpc::Server().add_service(frontendimp).start("0.0.0.0", UNI_IPC_FRONTEND_PORT, "/frontend", "", "");
+    _rpcServer = new rpc::Server();
+    _rpcServer->add_service(frontendimp);
+    _rpcServer->start("0.0.0.0", UNI_IPC_FRONTEND_PORT, "/frontend", "", "");
+
+    connect(qApp, &QCoreApplication::aboutToQuit, [this]()
+    {
+        DLOG << "App exit, exit ipc server";
+        if (_rpcServer) {
+            _rpcServer->exit();
+        }
+    });
 }
 
 void TransferHandle::saveSession(fastring sessionid)

--- a/src/plugins/data-transfer/core/utils/transferworker.h
+++ b/src/plugins/data-transfer/core/utils/transferworker.h
@@ -51,6 +51,7 @@ private:
     QMap<int, int64_t> _file_ids;
 
     bool _this_destruct = false;
+    rpc::Server *_rpcServer = nullptr;
 };
 
 class TransferWoker


### PR DESCRIPTION
If the process uses socket on windows, then this process can not exit normally even has closed socket. Force abort at end in order to workaround this issue.

Log: fix exit bug.