### PR TITLE
fix: 两个设备之间的投送完成后，再用第三个设备投送文件到接收设备，接收设备无响应

### DIFF
--- a/src/plugins/cooperation/core/maincontroller/maincontroller.cpp
+++ b/src/plugins/cooperation/core/maincontroller/maincontroller.cpp
@@ -75,6 +75,11 @@ void MainController::updateDeviceList(const QString &ip, const QString &info, bo
         map.insert("IPAddress", ip);
 
         auto devInfo = DeviceInfo::fromVariantMap(map);
+        // 不允许被发现，作为下线处理
+        if (devInfo->discoveryMode() == DeviceInfo::DiscoveryMode::NotAllow) {
+            Q_EMIT deviceOffline(ip);
+            return;
+        }
         Q_EMIT deviceOnline({ devInfo });
     } else {
         Q_EMIT deviceOffline(ip);

--- a/src/plugins/daemon/core/service/rpc/sendrpcservice.cpp
+++ b/src/plugins/daemon/core/service/rpc/sendrpcservice.cpp
@@ -62,8 +62,7 @@ void SendRpcWork::handleDoSendProtoMsg(const uint32 type, const QString appName,
     SendResult res;
     if (!sender.isNull()) {
         // 创建exector
-        if (type == IN_LOGIN_INFO)
-            sender->createExecutor();
+        sender->createExecutor();
         if (type == TRANS_APPLY) {
             co::Json param;
             param.parse_from(msg.toStdString());


### PR DESCRIPTION
After the delivery between two devices is completed, then a third device is used to deliver the file to the receiving device, and the receiving device does not respond

Log: After the delivery between two devices is completed, then a third device is used to deliver the file to the receiving device, and the receiving device does not respond
Bug: https://pms.uniontech.com/bug-view-228459.html