### PR TITLE
fix: Modify the back-end discovery logic to only send signals for every time there is a change

### DIFF
--- a/3rdparty/coost/src/so/rpc.cc
+++ b/3rdparty/coost/src/so/rpc.cc
@@ -394,7 +394,7 @@ void ServerImpl::on_connection(tcp::Connection conn)
     }
 
 recv_zero_err:
-    LOG << "rpc client close the connection, connfd: " << conn.socket();
+//    LOG << "rpc client close the connection, connfd: " << conn.socket();
     if (this->callback) {
         callback(0, _tcp_serv.addressIP(), _tcp_serv.addressPort());
     }

--- a/3rdparty/coost/src/so/tcp.cc
+++ b/3rdparty/coost/src/so/tcp.cc
@@ -337,9 +337,9 @@ void ServerImpl::loop() {
         }
 
         const uint32 n = this->ref() - 1;
-        DLOG << "server " << _ip << ':' << _port
-             << " accept connection: " << co::addr2str(&_addr, _addrlen)
-             << ", connfd: " << _connfd << ", conn num: " << n;
+//        DLOG << "server " << _ip << ':' << _port
+//             << " accept connection: " << co::addr2str(&_addr, _addrlen)
+//             << ", connfd: " << _connfd << ", conn num: " << n;
 #if !defined(DISABLE_GO)
         go(&_on_sock, _connfd);
 #else


### PR DESCRIPTION
Modify the back-end discovery logic to only send signals for every time there is a change

Log: Modify the back-end discovery logic to only send signals for every time there is a change