### PR TITLE
fix: File Delivery - Invalid file save location setting

### DIFF
--- a/src/plugins/daemon/core/service/job/transferjob.h
+++ b/src/plugins/daemon/core/service/job/transferjob.h
@@ -87,6 +87,7 @@ private:
     fastring _app_name; // //前端应用名
     fastring _path; // 目录或文件路径
     fastring _savedir; // 写作业，文件保存的目录
+    fastring _save_fulldir; // 全路径
     fastring _tar_app_name; // 发送到目标的应用名称
     fastring _tar_ip;
 

--- a/src/plugins/daemon/core/utils/config.h
+++ b/src/plugins/daemon/core/utils/config.h
@@ -66,7 +66,6 @@ public:
         _fileConfig->beginGroup(groupname);
         value = _fileConfig->value(key.c_str(), "").toString().toStdString();
         _fileConfig->endGroup();
-
         return value;
     }
 
@@ -176,15 +175,10 @@ public:
     const fastring getStorageDir(const fastring &appName)
     {
         fastring home;
-        auto it = _storage_caches.find(appName);
-        if (it != _storage_caches.end()) {
-            home = it->second;
-        } else {
-            home = getAppConfig(appName, "storagedir");
-            if (home.empty())
-                home = getStorageDir();
-            _storage_caches.insert(std::make_pair(appName, home));
-        }
+        home = getAppConfig(appName, "storagedir");
+        if (home.empty())
+            home = getStorageDir();
+
         return home;
     }
 
@@ -194,7 +188,6 @@ private:
     fastring _authedToken;
     fastring _storageDir;
     fastring _targetName;
-    co::map<fastring, fastring> _storage_caches;
 
     QSettings *_fileConfig;
     QReadWriteLock _config_mutex;


### PR DESCRIPTION
Added to cache to read file configuration, not cached during setup

Log: File Delivery - Invalid file save location setting
Bug: https://pms.uniontech.com/bug-view-232831.html