### PR TITLE
fix: Unable to transfer files again after network disconnection

### DIFF
--- a/3rdparty/zrpc/include/zrpc.h
+++ b/3rdparty/zrpc/include/zrpc.h
@@ -45,6 +45,7 @@ public:
 
     void setCallBackFunc(const std::function<void(int, const fastring &, const uint16)> &call);
 
+    bool checkConnected();
 private:
     bool doregister(std::shared_ptr<google::protobuf::Service> service);
 

--- a/3rdparty/zrpc/src/net/tcpbuffer.cpp
+++ b/3rdparty/zrpc/src/net/tcpbuffer.cpp
@@ -116,8 +116,8 @@ void TcpBuffer::recycleWrite(int index) {
 }
 
 std::string TcpBuffer::getBufferString() {
-    std::string re(readAble(), '0');
-    memcpy(&re[0], &m_buffer[m_read_index], readAble());
+    std::string re(static_cast<size_t>(readAble()), '0');
+    memcpy(&re[0], &m_buffer[static_cast<size_t>(m_read_index)], static_cast<size_t>(readAble()));
     return re;
 }
 

--- a/3rdparty/zrpc/src/net/tcpclient.cpp
+++ b/3rdparty/zrpc/src/net/tcpclient.cpp
@@ -18,12 +18,12 @@ TcpClient::TcpClient(NetAddress::ptr addr)
     m_codec = std::make_shared<ZRpcCodeC>();
 
     char *ip = m_peer_addr.get()->getIP();
-    uint16 port = m_peer_addr.get()->getPort();
+    uint16 port = static_cast<uint16>(m_peer_addr.get()->getPort());
     bool ssl = m_peer_addr.get()->isSSL();
 
     _tcp_cli = new tcp::Client(ip, port, ssl);
 
-    m_connection = std::make_shared<TcpConnection>(this, _tcp_cli, 1024, m_peer_addr);
+    m_connection = std::make_shared<TcpConnection>(this, _tcp_cli, PERPKG_MAX_LEN, m_peer_addr);
 }
 
 TcpClient::~TcpClient() {
@@ -37,7 +37,7 @@ bool TcpClient::tryConnect() {
     if (!this->connected() && !this->connect()) {
         if (callback) {
             fastring ip = m_peer_addr ? m_peer_addr->getIP() : "";
-            uint16 port = m_peer_addr ? m_peer_addr->getPort() : 0;
+            uint16 port = m_peer_addr ? static_cast<uint16>(m_peer_addr->getPort()) : 0;
             callback(1, ip, port); // 1 超时
         }
         return false;
@@ -57,7 +57,7 @@ bool TcpClient::connect() {
 
 TcpConnection *TcpClient::getConnection() {
     if (!m_connection.get()) {
-        m_connection = std::make_shared<TcpConnection>(this, _tcp_cli, 1024, m_peer_addr);
+        m_connection = std::make_shared<TcpConnection>(this, _tcp_cli, PERPKG_MAX_LEN, m_peer_addr);
     }
     return m_connection.get();
 }

--- a/3rdparty/zrpc/src/net/tcpconnection.h
+++ b/3rdparty/zrpc/src/net/tcpconnection.h
@@ -89,9 +89,11 @@ public:
 
     void initServer();
 
+    bool waited();
+
 private:
-    int64 read_hook(char *buf, size_t len);
-    int64 write_hook(const void *buf, size_t count);
+    int64 read_hook(char *buf, int len);
+    int64 write_hook(const void *buf, int count);
     void clearClient();
 
 private:
@@ -119,6 +121,7 @@ private:
     fastring remoteIP;
 
     CallBackFunc callback { nullptr };
+    int64 _rev_start_time = 0;
 };
 
 }   // namespace zrpc_ns

--- a/3rdparty/zrpc/src/net/tcpserver.h
+++ b/3rdparty/zrpc/src/net/tcpserver.h
@@ -36,6 +36,8 @@ public:
 
     void setCallBackFunc(const CallBackFunc &callback);
 
+    bool checkConnected();
+
 public:
     AbstractDispatcher::ptr getDispatcher();
 

--- a/3rdparty/zrpc/src/spec/rpcchannel.cpp
+++ b/3rdparty/zrpc/src/spec/rpcchannel.cpp
@@ -107,7 +107,7 @@ void ZRpcChannel::CallMethod(const google::protobuf::MethodDescriptor *method,
     if (res_data->err_code != 0) {
         ELOG << pb_struct.msg_req << "|server reply error_code=" << res_data->err_code
              << ", err_info=" << res_data->err_info;
-        rpc_controller->SetError(res_data->err_code, res_data->err_info);
+        rpc_controller->SetError(static_cast<int>(res_data->err_code), res_data->err_info);
         return;
     }
 

--- a/3rdparty/zrpc/src/zrpc.cpp
+++ b/3rdparty/zrpc/src/zrpc.cpp
@@ -19,7 +19,7 @@ ZRpcClient::ZRpcClient(const char *ip, uint16 port, bool ssl, const bool isLong)
 }
 
 void ZRpcClient::setTimeout(uint32 timeout) {
-    m_controller.get()->SetTimeout(timeout);
+    m_controller.get()->SetTimeout(static_cast<int>(timeout));
 }
 
 class ZRpcServerImpl {
@@ -44,6 +44,12 @@ public:
         return true;
     }
 
+    bool checkConnected() {
+        if (_tcpserver == nullptr)
+            return false;
+        return _tcpserver->checkConnected();
+    }
+
 private:
     TcpServer::ptr _tcpserver{nullptr};
 };
@@ -53,21 +59,26 @@ ZRpcServer::ZRpcServer(uint16 port, char *key, char *crt) {
 }
 
 ZRpcServer::~ZRpcServer() {
-    co::del((ZRpcServerImpl *)_p);
+    co::del(static_cast<ZRpcServerImpl *>(_p));
 }
 
 bool ZRpcServer::doregister(std::shared_ptr<google::protobuf::Service> service) {
-    TcpServer::ptr tcpserver = ((ZRpcServerImpl *)_p)->getServer();
+    TcpServer::ptr tcpserver = (static_cast<ZRpcServerImpl *>(_p))->getServer();
     return tcpserver->registerService(service);
 }
 
 bool ZRpcServer::start() {
-    return ((ZRpcServerImpl *)_p)->start();
+    return (static_cast<ZRpcServerImpl *>(_p))->start();
 }
 
 void ZRpcServer::setCallBackFunc(const std::function<void (int, const fastring &, const uint16)> &call)
 {
-    ((ZRpcServerImpl *)_p)->getServer()->setCallBackFunc(call);
+    (static_cast<ZRpcServerImpl *>(_p))->getServer()->setCallBackFunc(call);
+}
+
+bool ZRpcServer::checkConnected()
+{
+    return (static_cast<ZRpcServerImpl *>(_p))->checkConnected();
 }
 
 } // namespace zrpc_ns

--- a/src/plugins/daemon/core/service/comshare.cpp
+++ b/src/plugins/daemon/core/service/comshare.cpp
@@ -5,7 +5,58 @@
 #include "comshare.h"
 
 
-comshare::comshare()
+Comshare::Comshare()
 {
 
+}
+
+Comshare::~Comshare()
+{
+
+}
+
+Comshare *Comshare::instance()
+{
+    static Comshare s;
+    return &s;
+}
+
+void Comshare::updateStatus(const CurrentStatus st)
+{
+    QWriteLocker lk(&_lock);
+    _cur_status = st;
+}
+
+void Comshare::updateComdata(const QString &appName, const QString &tarappName, const QString &ip)
+{
+    QWriteLocker lk(&_lock);
+    _target_app.remove(appName);
+    _target_app.insert(appName, tarappName);
+    _target_ip.remove(appName);
+    _target_ip.insert(appName, ip);
+}
+
+QString Comshare::targetAppName(const QString &appName)
+{
+    QReadLocker lk(&_lock);
+    return _target_app.value(appName);
+}
+
+QString Comshare::targetIP(const QString &appName)
+{
+    QReadLocker lk(&_lock);
+    return _target_ip.value(appName);
+}
+
+CurrentStatus Comshare::currentStatus()
+{
+    QReadLocker lk(&_lock);
+    return static_cast<CurrentStatus>(_cur_status.load());
+}
+
+bool Comshare::checkTransCanConnect()
+{
+    QReadLocker lk(&_lock);
+    return _cur_status <= CurrentStatus::CURRENT_STATUS_DISCONNECT ||
+            _cur_status > CURRENT_STATUS_TRAN_FILE_RCV;
 }

--- a/src/plugins/daemon/core/service/comshare.h
+++ b/src/plugins/daemon/core/service/comshare.h
@@ -10,6 +10,8 @@
 #include <co/json.h>
 
 #include <QList>
+#include <QReadWriteLock>
+#include <QMap>
 
 typedef enum income_type_t {
     IN_LOGIN_RESULT= 100,
@@ -71,10 +73,36 @@ typedef enum barrier_type_t {
     Client = 666
 } BarrierType;
 
-class comshare
+enum CurrentStatus {
+    CURRENT_STATUS_DISCONNECT = 0, // 没有连接
+    CURRENT_STATUS_TRAN_CONNECT = 1, // 1是文件投送连接
+    CURRENT_STATUS_TRAN_APPLY = 2, // 2文件投送申请
+    CURRENT_STATUS_TRAN_FILE_SEN = 3, // 3文件发送
+    CURRENT_STATUS_TRAN_FILE_RCV = 4, // 4文件接收
+    CURRENT_STATUS_SHARE_CONNECT = 5, // 5键鼠共享连接
+    CURRENT_STATUS_SHARE_START = 6, // 5键鼠共享中
+};
+
+class Comshare
 {
+private:
+    Comshare();
 public:
-    comshare();
+    ~Comshare();
+    static Comshare *instance();
+    void updateStatus(const CurrentStatus st);
+    void updateComdata(const QString &appName, const QString &tarappName, const QString &ip);
+    QString targetAppName(const QString &appName);
+    QString targetIP(const QString &appName);
+    CurrentStatus currentStatus();
+    bool checkTransCanConnect();
+    bool checkCanTransJob();
+private:
+    QReadWriteLock _lock;
+    std::atomic_int _cur_status {0};// 0是没有连接，1是文件投送连接，
+    // 2文件投送申请，3文件发送，4文件接收，5键鼠共享连接，6键鼠共享中
+    QMap<QString, QString> _target_app; // appname
+    QMap<QString, QString> _target_ip; //
 };
 
 #endif // COMSHARE_H

--- a/src/plugins/daemon/core/service/job/transferjob.cpp
+++ b/src/plugins/daemon/core/service/job/transferjob.cpp
@@ -467,6 +467,8 @@ void TransferJob::readPath(fastring path, fastring root, const bool acTotal)
     fs::dir d(dirpath);
     auto v = d.all();   // 读取所有子项
     for (const fastring &file : v) {
+        if (_status >= STOPED)
+            return;
         fastring file_path = path::join(d.path(), file.c_str());
         scanPath(root, file_path, acTotal);
     }

--- a/src/plugins/daemon/core/service/rpc/handlerpcservice.h
+++ b/src/plugins/daemon/core/service/rpc/handlerpcservice.h
@@ -41,6 +41,8 @@ public:
     void handleRemoteShareStop(co::Json &info);
     void handleRemoteDisConnectCb(co::Json &info);
     void handleRemotePing(const QString &info);
+    // 检查51597和51599两个端口是否有连接阻塞，没有退出
+    bool checkConnected();
 
 private:
     void startRemoteServer(const quint16 port);

--- a/src/plugins/daemon/core/service/rpc/remoteservice.cpp
+++ b/src/plugins/daemon/core/service/rpc/remoteservice.cpp
@@ -78,11 +78,13 @@ SendResult RemoteServiceSender::doSendProtoMsg(const uint32 type, const QString 
     DLOG_IF(FLG_log_detail) << "send to remote = " << type << " = " << msg.toStdString() << "\n ip = "
          << _target_ip.toStdString() << " : port = " << _target_port;
     QSharedPointer<ZRpcClientExecutor> _executor_p{nullptr};
+
     if (!isTrans) {
         _executor_p = createExecutor();
     } else {
         _executor_p = createTransExecutor();
     }
+
     SendResult res;
     res.protocolType = type;
     if (_executor_p.isNull()) {
@@ -227,11 +229,18 @@ void RemoteServiceBinder::startRpcListen(const char *keypath, const char *crtpat
     char crt[1024];
     strcpy(key, keypath);
     strcpy(crt, crtpath);
-    zrpc_ns::ZRpcServer *server = new zrpc_ns::ZRpcServer(port, key, crt);
+    server = new zrpc_ns::ZRpcServer(port, key, crt);
     server->registerService<RemoteServiceImpl>();
     if (call) {
         callback = call;
         server->setCallBackFunc(callback);
     }
     server->start();
+}
+
+bool RemoteServiceBinder::checkConneted()
+{
+    if (!server)
+        return false;
+    return server->checkConnected();
 }

--- a/src/plugins/daemon/core/service/rpc/remoteservice.h
+++ b/src/plugins/daemon/core/service/rpc/remoteservice.h
@@ -87,8 +87,8 @@ private:
     QString _app_name;
     QString _target_ip;
     uint16 _target_port;
-    bool isTrans { false };
     int _rpc_call { 0 };
+    bool isTrans { false };
 };
 
 class RemoteServiceBinder : public QObject {
@@ -98,8 +98,10 @@ public:
     ~RemoteServiceBinder() override = default;
     void startRpcListen(const char *keypath, const char *crtpath, const quint16 port,
                         const std::function<void(int, const fastring &, const uint16)> &call = nullptr);
+    bool checkConneted();
 private:
     std::function<void(int, const fastring &, const uint16)> callback{ nullptr };
+    zrpc_ns::ZRpcServer *server{nullptr};
 };
 
 #endif   // REMOTE_SERVICE_H

--- a/src/plugins/daemon/core/service/servicemanager.h
+++ b/src/plugins/daemon/core/service/servicemanager.h
@@ -7,6 +7,7 @@
 
 #include <QObject>
 #include <QSharedPointer>
+#include <QTimer>
 
 #include "co/co.h"
 #include "co/json.h"
@@ -24,15 +25,22 @@ public:
     ~ServiceManager();
 
     void startRemoteServer();
+private Q_SLOTS:
+    void checkSelfNetWork();
 
 private:
     void localIPCStart();
     fastring genPeerInfo();
     void asyncDiscovery();
+    void createBashAndRun();
 private:
     HandleIpcService *_ipcService { nullptr };
     HandleRpcService *_rpcService { nullptr };
     QSharedPointer<HandleSendResultService> _logic;
+    bool _network_ok { true };
+    int _dis_counts { 0 };
+    int _check_count { -1 };
+    QTimer _net_check;
 };
 
 #endif // SERVICEMANAGER_H


### PR DESCRIPTION
Change to a short connection, send once and close TCP once. Modifying the issue of sending data errors

Log: Unable to transfer files again after network disconnection