### PR TITLE
fix: The device status is displayed incorrectly

### DIFF
--- a/src/plugins/cooperation/core/maincontroller/maincontroller.cpp
+++ b/src/plugins/cooperation/core/maincontroller/maincontroller.cpp
@@ -52,7 +52,7 @@ void MainController::checkNetworkState()
     }
 }
 
-void MainController::updateDeviceList(const QString &ip, int osType, const QString &info, bool isOnline)
+void MainController::updateDeviceList(const QString &ip, const QString &connectedIp, int osType, const QString &info, bool isOnline)
 {
     if (!this->isOnline)
         return;
@@ -71,6 +71,9 @@ void MainController::updateDeviceList(const QString &ip, int osType, const QStri
         map.insert("OSType", osType);
         auto devInfo = DeviceInfo::fromVariantMap(map);
         if (devInfo->discoveryMode() == DeviceInfo::DiscoveryMode::Everyone) {
+            if (connectedIp == CooperationUtil::localIPAddress())
+                devInfo->setConnectStatus(DeviceInfo::Connected);
+
             // 处理设备的共享属性发生变化情况
             CooperationManager::instance()->checkAndProcessShare(devInfo);
             Q_EMIT deviceOnline({ devInfo });

--- a/src/plugins/cooperation/core/maincontroller/maincontroller.h
+++ b/src/plugins/cooperation/core/maincontroller/maincontroller.h
@@ -37,7 +37,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void checkNetworkState();
-    void updateDeviceList(const QString &ip, int osType, const QString &info, bool isOnline);
+    void updateDeviceList(const QString &ip, const QString &connectedIp, int osType, const QString &info, bool isOnline);
     void onDiscoveryFinished(const QList<DeviceInfoPointer> &infoList);
     void onAppAttributeChanged(const QString &group, const QString &key, const QVariant &value);
 

--- a/src/plugins/cooperation/core/utils/cooperationutil.cpp
+++ b/src/plugins/cooperation/core/utils/cooperationutil.cpp
@@ -123,6 +123,7 @@ void CooperationUtilPrivate::localIPCStart()
                                                   "updateDeviceList",
                                                   Qt::QueuedConnection,
                                                   Q_ARG(QString, QString(nodeInfo.os.ipv4.c_str())),
+                                                  Q_ARG(QString, QString("")),
                                                   Q_ARG(int, nodeInfo.os.os_type),
                                                   Q_ARG(QString, QString("")),
                                                   Q_ARG(bool, param.result));
@@ -142,6 +143,7 @@ void CooperationUtilPrivate::localIPCStart()
                                                   "updateDeviceList",
                                                   Qt::QueuedConnection,
                                                   Q_ARG(QString, QString(nodeInfo.os.ipv4.c_str())),
+                                                  Q_ARG(QString, QString(nodeInfo.os.share_connect_ip.c_str())),
                                                   Q_ARG(int, nodeInfo.os.os_type),
                                                   Q_ARG(QString, QString(appInfo.json.c_str())),
                                                   Q_ARG(bool, param.result));


### PR DESCRIPTION
Symptom After the remote device is disconnected and reconnected, the device status is displayed incorrectly

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-234325.html