### PR TITLE
fix: Cancel job if frontend exit

### DIFF
--- a/src/plugins/daemon/core/service/job/transferjob.cpp
+++ b/src/plugins/daemon/core/service/job/transferjob.cpp
@@ -137,6 +137,7 @@ bool TransferJob::createFile(const fastring fullpath, const bool isDir)
 void TransferJob::start()
 {
     atomic_store(&_status, STARTED);
+    _mark_canceled = false;
 
     if (_writejob) {
         DLOG << "start write job: " << _savedir << " fullpath = " << _save_fulldir;
@@ -220,6 +221,7 @@ fastring TransferJob::getAppName()
 void TransferJob::cancel(bool notify)
 {
     DLOG << "job cancel: " << notify;
+    _mark_canceled = true;
     if (notify) {
         atomic_cas(&_status, STARTED, CANCELING);   // 如果运行，则赋值取消
     } else {
@@ -362,7 +364,7 @@ void TransferJob::handleBlockQueque()
             }
         }
     };
-    if (!exception) {
+    if (!exception && !_mark_canceled) {
         handleJobStatus(JOB_TRANS_FINISHED);
     }
     LOG << "trans job end: " << _jobid;

--- a/src/plugins/daemon/core/service/job/transferjob.h
+++ b/src/plugins/daemon/core/service/job/transferjob.h
@@ -91,6 +91,7 @@ private:
     bool _sub;
     bool _writejob {false};
     bool _init_success { true };
+    bool _mark_canceled { false };
 
     uint16 _tar_port{0};
     fastring _app_name; // //前端应用名


### PR DESCRIPTION
It should cancel running transfer job if the frontend exit by user.

Log: Fix cancel issue.