### PR TITLE
fix: After initiating a collaboration application, clicking the cancel button is invalid

### DIFF
--- a/src/common/commonstruct.h
+++ b/src/common/commonstruct.h
@@ -520,7 +520,7 @@ struct ShareStart {
         tarAppname = _x_.get("tarAppname").as_c_str();
         config.from_json(_x_.get("config"));
         ip = _x_.get("ip").as_c_str();
-        port = (int32)_x_.get("port").as_int64();
+        port = static_cast<int32>(_x_.get("port").as_int64());
     }
 
     co::Json as_json() const {
@@ -573,6 +573,30 @@ struct ShareStartRmoteReply {
         _x_.add_member("appName", appName);
         _x_.add_member("tarAppname", tarAppname);
         _x_.add_member("errorMsg", errorMsg);
+        return _x_;
+    }
+};
+
+// 取消共享连接申请
+struct ShareConnectDisApply {
+    fastring appName;
+    fastring tarAppname;
+    fastring ip;
+    fastring msg;
+
+    void from_json(const co::Json& _x_) {
+        appName = _x_.get("appName").as_c_str();
+        tarAppname = _x_.get("tarAppname").as_c_str();
+        ip = _x_.get("ip").as_c_str();
+        msg = _x_.get("msg").as_c_str();
+    }
+
+    co::Json as_json() const {
+        co::Json _x_;
+        _x_.add_member("appName", appName);
+        _x_.add_member("tarAppname", tarAppname);
+        _x_.add_member("ip", ip);
+        _x_.add_member("msg", msg);
         return _x_;
     }
 };

--- a/src/common/commonstruct.proto
+++ b/src/common/commonstruct.proto
@@ -175,3 +175,10 @@ object ShareStartRmoteReply {
     string tarAppname // 目标的app名称
     string errorMsg // 错误消息
 }
+
+object ShareConnectDisApply { // 取消共享连接申请
+    string appName // 自己的app名称
+    string tarAppname // 目标app的名称
+    string ip // 取消的ip（自己的ip）
+    string msg // 取消消息
+}

--- a/src/ipc/bridge.h
+++ b/src/ipc/bridge.h
@@ -25,6 +25,7 @@ typedef enum req_type_t {
     FRONT_SHARE_START_REPLY = 112, // 后端通知前端共享结果
     FRONT_SHARE_STOP = 113, // 收到停止事件
     FRONT_DISCONNECT_CB = 114, // 断开连接
+    FRONT_SHARE_DISAPPLY_CONNECT = 115, // 收到取消申请共享连接
     BACK_GET_DISCOVERY = 200,
     BACK_GET_PEER = 201,
     BACK_GET_PASSWORD = 202,
@@ -48,6 +49,7 @@ typedef enum req_type_t {
     BACK_SHARE_CONNECT_REPLY = 220, // 被控制方告诉后端连接被控制方的回复
     BACK_SHARE_STOP = 221, // 停止共享，两端都可以
     BACK_DISCONNECT_CB = 222, // 文件投送断开连接
+    BACK_SHARE_DISAPPLY_CONNECT = 223, // 控制方取消申请共享
 } ReqType;
 
 typedef enum res_type_t {

--- a/src/plugins/daemon/core/service/comshare.h
+++ b/src/plugins/daemon/core/service/comshare.h
@@ -37,6 +37,7 @@ typedef enum income_type_t {
     SHARE_START_RES = 1018, // 被控制方通知控制方，共享结果
     SHARE_STOP = 1019, // 停止
     DISCONNECT_CB = 1020, // 断开cb的连接
+    DISAPPLY_SHARE_CONNECT = 1021, // 取消申请共享
 } IncomeType;
 
 typedef enum outgo_type_t {

--- a/src/plugins/daemon/core/service/ipc/handleipcservice.cpp
+++ b/src/plugins/daemon/core/service/ipc/handleipcservice.cpp
@@ -206,6 +206,10 @@ void HandleIpcService::handleAllMsg(const QSharedPointer<BackendService> backend
         handleDisConnectCb(msg);
         break;
     }
+    case BACK_SHARE_DISAPPLY_CONNECT: {
+        handleShareConnectDisApply(msg);
+        break;
+    }
     default:
         break;
     }
@@ -449,6 +453,18 @@ void HandleIpcService::handleShareConnectReply(co::Json json)
     // 回复控制端连接结果
     SendRpcService::instance()->doSendProtoMsg(APPLY_SHARE_CONNECT_RES,
                                                reply.appName.c_str(), json.str().c_str());
+}
+// 取消协同申请
+void HandleIpcService::handleShareConnectDisApply(co::Json json)
+{
+    ShareConnectDisApply reply;
+    reply.from_json(json);
+
+    reply.ip = Util::getFirstIp();
+    // 回复控制端连接结果
+    SendRpcService::instance()->doSendProtoMsg(DISAPPLY_SHARE_CONNECT,
+                                               reply.appName.c_str(), json.str().c_str());
+
 }
 
 void HandleIpcService::handleShareStop(co::Json json)

--- a/src/plugins/daemon/core/service/ipc/handleipcservice.h
+++ b/src/plugins/daemon/core/service/ipc/handleipcservice.h
@@ -34,6 +34,7 @@ public slots:
     void handleShareConnect(co::Json json);
     void handleShareDisConnect(co::Json json);
     void handleShareConnectReply(co::Json json);
+    void handleShareConnectDisApply(co::Json json);
     void handleShareStop(co::Json json);
     void handleDisConnectCb(co::Json json);
     void handleShareServerStart(const bool ok, const QString msg);

--- a/src/plugins/daemon/core/service/rpc/handlerpcservice.cpp
+++ b/src/plugins/daemon/core/service/rpc/handlerpcservice.cpp
@@ -410,6 +410,21 @@ void HandleRpcService::handleRemotePing(const QString &info)
     _ping_lost_count.insert(appName, 0);
 }
 
+void HandleRpcService::handleRemoteDisApplyShareConnect(co::Json &info)
+{
+    // 发送给前端
+    ShareConnectDisApply sd;
+    sd.from_json(info);
+
+    ShareEvents event;
+    event.eventType = FRONT_SHARE_DISAPPLY_CONNECT;
+    event.data = info.str();
+    co::Json req = info;
+    req.add_member("api", "Frontend.shareEvents");
+    SendIpcService::instance()->handleSendToClient(sd.tarAppname.c_str(), req.str().c_str());
+    SendRpcService::instance()->removePing(sd.tarAppname.c_str());
+}
+
 bool HandleRpcService::checkConnected()
 {
     return _rpc->checkConneted() || _rpc_trans->checkConneted();
@@ -572,6 +587,14 @@ void HandleRpcService::startRemoteServer(const quint16 port)
                 OutData data;
                 _outgo_chan << data;
                 self->handleRemoteDisConnectCb(json_obj);
+                break;
+            }
+            case DISAPPLY_SHARE_CONNECT:
+            {
+                // 断开连接
+                OutData data;
+                _outgo_chan << data;
+                self->handleRemoteDisApplyShareConnect(json_obj);
                 break;
             }
             default:{

--- a/src/plugins/daemon/core/service/rpc/handlerpcservice.h
+++ b/src/plugins/daemon/core/service/rpc/handlerpcservice.h
@@ -41,6 +41,7 @@ public:
     void handleRemoteShareStop(co::Json &info);
     void handleRemoteDisConnectCb(co::Json &info);
     void handleRemotePing(const QString &info);
+    void handleRemoteDisApplyShareConnect(co::Json &info);
     // 检查51597和51599两个端口是否有连接阻塞，没有退出
     bool checkConnected();
 


### PR DESCRIPTION
Add/Cancel Sharing Connection Agreement

Log: After initiating a collaboration application, clicking the cancel button is invalid
Bug: https://pms.uniontech.com/bug-view-232941.html