### PR TITLE
fix: Fix sender no change UI if remote cancel

### DIFF
--- a/src/plugins/data-transfer/core/utils/transferworker.cpp
+++ b/src/plugins/data-transfer/core/utils/transferworker.cpp
@@ -247,6 +247,7 @@ void TransferHandle::handleTransJobStatus(int id, int result, QString path)
     case JOB_TRANS_CANCELED:
         _job_maps.remove(id);
         emit TransferHelper::instance()->interruption();
+        TransferHelper::instance()->emitDisconnected();
         break;
     default:
         break;


### PR DESCRIPTION
If the user cancel accept, the sender(win) not break.

Log: Fix cancel UI not change.