### PR TITLE
fix: The UOS end still displays a collaborative state with Win

### DIFF
--- a/src/plugins/cooperation/core/utils/cooperationutil.cpp
+++ b/src/plugins/cooperation/core/utils/cooperationutil.cpp
@@ -226,6 +226,7 @@ void CooperationUtilPrivate::localIPCStart()
                 ShareDisConnect disCon;
                 disCon.from_json(json_obj);
 
+                LOG << "share disconnect info: " << json_obj;
                 q->metaObject()->invokeMethod(CooperationManager::instance(),
                                               "handleDisConnectResult",
                                               Qt::QueuedConnection,

--- a/src/plugins/cooperation/daemon/utils/cooperationutil.cpp
+++ b/src/plugins/cooperation/daemon/utils/cooperationutil.cpp
@@ -6,6 +6,7 @@
 #include "cooperationutil_p.h"
 #include "maincontroller/maincontroller.h"
 #include "configs/settings/configmanager.h"
+#include "maincontroller/maincontroller.h"
 
 #include "common/constant.h"
 #include "ipc/frontendservice.h"
@@ -132,6 +133,7 @@ void CooperationUtilPrivate::localIPCStart()
             } break;
             case FRONT_SERVER_ONLINE:
                 pingBackend();
+                MainController::instance()->regist();
                 break;
             default:
                 break;

--- a/src/plugins/daemon/core/service/discoveryjob.cpp
+++ b/src/plugins/daemon/core/service/discoveryjob.cpp
@@ -46,7 +46,7 @@ DiscoveryJob::~DiscoveryJob()
 void DiscoveryJob::discovererRun()
 {
     _discoverer_p = co::make<searchlight::Discoverer>(
-        "ulink_service",
+        "{\"name\":\"ulink_service\",\"port\"",
         [this](const QList<searchlight::Discoverer::service> & services)
         {
             QWriteLocker lk(&_dis_lock);

--- a/src/plugins/daemon/core/service/ipc/sendipcservice.h
+++ b/src/plugins/daemon/core/service/ipc/sendipcservice.h
@@ -38,6 +38,7 @@ private slots:
 private:
     explicit SendIpcWork(QObject *parent = nullptr);
     void stop();
+    void handleStopShareConnect(const QString &info, const QSharedPointer<Session> s);
 
 private:
     // record the frontend session

--- a/src/plugins/daemon/core/service/searchlight.cpp
+++ b/src/plugins/daemon/core/service/searchlight.cpp
@@ -154,7 +154,7 @@ void Discoverer::handle_message(const fastring& message, const fastring& sender_
     auto preHost = ip.find_last_of(".") > ip.size()
             ? ip : ip.substr(0, ip.find_last_of("."));
     fastring self_ip = Util::getFirstIp();
-    if (name == _listen_for_service && ip != self_ip && self_ip.starts_with(preHost)) {
+    if (message.starts_with(_listen_for_service) && ip != self_ip && self_ip.starts_with(preHost)) {
         // 找到最近的时间修改，只发送改变了的
         handleChanges(endpoint, info, _timer.ms());
     } else {


### PR DESCRIPTION
Upon receiving the offline message, disconnect the current connection and notify the offline user again

Log: The UOS end still displays a collaborative state with Win
Bug: https://pms.uniontech.com/bug-view-233775.html