### PR TITLE
fix: After initiating a collaboration application, clicking the cancel button is invalid

### DIFF
--- a/src/plugins/cooperation/core/cooperation/cooperationmanager.h
+++ b/src/plugins/cooperation/core/cooperation/cooperationmanager.h
@@ -31,6 +31,7 @@ public Q_SLOTS:
     void handleConnectResult(int result);
     void handleDisConnectResult(const QString &devName);
     void onVerifyTimeout();
+    void handleCancelCooperApply();
 
 private:
     explicit CooperationManager(QObject *parent = nullptr);

--- a/src/plugins/cooperation/core/cooperation/cooperationmanager_p.h
+++ b/src/plugins/cooperation/core/cooperation/cooperationmanager_p.h
@@ -32,6 +32,7 @@ public:
 public Q_SLOTS:
     void onActionTriggered(uint replacesId, const QString &action);
     void stopCooperation();
+    void onCancelCooperApply();
 
 public:
     CooperationManager *q;

--- a/src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp
+++ b/src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp
@@ -8,8 +8,8 @@
 
 using namespace cooperation_core;
 #ifdef linux
-const char *Ktransfer_success = "transfer_success";
-const char *Ktransfer_fail = "transfer_fail";
+static constexpr char Ktransfer_success[] = "transfer_success";
+static constexpr char Ktransfer_fail[] = "transfer_fail";
 #else
 const char *Ktransfer_success = ":/icons/deepin/builtin/icons/transfer_success_128px.svg";
 const char *Ktransfer_fail = ":/icons/deepin/builtin/icons/transfer_fail_128px.svg";

--- a/src/plugins/cooperation/core/gui/widgets/deviceitem.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/deviceitem.cpp
@@ -18,9 +18,9 @@
 using namespace cooperation_core;
 
 #ifdef linux
-const char *Kcomputer_connected = "computer_connected";
-const char *Kcomputer_can_connect = "computer_can_connect";
-const char *Kcomputer_off_line = "computer_off_line";
+static constexpr char Kcomputer_connected[] = "computer_connected";
+static constexpr char Kcomputer_can_connect[] = "computer_can_connect";
+static constexpr char Kcomputer_off_line[] = "computer_off_line";
 #else
 const char *Kcomputer_connected = ":/icons/deepin/builtin/icons/computer_connected_52px.svg";
 const char *Kcomputer_can_connect = ":/icons/deepin/builtin/icons/computer_can_connect_52px.svg";

--- a/src/plugins/cooperation/core/utils/cooperationutil.cpp
+++ b/src/plugins/cooperation/core/utils/cooperationutil.cpp
@@ -232,6 +232,14 @@ void CooperationUtilPrivate::localIPCStart()
                                               Qt::QueuedConnection,
                                               Q_ARG(QString, QString(disCon.msg.c_str())));
             } break;
+            case FRONT_SHARE_DISAPPLY_CONNECT: {
+                ShareConnectDisApply param;
+                param.from_json(json_obj);
+                LOG << "share cancel apply : " << json_obj;
+                q->metaObject()->invokeMethod(CooperationManager::instance(),
+                                              "handleCancelCooperApply",
+                                              Qt::QueuedConnection);
+            } break;
             default:
                 break;
             }

--- a/src/plugins/daemon/core/service/rpc/handlerpcservice.cpp
+++ b/src/plugins/daemon/core/service/rpc/handlerpcservice.cpp
@@ -427,7 +427,7 @@ void HandleRpcService::handleRemoteDisApplyShareConnect(co::Json &info)
     ShareEvents event;
     event.eventType = FRONT_SHARE_DISAPPLY_CONNECT;
     event.data = info.str();
-    co::Json req = info;
+    co::Json req = event.as_json();
     req.add_member("api", "Frontend.shareEvents");
     SendIpcService::instance()->handleSendToClient(sd.tarAppname.c_str(), req.str().c_str());
     SendRpcService::instance()->removePing(sd.tarAppname.c_str());


### PR DESCRIPTION
Add processing logic for canceling collaboration requests

Log: After initiating a collaboration application, clicking the cancel button is invalid
Bug: https://pms.uniontech.com/bug-view-232941.html