### PR TITLE
fix: There is no prompt when the receiver and sender networks are disconnected

### DIFF
--- a/src/common/constant.h
+++ b/src/common/constant.h
@@ -198,6 +198,16 @@ enum JobTransFileOp {
     FILE_COUNTED = 0X0040, // 数据统计完成
 };
 
+enum CurrentStatus {
+    CURRENT_STATUS_DISCONNECT = 0, // 没有连接
+    CURRENT_STATUS_TRAN_CONNECT = 1, // 1是文件投送连接
+    CURRENT_STATUS_TRAN_APPLY = 2, // 2文件投送申请
+    CURRENT_STATUS_TRAN_FILE_SEN = 3, // 3文件发送
+    CURRENT_STATUS_TRAN_FILE_RCV = 4, // 4文件接收
+    CURRENT_STATUS_SHARE_CONNECT = 5, // 5键鼠共享连接
+    CURRENT_STATUS_SHARE_START = 6, // 5键鼠共享中
+};
+
 // use thread replace the coroutine
 #if defined(DISABLE_GO)
     #define UNIGO(...) \

--- a/src/ipc/proto/chan.h
+++ b/src/ipc/proto/chan.h
@@ -194,6 +194,7 @@ struct FSReport {
 struct SendStatus {
     int32 type{0};
     int32 status{0};
+    int32 curstatus{0};
     fastring msg;
 
     void from_json(const co::Json& _x_) {

--- a/src/ipc/proto/chan.proto
+++ b/src/ipc/proto/chan.proto
@@ -61,6 +61,7 @@ object FSReport {
 object SendStatus {
     int32 type // 服务器发送都对方服务器的类型, 0表示自己监听到发送端断开连接
     int32 status // 0 发送成功，-1发送失败，-2参数错误, 1表示远端下线
+    int32 curstatus // 当前所在阶段
     string msg
 }
 

--- a/src/plugins/cooperation/core/cooperation/cooperationmanager.cpp
+++ b/src/plugins/cooperation/core/cooperation/cooperationmanager.cpp
@@ -547,3 +547,24 @@ void CooperationManager::handleCancelCooperApply()
 #endif
     }
 }
+
+void CooperationManager::handleNetworkDismiss()
+{
+    if (d->isRecvMode) {
+        if (d->isReplied)
+            return;
+
+        static QString body(tr("Network not connected, file delivery failed this time.\
+                               Please connect to the network and try again!"));
+        d->notifyMessage(d->recvReplacesId, body, {}, 3 * 1000);
+    } else {
+        if (!d->taskDialog()->isVisible() || d->isReplied)
+            return;
+
+        static QString title(tr("File transfer failed"));
+        d->taskDialog()->switchFailPage(title,
+                                        tr("Network not connected, file delivery failed this time.\
+                                           Please connect to the network and try again!"),
+                                        true);
+    }
+}

--- a/src/plugins/cooperation/core/cooperation/cooperationmanager.h
+++ b/src/plugins/cooperation/core/cooperation/cooperationmanager.h
@@ -32,6 +32,7 @@ public Q_SLOTS:
     void handleDisConnectResult(const QString &devName);
     void onVerifyTimeout();
     void handleCancelCooperApply();
+    void handleNetworkDismiss();
 
 private:
     explicit CooperationManager(QObject *parent = nullptr);

--- a/src/plugins/cooperation/core/maincontroller/maincontroller.cpp
+++ b/src/plugins/cooperation/core/maincontroller/maincontroller.cpp
@@ -47,7 +47,6 @@ void MainController::checkNetworkState()
 
     if (isConnected != isOnline) {
         isOnline = isConnected;
-        networkMonitorTimer->stop();
         Q_EMIT onlineStateChanged(isConnected);
     }
 }

--- a/src/plugins/cooperation/core/utils/cooperationutil.cpp
+++ b/src/plugins/cooperation/core/utils/cooperationutil.cpp
@@ -17,6 +17,7 @@
 #include "ipc/frontendservice.h"
 #include "ipc/proto/comstruct.h"
 #include "ipc/proto/backend.h"
+#include "ipc/proto/chan.h"
 
 #include <QJsonDocument>
 #include <QNetworkInterface>
@@ -240,6 +241,19 @@ void CooperationUtilPrivate::localIPCStart()
                                               "handleCancelCooperApply",
                                               Qt::QueuedConnection);
             } break;
+            case FRONT_SEND_STATUS:
+            {
+                SendStatus param;
+                param.from_json(json_obj);
+                if (REMOTE_CLIENT_OFFLINE == param.status &&
+                        (param.curstatus == CURRENT_STATUS_TRAN_FILE_SEN ||
+                         param.curstatus == CURRENT_STATUS_TRAN_FILE_RCV)) {
+                    q->metaObject()->invokeMethod(CooperationManager::instance(),
+                                                  "handleNetworkDismiss",
+                                                  Qt::QueuedConnection);
+                }
+                break;
+            }
             default:
                 break;
             }

--- a/src/plugins/cooperation/daemon/maincontroller/maincontroller.cpp
+++ b/src/plugins/cooperation/daemon/maincontroller/maincontroller.cpp
@@ -290,3 +290,14 @@ void MainController::onConfirmTimeout()
     static QString msg(tr("\"%1\" delivery of files to you was interrupted due to a timeout"));
     recvNotifyId = notifyMessage(recvNotifyId, msg.arg(CommonUitls::elidedText(requestFrom, Qt::ElideMiddle, 25)), {}, {}, 3 * 1000);
 }
+
+void MainController::onNetworkMiss()
+{
+    if (recvNotifyId == 0)
+        return;
+    QStringList actions;
+    actions << NotifyViewAction << tr("View");
+    static QString msg(tr("Network not connected, file delivery failed this time.\
+                             Please connect to the network and try again!"));
+    recvNotifyId = notifyMessage(recvNotifyId, msg, actions, {}, 15 * 1000);
+}

--- a/src/plugins/cooperation/daemon/maincontroller/maincontroller.h
+++ b/src/plugins/cooperation/daemon/maincontroller/maincontroller.h
@@ -42,6 +42,7 @@ public Q_SLOTS:
     void onTransJobStatusChanged(int id, int result, const QString &msg);
     void onFileTransStatusChanged(const QString &status);
     void onConfirmTimeout();
+    void onNetworkMiss();
 
 private:
     explicit MainController(QObject *parent = nullptr);

--- a/src/plugins/cooperation/daemon/utils/cooperationutil.cpp
+++ b/src/plugins/cooperation/daemon/utils/cooperationutil.cpp
@@ -12,6 +12,7 @@
 #include "ipc/frontendservice.h"
 #include "ipc/proto/comstruct.h"
 #include "ipc/proto/backend.h"
+#include "ipc/proto/chan.h"
 
 #include <QJsonDocument>
 #include <QStandardPaths>
@@ -135,6 +136,17 @@ void CooperationUtilPrivate::localIPCStart()
                 pingBackend();
                 MainController::instance()->regist();
                 break;
+            case FRONT_SEND_STATUS:
+            {
+                SendStatus param;
+                param.from_json(json_obj);
+                if (REMOTE_CLIENT_OFFLINE == param.status && param.curstatus == CURRENT_STATUS_TRAN_FILE_RCV) {
+                    q->metaObject()->invokeMethod(MainController::instance(),
+                                                  "onNetworkMiss",
+                                                  Qt::QueuedConnection);
+                }
+                break;
+            }
             default:
                 break;
             }

--- a/src/plugins/daemon/core/service/comshare.h
+++ b/src/plugins/daemon/core/service/comshare.h
@@ -5,6 +5,7 @@
 #ifndef COMSHARE_H
 #define COMSHARE_H
 
+#include "common/constant.h"
 #include "message.pb.h"
 #include <co/co.h>
 #include <co/json.h>
@@ -73,16 +74,6 @@ typedef enum barrier_type_t {
     Server = 555,
     Client = 666
 } BarrierType;
-
-enum CurrentStatus {
-    CURRENT_STATUS_DISCONNECT = 0, // 没有连接
-    CURRENT_STATUS_TRAN_CONNECT = 1, // 1是文件投送连接
-    CURRENT_STATUS_TRAN_APPLY = 2, // 2文件投送申请
-    CURRENT_STATUS_TRAN_FILE_SEN = 3, // 3文件发送
-    CURRENT_STATUS_TRAN_FILE_RCV = 4, // 4文件接收
-    CURRENT_STATUS_SHARE_CONNECT = 5, // 5键鼠共享连接
-    CURRENT_STATUS_SHARE_START = 6, // 5键鼠共享中
-};
 
 class Comshare
 {

--- a/src/plugins/daemon/core/service/ipc/sendipcservice.cpp
+++ b/src/plugins/daemon/core/service/ipc/sendipcservice.cpp
@@ -300,6 +300,7 @@ void SendIpcService::preprocessOfflineStatus(const QString appName, int32 type, 
     SendStatus st;
     st.type = type;
     st.status = REMOTE_CLIENT_OFFLINE;
+    st.curstatus = Comshare::instance()->currentStatus();
     st.msg = msg;
     _offline_status.remove(appName);
     _offline_status.insert(appName, st);

--- a/src/plugins/daemon/core/service/job/transferjob.cpp
+++ b/src/plugins/daemon/core/service/job/transferjob.cpp
@@ -84,8 +84,11 @@ void TransferJob::initJob(fastring appname, fastring targetappname, int id, fast
     _status = INIT;
     _save_fulldir = path::join(DaemonConfig::instance()->getStorageDir(_app_name), _savedir);
     if (_writejob) {
+        Comshare::instance()->updateStatus(CURRENT_STATUS_TRAN_FILE_RCV);
         fastring fullpath = _save_fulldir;
         FSAdapter::newFileByFullPath(fullpath.c_str(), true);
+    } else {
+        Comshare::instance()->updateStatus(CURRENT_STATUS_TRAN_FILE_SEN);
     }
 }
 

--- a/src/plugins/daemon/core/service/rpc/handlesendresultservice.cpp
+++ b/src/plugins/daemon/core/service/rpc/handlesendresultservice.cpp
@@ -58,6 +58,7 @@ void HandleSendResultService::handleLogin(const QString &appName, const QString 
             // TODO: save the target peer info into target's map
             fastring token = res.token;
             PeerInfo target_info = res.peer;
+            Comshare::instance()->updateStatus(CURRENT_STATUS_TRAN_CONNECT);
             // login successful
             DaemonConfig::instance()->saveAuthed(token);
             SendRpcService::instance()->addPing(res.appName.c_str());


### PR DESCRIPTION
Add network disconnection prompt

Log: There is no prompt when the receiver and sender networks are disconnected
Bug: https://pms.uniontech.com/bug-view-228107.html