### PR TITLE
fix: When transferring files, the network is disconnected, and the second file delivery will immediately prompt a failure message

### DIFF
--- a/src/plugins/daemon/core/service/job/transferjob.cpp
+++ b/src/plugins/daemon/core/service/job/transferjob.cpp
@@ -259,12 +259,13 @@ qint64 TransferJob::freeBytes() const
     return _device_free_size;
 }
 
-void TransferJob::offlineCancel(const QString &ip)
+bool TransferJob::offlineCancel(const QString &ip)
 {
     if (_offlined || ip.isEmpty() || ip != QString(_tar_ip.c_str()))
-        return;
+        return false;
     _offlined = true;
     handleJobStatus(JOB_TRANS_FAILED);
+    return true;
 }
 
 fastring TransferJob::getSubdir(const char *path, const char *root)
@@ -352,9 +353,10 @@ void TransferJob::handleBlockQueque()
             exception = !sendToRemote(block);
         }
 
-        if (exception && !_offlined) {
-            DLOG << "trans job exception hanpend: " << _jobid;
-            handleJobStatus(JOB_TRANS_FAILED);
+        if (exception || _offlined) {
+            DLOG << "trans job exception hanpend: " << _jobid;\
+            if (!_offlined)
+                handleJobStatus(JOB_TRANS_FAILED);
             break;
         }
 

--- a/src/plugins/daemon/core/service/job/transferjob.h
+++ b/src/plugins/daemon/core/service/job/transferjob.h
@@ -43,7 +43,7 @@ public:
     bool initSuccess() const { return _init_success; }
     void setDeviceNotenough();
     qint64 freeBytes() const;
-    void offlineCancel(const QString &ip);
+    bool offlineCancel(const QString &ip);
 
 signals:
     // 传输作业结果通知：文件（目录），结果，保存路径


### PR DESCRIPTION
Incomplete processing of exiting file task

Log: When transferring files, the network is disconnected, and the second file delivery will immediately prompt a failure message
Bug: https://pms.uniontech.com/bug-view-239299.html