### PR TITLE
fix: Win, settings - name missing error prompt

### DIFF
--- a/src/plugins/daemon/core/service/ipc/sendipcservice.cpp
+++ b/src/plugins/daemon/core/service/ipc/sendipcservice.cpp
@@ -54,6 +54,7 @@ void SendIpcWork::handleStopShareConnect(const QString &info, const QSharedPoint
     ShareCooperationServiceManager::instance()->stop();
     _info.share_connect_ip = "";
     DiscoveryJob::instance()->updateAnnouncBase(_info.as_json().str());
+    Comshare::instance()->updateStatus(CURRENT_STATUS_DISCONNECT);
     // 向前段发送断开连接信号
     ShareEvents ev;
     ev.eventType = FRONT_SHARE_DISCONNECT;


### PR DESCRIPTION
Add self drawn background and prompt box

Log: Win, settings - name missing error prompt
Bug: https://pms.uniontech.com/bug-view-238419.html