### PR TITLE
fix: In dark mode, the input box for saving files in the settings is not adapted to dark mode

### DIFF
--- a/src/plugins/cooperation/core/gui/widgets/filechooseredit.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/filechooseredit.cpp
@@ -27,7 +27,7 @@ FileChooserEdit::FileChooserEdit(QWidget *parent)
 
 void FileChooserEdit::initUI()
 {
-    pathLabel = new QLabel(this);
+    pathLabel = new CooperationLineEdit(this);
     auto margins = pathLabel->contentsMargins();
     margins.setLeft(8);
     margins.setRight(8);

--- a/src/plugins/cooperation/core/gui/widgets/filechooseredit.h
+++ b/src/plugins/cooperation/core/gui/widgets/filechooseredit.h
@@ -35,7 +35,7 @@ protected:
 private:
     void initUI();
 
-    QLabel *pathLabel { nullptr };
+    CooperationLineEdit *pathLabel { nullptr };
     CooperationSuggestButton *fileChooserBtn { nullptr };
 };
 


### PR DESCRIPTION
Modified qlabel to dlineedit control

Log: In dark mode, the input box for saving files in the settings is not adapted to dark mode
Bug: https://pms.uniontech.com/bug-view-238233.html