### PR TITLE
fix: The gap between the pop-up window and the title is too large during file delivery

### DIFF
--- a/src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp
+++ b/src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp
@@ -83,7 +83,7 @@ void TransferDialog::createWaitConfirmPage()
     vLayout->addWidget(spinner, 0, Qt::AlignHCenter);
     vLayout->addSpacing(15);
     vLayout->addWidget(label, 0, Qt::AlignHCenter);
-    vLayout->addSpacerItem(new QSpacerItem(1, 10, QSizePolicy::Minimum, QSizePolicy::Expanding));
+    vLayout->addSpacerItem(new QSpacerItem(1, 85, QSizePolicy::Minimum, QSizePolicy::Expanding));
 }
 
 void TransferDialog::createResultPage()


### PR DESCRIPTION
The gap between the pop-up window and the title is too large during file delivery

Log: The gap between the pop-up window and the title is too large during file delivery
Bug: https://pms.uniontech.com/bug-view-238225.html