### PR TITLE
fix: When sending files from the win end to the uos end, the network is disconnected, and the prompt is always to cancel the file delivery for the other party

### DIFF
--- a/src/plugins/daemon/core/service/job/transferjob.h
+++ b/src/plugins/daemon/core/service/job/transferjob.h
@@ -30,7 +30,7 @@ public:
     bool createFile(const fastring fullpath, const bool isDir);
 
     void start();
-    void stop();
+    void stop(const bool notify = true);
     void waitFinish();
     bool ended();
     bool isRunning();
@@ -97,6 +97,7 @@ private:
     bool _mark_canceled { false };
     std::atomic_bool _device_not_enough{ false };
     std::atomic_bool _offlined {false};
+    std::atomic_bool _not_notify {false};
 
     uint16 _tar_port{0};
     fastring _app_name; // //前端应用名

--- a/src/plugins/daemon/core/service/jobmanager.cpp
+++ b/src/plugins/daemon/core/service/jobmanager.cpp
@@ -56,8 +56,11 @@ bool JobManager::handleRemoteRequestJob(QString json, QString *targetAppName)
             QReadLocker lk(&g_m);
             _job = _transjob_recvs.value(jobId);
         }
-        if (!_job.isNull())
-            _job->cancel();
+        if (!_job.isNull() && !_job->ended()) {
+            QWriteLocker lk(&g_m);
+            _transjob_break.insert(jobId, _job);
+            _job->stop(false);
+        }
 
         QWriteLocker lk(&g_m);
         _transjob_recvs.remove(jobId);
@@ -68,8 +71,12 @@ bool JobManager::handleRemoteRequestJob(QString json, QString *targetAppName)
             QReadLocker lk(&g_m);
             _job = _transjob_sends.value(jobId);
         }
-        if (!_job.isNull())
-            _job->cancel();
+
+        if (!_job.isNull() && !_job->ended()) {
+            QWriteLocker lk(&g_m);
+            _transjob_break.insert(jobId, _job);
+            _job->stop(false);
+        }
 
         QWriteLocker lk(&g_m);
         _transjob_sends.remove(jobId);


### PR DESCRIPTION
The network disconnection operation will be executed here, and the fast execution of cancel has been executed

Log: When sending files from the win end to the uos end, the network is disconnected, and the prompt is always to cancel the file delivery for the other party
Bug: https://pms.uniontech.com/bug-view-240641.html