### PR TITLE
fix: The input box for the file save location is not adapted to dark mode

### DIFF
--- a/src/plugins/cooperation/core/gui/widgets/filechooseredit.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/filechooseredit.cpp
@@ -27,16 +27,18 @@ FileChooserEdit::FileChooserEdit(QWidget *parent)
 
 void FileChooserEdit::initUI()
 {
+#ifdef linux
     pathLabel = new CooperationLineEdit(this);
+    pathLabel->setClearButtonEnabled(false);
+    pathLabel->lineEdit()->setReadOnly(true);
+    fileChooserBtn = new CooperationSuggestButton(this);
+    fileChooserBtn->setIcon(DTK_WIDGET_NAMESPACE::DStyleHelper(style()).standardIcon(DTK_WIDGET_NAMESPACE::DStyle::SP_SelectElement, nullptr));
+#else
+    pathLabel = new QLabel(this);
     auto margins = pathLabel->contentsMargins();
     margins.setLeft(8);
     margins.setRight(8);
     pathLabel->setContentsMargins(margins);
-
-#ifdef linux
-    fileChooserBtn = new CooperationSuggestButton(this);
-    fileChooserBtn->setIcon(DTK_WIDGET_NAMESPACE::DStyleHelper(style()).standardIcon(DTK_WIDGET_NAMESPACE::DStyle::SP_SelectElement, nullptr));
-#else
     fileChooserBtn = new FileChooserBtn(this);
     fileChooserBtn->setStyleSheet(
             "QPushButton {"

--- a/src/plugins/cooperation/core/gui/widgets/filechooseredit.h
+++ b/src/plugins/cooperation/core/gui/widgets/filechooseredit.h
@@ -35,7 +35,11 @@ protected:
 private:
     void initUI();
 
+#ifdef linux
     CooperationLineEdit *pathLabel { nullptr };
+#else
+    QLabel *pathLabel { nullptr };
+#endif
     CooperationSuggestButton *fileChooserBtn { nullptr };
 };
 


### PR DESCRIPTION
Using dlineedit on Linux

Log: The input box for the file save location is not adapted to dark mode
Bug: https://pms.uniontech.com/bug-view-238233.html