### PR TITLE
fix: In compact mode, setting the text size is not compatible with compact mode

### DIFF
--- a/src/plugins/cooperation/core/cooperation/cooperationtaskdialog.cpp
+++ b/src/plugins/cooperation/core/cooperation/cooperationtaskdialog.cpp
@@ -5,7 +5,6 @@
 #include "cooperationtaskdialog.h"
 #include "common/commonutils.h"
 
-#include <QLabel>
 #include <QVBoxLayout>
 
 using namespace cooperation_core;
@@ -110,7 +109,7 @@ QWidget *CooperationTaskDialog::createFailPage()
     QVBoxLayout *vlayout = new QVBoxLayout(widget);
     vlayout->setContentsMargins(0, 0, 0, 0);
 
-    failMsgLabel = new QLabel(this);
+    failMsgLabel = new CooperationLabel(this);
     failMsgLabel->setAlignment(Qt::AlignHCenter);
     failMsgLabel->setWordWrap(true);
 
@@ -135,7 +134,7 @@ QWidget *CooperationTaskDialog::createConfirmPage()
     QVBoxLayout *vlayout = new QVBoxLayout(widget);
     vlayout->setContentsMargins(0, 0, 0, 0);
 
-    confirmMsgLabel = new QLabel(this);
+    confirmMsgLabel = new CooperationLabel(this);
     confirmMsgLabel->setAlignment(Qt::AlignHCenter);
     confirmMsgLabel->setWordWrap(true);
 
@@ -160,7 +159,7 @@ QWidget *CooperationTaskDialog::createInfomationPage()
     QVBoxLayout *vlayout = new QVBoxLayout(widget);
     vlayout->setContentsMargins(0, 0, 0, 0);
 
-    infoLabel = new QLabel(this);
+    infoLabel = new CooperationLabel(this);
     infoLabel->setAlignment(Qt::AlignHCenter);
     infoLabel->setWordWrap(true);
 

--- a/src/plugins/cooperation/core/cooperation/cooperationtaskdialog.h
+++ b/src/plugins/cooperation/core/cooperation/cooperationtaskdialog.h
@@ -39,9 +39,9 @@ protected:
 private:
     QStackedLayout *switchLayout { nullptr };
 
-    QLabel *failMsgLabel { nullptr };
-    QLabel *confirmMsgLabel { nullptr };
-    QLabel *infoLabel { nullptr };
+    CooperationLabel *failMsgLabel { nullptr };
+    CooperationLabel *confirmMsgLabel { nullptr };
+    CooperationLabel *infoLabel { nullptr };
     CooperationSuggestButton *retryBtn { nullptr };
 };
 

--- a/src/plugins/cooperation/core/gui/dialogs/settingdialog.cpp
+++ b/src/plugins/cooperation/core/gui/dialogs/settingdialog.cpp
@@ -101,7 +101,7 @@ void SettingDialogPrivate::initWindow()
 
 void SettingDialogPrivate::createBasicWidget()
 {
-    QLabel *basicLable = new QLabel(tr("Basic Settings"), q);
+    CooperationLabel *basicLable = new CooperationLabel(tr("Basic Settings"), q);
     auto cm = basicLable->contentsMargins();
     cm.setLeft(10);
     basicLable->setContentsMargins(cm);
@@ -341,7 +341,6 @@ void SettingDialogPrivate::initFont()
 
     tipFont = q->font();
     tipFont.setWeight(QFont::Normal);
-    tipFont.setPixelSize(12);
 }
 
 void SettingDialogPrivate::reportDeviceStatus(const QString &type, bool status)

--- a/src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp
+++ b/src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp
@@ -77,7 +77,7 @@ void TransferDialog::createWaitConfirmPage()
     movie->setSpeed(180);
 #endif
 
-    QLabel *label = new QLabel(tr("Wait for confirmation..."), this);
+    CooperationLabel *label = new CooperationLabel(tr("Wait for confirmation..."), this);
     label->setAlignment(Qt::AlignHCenter);
     vLayout->addSpacing(20);
     vLayout->addWidget(spinner, 0, Qt::AlignHCenter);
@@ -93,8 +93,8 @@ void TransferDialog::createResultPage()
     vLayout->setSpacing(0);
     stackedLayout->addWidget(widget);
 
-    iconLabel = new QLabel(this);
-    msgLabel = new QLabel(this);
+    iconLabel = new CooperationLabel(this);
+    msgLabel = new CooperationLabel(this);
     msgLabel->setAlignment(Qt::AlignHCenter);
     msgLabel->setWordWrap(true);
 
@@ -110,7 +110,7 @@ void TransferDialog::createProgressPage()
     vLayout->setSpacing(0);
     stackedLayout->addWidget(widget);
 
-    titleLabel = new QLabel(this);
+    titleLabel = new CooperationLabel(this);
     titleLabel->setAlignment(Qt::AlignHCenter);
     auto font = titleLabel->font();
     font.setPixelSize(14);
@@ -122,7 +122,7 @@ void TransferDialog::createProgressPage()
     progressBar->setTextVisible(false);
     progressBar->setFixedSize(339, 8);
 
-    progressMsgLael = new QLabel(this);
+    progressMsgLael = new CooperationLabel(this);
     progressMsgLael->setAlignment(Qt::AlignHCenter);
     font.setPixelSize(12);
     progressMsgLael->setFont(font);

--- a/src/plugins/cooperation/core/gui/dialogs/transferdialog.h
+++ b/src/plugins/cooperation/core/gui/dialogs/transferdialog.h
@@ -9,7 +9,6 @@
 
 #include <QStackedLayout>
 #include <QPushButton>
-#include <QLabel>
 #include <QProgressBar>
 
 namespace cooperation_core {
@@ -45,10 +44,10 @@ private:
 
     QPushButton *okBtn { nullptr };
     CooperationSpinner *spinner { nullptr };
-    QLabel *iconLabel { nullptr };
-    QLabel *msgLabel { nullptr };
-    QLabel *titleLabel { nullptr };
-    QLabel *progressMsgLael { nullptr };
+    CooperationLabel *iconLabel { nullptr };
+    CooperationLabel *msgLabel { nullptr };
+    CooperationLabel *titleLabel { nullptr };
+    CooperationLabel *progressMsgLael { nullptr };
     QProgressBar *progressBar { nullptr };
 };
 

--- a/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.cpp
@@ -54,7 +54,7 @@ void LookingForDeviceWidget::initUI()
 {
     setFocusPolicy(Qt::ClickFocus);
 
-    iconLabel = new QLabel(this);
+    iconLabel = new CooperationLabel(this);
     iconLabel->setFixedSize(250, 250);
     QIcon icon = QIcon::fromTheme(Kfind_device);
     iconLabel->setPixmap(icon.pixmap(250, 250));
@@ -62,7 +62,7 @@ void LookingForDeviceWidget::initUI()
         iconLabel->setPixmap(icon.pixmap(250, 250));
     });
 
-    QLabel *tipsLabel = new QLabel(tr("Looking for devices"), this);
+    CooperationLabel *tipsLabel = new CooperationLabel(tr("Looking for devices"), this);
     tipsLabel->setAlignment(Qt::AlignHCenter);
 
     QVBoxLayout *vLayout = new QVBoxLayout;
@@ -119,7 +119,7 @@ void NoNetworkWidget::initUI()
 {
     setFocusPolicy(Qt::ClickFocus);
 
-    QLabel *iconLabel = new QLabel(this);
+    CooperationLabel *iconLabel = new CooperationLabel(this);
     iconLabel->setFixedSize(150, 150);
     QIcon icon = QIcon::fromTheme(Kno_network);
     iconLabel->setPixmap(icon.pixmap(150, 150));
@@ -127,7 +127,7 @@ void NoNetworkWidget::initUI()
         iconLabel->setPixmap(icon.pixmap(150, 150));
     });
 
-    QLabel *tipsLabel = new QLabel(tr("Please connect to the network"), this);
+    CooperationLabel *tipsLabel = new CooperationLabel(tr("Please connect to the network"), this);
 
     QVBoxLayout *vLayout = new QVBoxLayout;
     vLayout->setContentsMargins(0, 0, 0, 0);
@@ -155,7 +155,7 @@ void NoResultWidget::initUI()
 {
     setFocusPolicy(Qt::ClickFocus);
 
-    QLabel *iconLabel = new QLabel(this);
+    CooperationLabel *iconLabel = new CooperationLabel(this);
     iconLabel->setFixedSize(150, 150);
     QIcon icon = QIcon::fromTheme(Knot_find_device);
     iconLabel->setPixmap(icon.pixmap(150, 150));
@@ -163,7 +163,7 @@ void NoResultWidget::initUI()
         iconLabel->setPixmap(icon.pixmap(150, 150));
     });
 
-    QLabel *tipsLabel = new QLabel(tr("No device found"), this);
+    CooperationLabel *tipsLabel = new CooperationLabel(tr("No device found"), this);
     auto font = tipsLabel->font();
     font.setWeight(QFont::Medium);
     tipsLabel->setFont(font);

--- a/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.h
+++ b/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.h
@@ -6,7 +6,7 @@
 #define COOPERATIONSTATEWIDGET_H
 
 #include <QWidget>
-#include <QLabel>
+#include "global_defines.h"
 
 namespace cooperation_core {
 
@@ -24,7 +24,7 @@ protected:
 private:
     void initUI();
 
-    QLabel *iconLabel { nullptr };
+    CooperationLabel *iconLabel { nullptr };
     QTimer *animationTimer { nullptr };
     int angle { 0 };
     bool isEnabled { false };

--- a/src/plugins/cooperation/core/gui/widgets/deviceitem.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/deviceitem.cpp
@@ -28,7 +28,7 @@ const char *Kcomputer_off_line = ":/icons/deepin/builtin/icons/computer_off_line
 #endif
 
 StateLabel::StateLabel(QWidget *parent)
-    : QLabel(parent)
+    : CooperationLabel(parent)
 {
 }
 
@@ -109,8 +109,8 @@ void DeviceItem::initUI()
     setFixedSize(460, 90);
     setBackground(8, NoType, TopAndBottom);
 
-    iconLabel = new QLabel(this);
-    nameLabel = new QLabel(this);
+    iconLabel = new CooperationLabel(this);
+    nameLabel = new CooperationLabel(this);
     nameLabel->installEventFilter(this);
     setLabelFont(nameLabel, 14, QFont::Medium);
 
@@ -151,7 +151,7 @@ void DeviceItem::initConnect()
     connect(btnBoxWidget, &ButtonBoxWidget::buttonClicked, this, &DeviceItem::onButtonClicked);
 }
 
-void DeviceItem::setLabelFont(QLabel *label, int pointSize, int weight)
+void DeviceItem::setLabelFont(CooperationLabel *label, int pointSize, int weight)
 {
     QFont font = this->font();
     font.setPixelSize(pointSize);

--- a/src/plugins/cooperation/core/gui/widgets/deviceitem.h
+++ b/src/plugins/cooperation/core/gui/widgets/deviceitem.h
@@ -9,14 +9,13 @@
 #include "info/deviceinfo.h"
 #include "backgroundwidget.h"
 
-#include <QLabel>
 #include <QIcon>
 #include <QMap>
 
 namespace cooperation_core {
 
 class ButtonBoxWidget;
-class StateLabel : public QLabel
+class StateLabel : public CooperationLabel
 {
     Q_OBJECT
 public:
@@ -71,13 +70,13 @@ protected:
 private:
     void initUI();
     void initConnect();
-    void setLabelFont(QLabel *label, int pointSize, int weight);
+    void setLabelFont(CooperationLabel *label, int pointSize, int weight);
     void setDeviceName(const QString &name);
     void setDeviceStatus(DeviceInfo::ConnectStatus status);
 
 private:
-    QLabel *iconLabel { nullptr };
-    QLabel *nameLabel { nullptr };
+    CooperationLabel *iconLabel { nullptr };
+    CooperationLabel *nameLabel { nullptr };
     CooperationLabel *ipLabel { nullptr };
     StateLabel *stateLabel { nullptr };
     ButtonBoxWidget *btnBoxWidget { nullptr };

--- a/src/plugins/cooperation/core/gui/widgets/settingitem.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/settingitem.cpp
@@ -4,8 +4,8 @@
 
 #include "settingitem.h"
 #include "utils/cooperationguihelper.h"
+#include "global_defines.h"
 
-#include <QLabel>
 #include <QPainter>
 #include <QPainterPath>
 
@@ -24,10 +24,9 @@ SettingItem::SettingItem(QWidget *parent)
 
 void SettingItem::setItemInfo(const QString &text, QWidget *w)
 {
-    QLabel *label = new QLabel(text, this);
+    CooperationLabel *label = new CooperationLabel(text, this);
     auto font = label->font();
     font.setWeight(QFont::Medium);
-    font.setPixelSize(14);
     label->setFont(font);
 
     mainLayout->addWidget(label, 0, Qt::AlignLeft);

--- a/src/plugins/cooperation/core/gui/win/cooperationsearchedit.h
+++ b/src/plugins/cooperation/core/gui/win/cooperationsearchedit.h
@@ -5,10 +5,11 @@
 #ifndef COOPERATIONSEARCHEDIT_H
 #define COOPERATIONSEARCHEDIT_H
 
+#include "global_defines.h"
+
 #include <QFrame>
 
 class QLineEdit;
-class QLabel;
 class QToolButton;
 namespace cooperation_core {
 
@@ -31,8 +32,8 @@ protected:
 
 private:
     QLineEdit *searchEdit{ nullptr };
-    QLabel *searchIcon{ nullptr };
-    QLabel *searchText{ nullptr };
+    CooperationLabel *searchIcon{ nullptr };
+    CooperationLabel *searchText{ nullptr };
     QToolButton *closeBtn{ nullptr };
     QString placeholderText;
 };

--- a/src/plugins/cooperation/core/proxy/cooperationdialog.cpp
+++ b/src/plugins/cooperation/core/proxy/cooperationdialog.cpp
@@ -23,7 +23,7 @@ void ConfirmWidget::setDeviceName(const QString &name)
 
 void ConfirmWidget::init()
 {
-    msgLabel = new QLabel(this);
+    msgLabel = new CooperationLabel(this);
     rejectBtn = new QPushButton(tr("Reject", "button"), this);
     acceptBtn = new QPushButton(tr("Accept", "button"), this);
 
@@ -59,8 +59,8 @@ void ProgressWidget::setProgress(int value, const QString &msg)
 
 void ProgressWidget::init()
 {
-    titleLabel = new QLabel(this);
-    msgLabel = new QLabel(this);
+    titleLabel = new CooperationLabel(this);
+    msgLabel = new CooperationLabel(this);
 
     progressBar = new QProgressBar(this);
     progressBar->setRange(0, 100);
@@ -100,8 +100,8 @@ void ResultWidget::setResult(bool success, const QString &msg)
 
 void ResultWidget::init()
 {
-    iconLabel = new QLabel(this);
-    msgLabel = new QLabel(this);
+    iconLabel = new CooperationLabel(this);
+    msgLabel = new CooperationLabel(this);
     msgLabel->setWordWrap(true);
     msgLabel->setAlignment(Qt::AlignHCenter);
 

--- a/src/plugins/cooperation/core/proxy/cooperationdialog.h
+++ b/src/plugins/cooperation/core/proxy/cooperationdialog.h
@@ -5,8 +5,9 @@
 #ifndef COOPERATIONDIALOG_H
 #define COOPERATIONDIALOG_H
 
+#include "global_defines.h"
+
 #include <QDialog>
-#include <QLabel>
 #include <QPushButton>
 #include <QProgressBar>
 #include <QStackedLayout>
@@ -28,7 +29,7 @@ Q_SIGNALS:
 private:
     void init();
 
-    QLabel *msgLabel { nullptr };
+    CooperationLabel *msgLabel { nullptr };
     QPushButton *acceptBtn { nullptr };
     QPushButton *rejectBtn { nullptr };
 };
@@ -48,8 +49,8 @@ Q_SIGNALS:
 private:
     void init();
 
-    QLabel *titleLabel { nullptr };
-    QLabel *msgLabel { nullptr };
+    CooperationLabel *titleLabel { nullptr };
+    CooperationLabel *msgLabel { nullptr };
     QProgressBar *progressBar { nullptr };
     QPushButton *cancelBtn { nullptr };
 };
@@ -69,8 +70,8 @@ Q_SIGNALS:
 private:
     void init();
 
-    QLabel *iconLabel { nullptr };
-    QLabel *msgLabel { nullptr };
+    CooperationLabel *iconLabel { nullptr };
+    CooperationLabel *msgLabel { nullptr };
     QPushButton *okBtn { nullptr };
     QPushButton *viewBtn { nullptr };
 };


### PR DESCRIPTION
Replace all qlabels with dlabels

Log: In compact mode, setting the text size is not compatible with compact mode
Bug: https://pms.uniontech.com/bug-view-238237.html