### PR TITLE
fix: In compact mode, the device list is not adapted to compact mode

### DIFF
--- a/src/plugins/cooperation/core/gui/widgets/deviceitem.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/deviceitem.cpp
@@ -153,8 +153,11 @@ void DeviceItem::initConnect()
 
 void DeviceItem::setLabelFont(CooperationLabel *label, int pointSize, int weight)
 {
+    Q_UNUSED(pointSize);
     QFont font = this->font();
+#ifndef linux
     font.setPixelSize(pointSize);
+#endif
     font.setWeight(weight);
 
     label->setFont(font);


### PR DESCRIPTION
In compact mode, the device list is not adapted to compact mode

Log: In compact mode, the device list is not adapted to compact mode
Bug: In compact mode, the device list is not adapted to compact mode