### PR TITLE
Fix: the backend do not exit on win

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,8 +1,8 @@
 cmake_minimum_required (VERSION 3.4)
 
 set (APP_VERSION_MAJOR 0)
-set (APP_VERSION_MINOR 6)
-set (APP_VERSION_PATCH 0)
+set (APP_VERSION_MINOR 7)
+set (APP_VERSION_PATCH 1)
 set (APP_VERSION_STAGE "release")
 
 #

--- a/src/apps/dde-cooperation/res/win/main.vbs
+++ b/src/apps/dde-cooperation/res/win/main.vbs
@@ -1,3 +1,4 @@
+kill = False
 Set shell = Wscript.createobject("wscript.shell")
 Set objWMIService = GetObject("winmgmts:\\.\root\cimv2")
 Set backProcess = objWMIService.ExecQuery("Select * from Win32_Process where Name = 'cooperation-daemon.exe'")
@@ -19,9 +20,26 @@ if backProcess.Count = 0 Then
         Wscript.Quit
     else
         ' Wscript.Echo "cooperation-daemon.exe is started successfully."
+        kill = True
     end if
 else
     ' Wscript.Echo "backend daemon is already running."
 end if
 
 b = shell.run(".\dde-cooperation.exe",0)
+
+' 检测自身进程退出，如果是自己拉起来的后端，则杀掉
+Do While True
+    Set colProcess = objWMIService.ExecQuery("Select * from Win32_Process where Name = 'dde-cooperation.exe'")
+    if colProcess.Count = 0 Then
+        if kill = True Then
+            Set daemonProcesses = objWMIService.ExecQuery("Select * from Win32_Process where Name = 'cooperation-daemon.exe'")
+            For Each objProccess in daemonProcesses
+                objProccess.Terminate()
+            Next
+        end if
+        Wscript.Quit
+    end if
+
+    Wscript.Sleep 2000
+Loop


### PR DESCRIPTION
In order to free the backend file handle, kill it if the frontend app exit.

Log: exit backend after app quit.