### PR TITLE
fix: Fix max file size 4G issue

### DIFF
--- a/src/ipc/proto/chan.h
+++ b/src/ipc/proto/chan.h
@@ -92,7 +92,7 @@ struct FSDataBlock {
     int32 file_id{0};
     fastring rootdir;
     fastring filename;
-    uint32 blk_id{0};
+    int64 blk_id{0};
     int32 flags{0};
     int64 data_size{0};
     fastring data;
@@ -102,7 +102,7 @@ struct FSDataBlock {
         file_id = (int32)_x_.get("file_id").as_int64();
         rootdir = _x_.get("rootdir").as_c_str();
         filename = _x_.get("filename").as_c_str();
-        blk_id = (uint32)_x_.get("blk_id").as_int64();
+        blk_id = (int64)_x_.get("blk_id").as_int64();
         flags = (int32)_x_.get("flags").as_int64();
         data_size = _x_.get("data_size").as_int64();
         data = _x_.get("data").as_c_str();

--- a/src/ipc/proto/chan.proto
+++ b/src/ipc/proto/chan.proto
@@ -31,7 +31,7 @@ object FSDataBlock {
     int32 file_id
     string rootdir // 文件的读取或保存路径
     string filename // 相对于TransJob中path的相对路径
-    uint32 blk_id
+    int64 blk_id
     int32 flags // 标志位，所有文件读取完成1（data_size 也是0）
     int64 data_size // 数据块长度
     string data // 块数据


### PR DESCRIPTION
The offset should be int64, but it static cast from uint32 * BLOCK_SIZE, which still max uint32 value.

Log: Fix max file size 4G issue.
Bug: https://pms.uniontech.com/bug-view-250159.html