### PR TITLE
fix: [UI] fix cursor still blinks in the input box

### DIFF
--- a/src/plugins/cooperation/core/gui/dialogs/settingdialog.cpp
+++ b/src/plugins/cooperation/core/gui/dialogs/settingdialog.cpp
@@ -155,6 +155,7 @@ void SettingDialogPrivate::createBasicWidget()
 
     nameEdit = new CooperationLineEdit(q);
     nameEdit->installEventFilter(q);
+    nameEdit->setClearButtonEnabled(false);
     QRegExp regExp("^[a-zA-Z0-9\u4e00-\u9fa5-]+$");   // 正则表达式定义允许的字符范围
     QRegExpValidator *validator = new QRegExpValidator(regExp, nameEdit);
 #ifdef linux
@@ -482,6 +483,27 @@ bool SettingDialog::eventFilter(QObject *watched, QEvent *event)
         }
 #endif
     } while (false);
+
+    if(event->type() == QEvent::KeyRelease){
+        QWidget *widget = qobject_cast<QWidget *>(watched);
+        if (widget && d->nameEdit == watched){
+            QKeyEvent *keypressEvent = static_cast<QKeyEvent *>(event);
+            if(keypressEvent->key() == Qt::Key_Return || keypressEvent->key() == Qt::Key_Enter){
+                d->q->setFocus();
+            }
+        }
+    }
+
+    QWidget *widget = qobject_cast<QWidget *>(watched);
+    if (widget && d->nameEdit == watched){
+        if(event->type() == QEvent::Paint){
+            if(d->nameEdit->hasFocus()){
+                d->nameEdit->setClearButtonEnabled(true);
+            }else{
+                d->nameEdit->setClearButtonEnabled(false);
+            }
+        }
+    }
 
     return CooperationAbstractDialog::eventFilter(watched, event);
 }

--- a/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.cpp
+++ b/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.cpp
@@ -31,6 +31,7 @@ DWIDGET_USE_NAMESPACE
 #include <common/commonutils.h>
 
 using namespace cooperation_core;
+DWIDGET_USE_NAMESPACE
 
 #ifdef linux
 const char *Kfind_device = "find_device";
@@ -429,11 +430,13 @@ void FirstTipWidget::setVisible(bool visible)
     QWidget::setVisible(visible);
     tipBtn->setVisible(visible);
 #ifdef linux
-    tipBtn->setGeometry(450, 41 + height() / 2, 30, 30);
+    tipBtn->setGeometry(450, DSizeModeHelper::element(29, 42) + height() / 2, 30, 30);
 #    ifdef DTKWIDGET_CLASS_DSizeMode
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this] {
         tipBtn->setGeometry(450, DSizeModeHelper::element(29, 42) + height() / 2, 30, 30);
     });
+#else
+    tipBtn->setGeometry(450, 42 + height() / 2, 30, 30);
 #    endif
 #else
     tipBtn->setGeometry(450, 90 + height() / 2, 30, 30);
@@ -446,12 +449,10 @@ void FirstTipWidget::themeTypeChanged()
         firstTip->setStyleSheet("background-color: rgba(255, 255, 255, 0.03); "
                                 "border-radius: 10px;"
                                 "color: rgba(255, 255, 255, 0.6);");
-        tipBtn->setIcon(QIcon::fromTheme(":/icons/deepin/builtin/dark/icons/tab_close_normal.svg"));
     } else {
         firstTip->setStyleSheet("background-color: white; "
                                 "border-radius: 10px;"
                                 "color: rgba(0, 0, 0, 0.6);");
-        tipBtn->setIcon(QIcon::fromTheme(":/icons/deepin/builtin/icons/close_normal.svg"));
     }
 }
 
@@ -464,20 +465,10 @@ void FirstTipWidget::initUI()
     firstTip->setFixedWidth(480);
     firstTip->setContentsMargins(10, 10, 40, 10);
 
-    tipBtn = new QPushButton(dynamic_cast<QWidget *>(parent()));
-    tipBtn->setIcon(QIcon::fromTheme(":/icons/deepin/builtin/icons/close_normal.svg"));
+    tipBtn = new DIconButton(dynamic_cast<QWidget *>(parent()));
     tipBtn->setIconSize(QSize(30, 30));
-
-    tipBtn->setStyleSheet("QPushButton{"
-                          "border-radius: 15px;"
-                          "min-width:30px;"
-                          "min-height:30px;"
-                          "max-width:30px;"
-                          "max-height:30px;}"
-                          "QPushButton:hover{"
-                          "background-color: #E5E5E5;}"
-                          "QPushButton:pressed{"
-                          "background-color: #A0B0BB;}");
+    tipBtn->setIcon(DStyle::SP_CloseButton);
+    tipBtn->setFlat(true);
 
     themeTypeChanged();
 

--- a/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.h
+++ b/src/plugins/cooperation/core/gui/widgets/cooperationstatewidget.h
@@ -9,6 +9,8 @@
 #include "backgroundwidget.h"
 #include "global_defines.h"
 
+#include <DIconButton>
+
 namespace cooperation_core {
 
 class LookingForDeviceWidget : public QWidget
@@ -101,7 +103,7 @@ public:
 
 private:
     void initUI();
-    QPushButton *tipBtn { nullptr };
+    DTK_WIDGET_NAMESPACE::DIconButton *tipBtn { nullptr };
     QLabel *firstTip { nullptr };
 };
 

--- a/translations/dde-cooperation/dde-cooperation_zh_TW.ts
+++ b/translations/dde-cooperation/dde-cooperation_zh_TW.ts
@@ -563,7 +563,7 @@
         <location filename="../../src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp" line="46"/>
         <location filename="../../src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp" line="69"/>
         <source>File Transfer</source>
-        <translation>裝置暱稱必須介於1-63個字元之內</translation>
+        <translation>文件投送</translation>
     </message>
     <message>
         <location filename="../../src/plugins/cooperation/core/gui/dialogs/transferdialog.cpp" line="85"/>


### PR DESCRIPTION
fix: [UI] fix cursor still blinks in the input box

Change the user name after pressing enter, the cursor still blinks in the input box. We fixed.

Log: Change the user name after pressing enter, the cursor still blinks in the input box.
Bug: https://pms.uniontech.com/bug-view-241037.html