### PR TITLE
fix: Fix communication freeze issue

### DIFF
--- a/src/lib/common/manager/sessionworker.h
+++ b/src/lib/common/manager/sessionworker.h
@@ -44,11 +44,14 @@ signals:
     void onCancelJob(const std::string jobid);
     void onConnectChanged(int result, QString reason);
 
+    // local signals which emit from RPC
+    void onRemoteDisconnected(const QString &remote);
 public slots:
+    void handleRemoteDisconnected(const QString &remote);
+
 private:
     bool listen(int port);
     bool connect(QString &address, int port);
-    size_t getDirectorySize(const std::string& path);
 
     std::weak_ptr<AsioService> _service;
     // rpc service and client

--- a/src/lib/common/manager/transferworker.cpp
+++ b/src/lib/common/manager/transferworker.cpp
@@ -17,8 +17,8 @@ TransferWorker::TransferWorker(const std::shared_ptr<AsioService> &service, QObj
     : QObject(parent)
     , _service(service)
 {
-    connect(this, &TransferWorker::speedTimerTick, this, &TransferWorker::handleTimerTick, Qt::QueuedConnection);
-    connect(&_speedTimer, &QTimer::timeout, this, &TransferWorker::doCalculateSpeed, Qt::QueuedConnection);
+    QObject::connect(this, &TransferWorker::speedTimerTick, this, &TransferWorker::handleTimerTick, Qt::QueuedConnection);
+    QObject::connect(&_speedTimer, &QTimer::timeout, this, &TransferWorker::doCalculateSpeed, Qt::QueuedConnection);
 }
 
 

--- a/src/lib/common/manager/transferworker.h
+++ b/src/lib/common/manager/transferworker.h
@@ -57,13 +57,7 @@ private:
     std::shared_ptr<FileServer> _file_server { nullptr };
     std::shared_ptr<FileClient> _file_client { nullptr };
 
-    // <jobid, jobpath>
-//    QMap<int, QString> _job_maps;
-//    int _request_job_id;
-
-//    QString _accessToken = "";
     QString _saveRoot = "";
-//    QString _connectedAddress = "";
     QTimer _speedTimer;
     int _noDataCount = 0;
 

--- a/src/lib/common/session/protoserver.h
+++ b/src/lib/common/session/protoserver.h
@@ -17,7 +17,6 @@ class ProtoServer : public CppServer::Asio::TCPServer, public FBE::proto::Client
 public:
     using CppServer::Asio::TCPServer::TCPServer;
 
-    //    ProtoServer();
     void setCallbacks(std::shared_ptr<SessionCallInterface> callbacks);
 
     bool hasConnected(const std::string &ip);


### PR DESCRIPTION
It can not send request again if remote restart, it can not get the remote address from the session when disconnected, and we need to reset all connected target.

Log: Fix communication freeze issue.