### PR TITLE
fix: Fix async rpc and search

### DIFF
--- a/src/lib/common/manager/sessionworker.cpp
+++ b/src/lib/common/manager/sessionworker.cpp
@@ -352,7 +352,12 @@ bool SessionWorker::connect(QString &address, int port)
             _client->setCallbacks(self);
         }
     }
+
     _client->ConnectAsync();
+    // wait until has reply.
+    while (!_client->connectReplyed()) {
+        CppCommon::Thread::Yield();
+    };
 
     return _client->IsConnected();
 }

--- a/src/lib/common/session/protoclient.h
+++ b/src/lib/common/session/protoclient.h
@@ -26,6 +26,7 @@ public:
     void DisconnectAndStop();
 
     bool hasConnected(const std::string &ip);
+    bool connectReplyed();
     proto::OriginMessage sendRequest(const proto::OriginMessage &msg);
 
 protected:
@@ -47,6 +48,7 @@ protected:
 
 private:
     std::atomic<bool> _stop { false };
+    std::atomic<bool> _connect_replay { false };
 
     std::shared_ptr<SessionCallInterface> _callbacks { nullptr };
 

--- a/src/lib/cooperation/core/discover/discovercontroller.h
+++ b/src/lib/cooperation/core/discover/discovercontroller.h
@@ -45,11 +45,16 @@ private Q_SLOTS:
     void onDConfigValueChanged(const QString &config, const QString &key);
     void onAppAttributeChanged(const QString &group, const QString &key, const QVariant &value);
 
+    // update device info into discovery list.
+    void updateDeviceInfo(const QString &info);
+
 private:
     explicit DiscoverController(QObject *parent = nullptr);
     ~DiscoverController();
 
     void initConnect();
+
+    DeviceInfoPointer parseDeviceInfo(const QString &info);
 
 private:
     QSharedPointer<DiscoverControllerPrivate> d { nullptr };

--- a/src/lib/cooperation/core/gui/widgets/workspacewidget.cpp
+++ b/src/lib/cooperation/core/gui/widgets/workspacewidget.cpp
@@ -17,6 +17,8 @@
 
 #include <gui/utils/cooperationguihelper.h>
 
+#include <net/networkutil.h>
+
 using namespace cooperation_core;
 
 WorkspaceWidgetPrivate::WorkspaceWidgetPrivate(WorkspaceWidget *qq)
@@ -117,7 +119,7 @@ void WorkspaceWidgetPrivate::onSearchDevice()
 
     q->switchWidget(WorkspaceWidget::kLookignForDeviceWidget);
     QTimer::singleShot(500, this, [ip] {
-        //   TransferHelper::instance()->searchDevice(ip);
+        NetworkUtil::instance()->searchDevice(ip);
     });
 }
 

--- a/src/lib/cooperation/core/net/helper/sharehelper.cpp
+++ b/src/lib/cooperation/core/net/helper/sharehelper.cpp
@@ -245,9 +245,6 @@ void ShareHelper::disconnectToDevice(const DeviceInfoPointer info)
 
 void ShareHelper::buttonClicked(const QString &id, const DeviceInfoPointer info)
 {
-    // connect remote to prepare share
-    NetworkUtil::instance()->pingTarget(info->ipAddress());
-
     if (id == ConnectButtonId) {
         ShareHelper::instance()->connectToDevice(info);
         return;

--- a/src/lib/cooperation/core/net/helper/transferhelper.cpp
+++ b/src/lib/cooperation/core/net/helper/transferhelper.cpp
@@ -184,10 +184,6 @@ void TransferHelper::buttonClicked(const QString &id, const DeviceInfoPointer in
         << " device name: " << name.toStdString();
 
     if (id == TransferButtonId) {
-
-        // connect remote to prepare transfer
-        NetworkUtil::instance()->pingTarget(ip);
-
         QStringList selectedFiles = qApp->property("sendFiles").toStringList();
         if (selectedFiles.isEmpty())
             selectedFiles = QFileDialog::getOpenFileNames(qApp->activeWindow());

--- a/src/lib/cooperation/core/net/networkutil.cpp
+++ b/src/lib/cooperation/core/net/networkutil.cpp
@@ -39,12 +39,10 @@ NetworkUtilPrivate::NetworkUtilPrivate(NetworkUtil *qq)
             *res_msg = res.as_json().serialize();
 
             // update this device info to discovery list
-            //            auto devInfo = q->parseDeviceInfo(QString(req.nick.c_str()));
-            //            if (devInfo && devInfo->isValid() && devInfo->discoveryMode() == DeviceInfo::DiscoveryMode::Everyone) {
-            //                QList<DeviceInfoPointer> devInfoList;
-            //                devInfoList << devInfo;
-            //                Q_EMIT q->discoveryFinished(devInfoList);
-            //            }
+            q->metaObject()->invokeMethod(DiscoverController::instance(),
+                                          "updateDeviceInfo",
+                                          Qt::QueuedConnection,
+                                          Q_ARG(QString, QString(req.nick.c_str())));
         }
             return true;
         case APPLY_TRANS: {
@@ -205,15 +203,18 @@ void NetworkUtil::updateStorageConfig(const QString &value)
 void NetworkUtil::searchDevice(const QString &ip)
 {
     DLOG << "searching " << ip.toStdString();
-    pingTarget(ip);
-    reqTargetInfo(ip);
+
+    // session connect and then send rpc request
+    bool logind = d->sessionManager->sessionConnect(ip, COO_SESSION_PORT, COO_HARD_PIN);
+    if (logind) {
+        reqTargetInfo(ip);
+    }
 }
 
 void NetworkUtil::pingTarget(const QString &ip)
 {
     // session connect by async, handle status in callback
     d->sessionManager->sessionPing(ip, COO_SESSION_PORT);
-    //    emit CooperationManager::instance()->handleSearchDeviceResult(pong);
 }
 
 void NetworkUtil::reqTargetInfo(const QString &ip)
@@ -229,7 +230,6 @@ void NetworkUtil::reqTargetInfo(const QString &ip)
         // transfer request send exception, it perhaps network error
         WLOG << "Send APPLY_TRANS failed.";
     } else {
-        WLOG << "APPLY_TRANS replay:" << res.toStdString();
         picojson::value json_value;
         std::string err = picojson::parse(json_value, res.toStdString());
         if (!err.empty()) {
@@ -240,12 +240,10 @@ void NetworkUtil::reqTargetInfo(const QString &ip)
         ApplyMessage replay;
         replay.from_json(json_value);
         // update this device info to discovery list
-        //        auto devInfo = parseDeviceInfo(replay.nick.c_str());
-        //        if (devInfo && devInfo->isValid() && devInfo->discoveryMode() == DeviceInfo::DiscoveryMode::Everyone) {
-        //            QList<DeviceInfoPointer> devInfoList;
-        //            devInfoList << devInfo;
-        //            Q_EMIT discoveryFinished(devInfoList);
-        //        }
+        metaObject()->invokeMethod(DiscoverController::instance(),
+                                   "updateDeviceInfo",
+                                   Qt::QueuedConnection,
+                                   Q_ARG(QString, QString(replay.nick.c_str())));
     }
 }
 
@@ -282,7 +280,12 @@ void NetworkUtil::sendTransApply(const QString &ip)
 
 void NetworkUtil::sendShareEvents(const QString &ip)
 {
-    d->sessionManager->sessionConnect(ip, COO_SESSION_PORT, COO_HARD_PIN);
+    bool logind = d->sessionManager->sessionConnect(ip, COO_SESSION_PORT, COO_HARD_PIN);
+    if (!logind) {
+        WLOG << "fail to login: " << ip.toStdString() << " pls try again.";
+        return;
+    }
+
     DeviceInfoPointer selfinfo = DiscoverController::instance()->findDeviceByIP(CooperationUtil::localIPAddress());
     // session connect and then send rpc request
     ApplyMessage msg;
@@ -299,7 +302,12 @@ void NetworkUtil::sendShareEvents(const QString &ip)
 
 void NetworkUtil::sendDisconnectShareEvents(const QString &ip)
 {
-    d->sessionManager->sessionConnect(ip, COO_SESSION_PORT, COO_HARD_PIN);
+    bool logind = d->sessionManager->sessionConnect(ip, COO_SESSION_PORT, COO_HARD_PIN);
+    if (!logind) {
+        WLOG << "fail to login: " << ip.toStdString() << " pls try again.";
+        return;
+    }
+
     DeviceInfoPointer selfinfo = DiscoverController::instance()->findDeviceByIP(CooperationUtil::localIPAddress());
     // session connect and then send rpc request
     ApplyMessage msg;


### PR DESCRIPTION
It uses async connect and do not get connect state immediately, use thread yield in order to avoid getting stuck. Enable search and update info into discovery.

Log: Fix async rpc and search.