### PR TITLE
fix: Fix http get error header

### DIFF
--- a/3rdparty/CppServer/source/server/http/http_request.cpp
+++ b/3rdparty/CppServer/source/server/http/http_request.cpp
@@ -79,7 +79,7 @@ HTTPRequest& HTTPRequest::SetBegin(std::string_view method, std::string_view url
     _url_index = index;
     _url_size = url.size();
 
-    _cache.append(" ");
+    _cache.append("\r\n");
     index = _cache.size();
 
     // Append the HTTP request protocol version
@@ -315,7 +315,7 @@ bool HTTPRequest::ReceiveHeader(const void* buffer, size_t size)
             // Parse URL
             _url_index = index;
             _url_size = 0;
-            while (_cache[index] != ' ')
+            while (_cache[index] != '\r')
             {
                 ++_url_size;
                 ++index;

--- a/src/apps/launcher/CMakeLists.txt
+++ b/src/apps/launcher/CMakeLists.txt
@@ -11,10 +11,16 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(${CMAKE_SOURCE_DIR}/src/lib/common)
 
 FILE(GLOB CPP_SRC
+    "${CMAKE_SOURCE_DIR}/src/common/log.h"
+    "${CMAKE_SOURCE_DIR}/src/common/logger.h"
+    "${CMAKE_SOURCE_DIR}/src/common/logger.cpp"
+    "${CMAKE_SOURCE_DIR}/src/common/commonutils.h"
+    "${CMAKE_SOURCE_DIR}/src/common/commonutils.cpp"
     *.h
     *.cpp
 )
 
+list(APPEND LINKLIBS cpplogging)
 list(APPEND LINKLIBS sessionmanager)
 
 if (WIN32)

--- a/src/apps/launcher/main.cpp
+++ b/src/apps/launcher/main.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "manager/sessionmanager.h"
+#include "common/commonutils.h"
 
 //#include <unistd.h>
 #include <iostream>
@@ -17,10 +18,14 @@
 
 #define COO_WEB_PORT 51568
 
+using namespace deepin_cross;
+
 int main(int argc, char** argv)
 {
+    CommonUitls::initLog();
+
     ExtenMessageHandler msg_cb([](int32_t mask, const picojson::value &json_value, std::string *res_msg) -> bool {
-        std::cout << "Main >> " << mask <<" msg_cb, json_msg: " << json_value << std::endl;
+        LOG << "Main >> " << mask <<" msg_cb, json_msg: " << json_value;
         return false;
     });
     auto sessionManager = new SessionManager();
@@ -33,16 +38,16 @@ int main(int argc, char** argv)
     sessionManager->setStorageRoot(downloadDir);
     sessionManager->updateSaveFolder("launcher");
 
-    std::cout << "start listen........" << COO_SESSION_PORT << std::endl;
+    LOG << "start listen........" << COO_SESSION_PORT;
 
     qputenv("QT_LOGGING_RULES", "cooperation-launcher.debug=true");
 
 #if 0
     QString ip = "10.8.11.98";
-    std::cout << "connect remote " << ip.toStdString() << std::endl;
+    LOG << "connect remote " << ip.toStdString();
     sessionManager->sessionConnect(ip, COO_SESSION_PORT, COO_HARD_PIN);
     QThread::msleep(100);
-    std::cout << "sending file.........." << ip.toStdString() << std::endl;
+    LOG << "sending file.........." << ip.toStdString();
     QStringList fileList;
     fileList << "/home/doll/Downloads/launcher/Fuck floder";
     fileList << "/home/doll/Downloads/launcher/【成研】跨端冒烟测试1.xlsx";
@@ -51,7 +56,7 @@ int main(int argc, char** argv)
     QApplication app(argc, argv);
     app.exec();
 
-    std::cout << "Done!" << std::endl;
+    LOG << "Done!";
 
     return 0;
 }

--- a/src/apps/launcher/main.cpp
+++ b/src/apps/launcher/main.cpp
@@ -12,7 +12,7 @@
 #include <QCryptographicHash>
 #include <QThread>
 
-#define COO_SESSION_PORT 51566
+#define COO_SESSION_PORT 51588
 #define COO_HARD_PIN "515616"
 
 #define COO_WEB_PORT 51568
@@ -38,16 +38,14 @@ int main(int argc, char** argv)
     qputenv("QT_LOGGING_RULES", "cooperation-launcher.debug=true");
 
 #if 0
-    QString ip = "10.8.11.52";
+    QString ip = "10.8.11.98";
     std::cout << "connect remote " << ip.toStdString() << std::endl;
-    sessionManager->sessionPing(ip, COO_SESSION_PORT);
-    QThread::msleep(100);
-    std::cout << "sessionConnect..........." << std::endl;
     sessionManager->sessionConnect(ip, COO_SESSION_PORT, COO_HARD_PIN);
     QThread::msleep(100);
     std::cout << "sending file.........." << ip.toStdString() << std::endl;
     QStringList fileList;
-    fileList << "/home/zero1/Downloads/ss-1.bin";
+    fileList << "/home/doll/Downloads/launcher/Fuck floder";
+    fileList << "/home/doll/Downloads/launcher/【成研】跨端冒烟测试1.xlsx";
     sessionManager->sendFiles(ip, COO_WEB_PORT, fileList);
 #endif
     QApplication app(argc, argv);

--- a/src/lib/common/httpweb/fileclient.cpp
+++ b/src/lib/common/httpweb/fileclient.cpp
@@ -61,7 +61,7 @@ protected:
     // it has been marked response arrived when geting its header. Mark all done and clear
     void onReceivedResponse(const HTTPResponse &response) override
     {
-        std::cout << "Response done! data len:" << response.body_length() << std::endl;
+        //std::cout << "Response done! data len:" << response.body_length() << std::endl;
         if (_canceled)
             return;
 
@@ -247,12 +247,12 @@ bool FileClient::downloadFile(const std::string &name)
     if (tempFile.IsFileExists()) {
         // get current file lenght and continue download.
         offset = tempFile.size();
-        std::cout << "tempFile exist size=: " << offset << std::endl;
+        //std::cout << "tempFile exist size=: " << offset << std::endl;
     } else {
         CppCommon::File::WriteEmpty(tempFile);
-        std::cout << "tempFile created: " << offset << std::endl;
+        //std::cout << "tempFile created: " << offset << std::endl;
     }
-    std::cout << "tempFile: " << tempFile.absolute().string() << std::endl;
+    //std::cout << "tempFile: " << tempFile.absolute().string() << std::endl;
 
 
     url.append("&token=").append(_token);
@@ -280,14 +280,14 @@ bool FileClient::downloadFile(const std::string &name)
         }
         break;
         case RES_OKHEADER: {
-            std::string flag = this->getHeadKey(buffer, "Flag");
-            std::cout << "head flag: " << flag << std::endl;
+            //std::string flag = this->getHeadKey(buffer, "Flag");
+            //std::cout << "head flag: " << flag << std::endl;
 
             if (!tempFile.IsFileWriteOpened()) {
                 size_t cur_off = 0;
                 if (tempFile.IsFileExists()) {
                     cur_off = tempFile.size();
-                    std::cout << "Exists seek=: " << offset  << " cur_off=" << cur_off << std::endl;
+                    //std::cout << "Exists seek=: " << offset  << " cur_off=" << cur_off << std::endl;
                 }
                 tempFile.OpenOrCreate(false, true, true);
 
@@ -302,9 +302,7 @@ bool FileClient::downloadFile(const std::string &name)
             if (tempFile.IsFileWriteOpened() && buffer && size > 0) {
                 current += size;
                 // 实现层已循环写全部
-                size_t wr = tempFile.Write(buffer, size);
-                if (wr != size)
-                    std::cout << "write offset=: " << tempFile.offset() << " size=" << size << " wr=" << wr << std::endl;
+                tempFile.Write(buffer, size);
 
                 shouldExit = _callback->onProgress(size);
             }
@@ -328,11 +326,11 @@ bool FileClient::downloadFile(const std::string &name)
 //                tempFile.Flush();
                 tempFile.Close();
             }
-            std::cout << "RES_FINISH, current=" << current << " total:" << total << std::endl;
+            //std::cout << "RES_FINISH, current=" << current << " total:" << total << std::endl;
 
             // rename only for finished
             if (current >= total) {
-                std::cout << "File path:" << tempFile.absolute().RemoveExtension() << std::endl;
+                //std::cout << "File path:" << tempFile.absolute().RemoveExtension() << std::endl;
 
                 CppCommon::Path::Rename(tempFile.absolute(), tempFile.absolute().RemoveExtension());
                 tempFile.Clear();

--- a/src/lib/common/httpweb/fileserver.cpp
+++ b/src/lib/common/httpweb/fileserver.cpp
@@ -56,7 +56,7 @@ protected:
             }
 
             std::string json_str = fileInfo.as_json().serialize();
-            std::cout << "serveInfo >>: " << json_str << std::endl;
+            //std::cout << "serveInfo >>: " << json_str << std::endl;
 
             // Response with all dir/file values
             SendResponseAsync(response().MakeGetResponse(json_str, "application/json; charset=UTF-8"));
@@ -83,8 +83,8 @@ protected:
                 uint64_t total = 0;
 
                 size_t sz = info.size();
-                if (offset < sz) {
-                    std::cout << "breakpoint continue transfer from:" << offset << std::endl;
+                if (offset > 0 && offset < sz) {
+                    //std::cout << "breakpoint continue transfer from:" << offset << std::endl;
                     info.Seek(offset); // seek to offset for breakpoint continue
                 }
 
@@ -98,8 +98,6 @@ protected:
                 SendResponse(response());
 
                 _handler(RES_OKHEADER, info.string().data(), total);
-
-                std::cout << "response header:" << response() << std::endl;
 
                 bool cancel = false;
                 size_t read_sz = 0;
@@ -126,7 +124,7 @@ protected:
             _handler(RES_NOTFOUND, info.string().data(), 0);
         }
 
-        std::cout << "response body end:" << std::endl;
+        //std::cout << "response body end:" << total << std::endl;
     }
 
     // 解析URL中的query参数
@@ -158,7 +156,7 @@ protected:
     void onReceivedRequest(const CppServer::HTTP::HTTPRequest &request) override
     {
         // Show HTTP request content
-        std::cout << std::endl << request;
+        //std::cout << std::endl << request;
 
         // Process HTTP request methods
         if (request.method() == "HEAD")

--- a/src/lib/common/httpweb/tokencache.cpp
+++ b/src/lib/common/httpweb/tokencache.cpp
@@ -36,7 +36,7 @@ bool TokenCache::verifyToken(std::string &token)
     try {
         auto decoded = jwt::decode(token);
         verifier.verify(decoded);
-        std::cout << "Token verify success!" << std::endl;
+        //std::cout << "Token verify success!" << std::endl;
     } catch (const std::exception& ex) {
         std::cout << "Error: " << ex.what() << std::endl;
         return false;

--- a/src/lib/common/httpweb/tokencache.cpp
+++ b/src/lib/common/httpweb/tokencache.cpp
@@ -33,9 +33,8 @@ bool TokenCache::verifyToken(std::string &token)
                           .allow_algorithm(jwt::algorithm::es256k(es256k_pub_key, es256k_priv_key, "", ""))
                           .with_issuer("deepin");
 
-    auto decoded = jwt::decode(token);
-
     try {
+        auto decoded = jwt::decode(token);
         verifier.verify(decoded);
         std::cout << "Token verify success!" << std::endl;
     } catch (const std::exception& ex) {


### PR DESCRIPTION
The http parse incorrect request url if it includes space, it cause crash when verify error token.

Log: Fix http get error header.