### PR TITLE
fix: [memory leaks] Fix memory leaks

### DIFF
--- a/3rdparty/zrpc/src/net/tcpclient.cpp
+++ b/3rdparty/zrpc/src/net/tcpclient.cpp
@@ -31,6 +31,10 @@ TcpClient::~TcpClient() {
         this->stop();
         DLOG << "~TcpClient() close : " << _tcp_cli->socket();
     }
+    if(_tcp_cli) {
+        delete _tcp_cli;
+        _tcp_cli = nullptr;
+    }
 }
 
 bool TcpClient::tryConnect() {

--- a/src/common/constant.h
+++ b/src/common/constant.h
@@ -211,15 +211,34 @@ enum CurrentStatus {
     CURRENT_STATUS_SHARE_START = 6, // 5键鼠共享中
 };
 
-// use thread replace the coroutine
+//QUNIGO不会持续创建新线程，导致co的内存泄露
 #if defined(DISABLE_GO)
+#include <QThreadPool>
+class LambdaTask : public QRunnable {
+public:
+    using FunctionType = std::function<void()>;
+
+    explicit LambdaTask(FunctionType func) : function(std::move(func)) {}
+
+    void run() override {
+        function();
+    }
+
+private:
+    FunctionType function;
+};
+    #define QUNIGO(...) \
+    do { \
+        QThreadPool::globalInstance()->start(new LambdaTask(__VA_ARGS__)); \
+    } while(0)
     #define UNIGO(...) \
-        do { \
-            std::thread coThread(__VA_ARGS__); \
-            coThread.detach(); \
-        } while(0)
+    do { \
+        std::thread coThread(__VA_ARGS__); \
+        coThread.detach(); \
+    } while(0)
 #else
     #define UNIGO go
+    #define QUNIGO go
 #endif
 
 #endif // CONSTANT_H

--- a/src/plugins/cooperation/daemon/utils/cooperationutil.cpp
+++ b/src/plugins/cooperation/daemon/utils/cooperationutil.cpp
@@ -185,7 +185,7 @@ void CooperationUtil::registAppInfo(const QString &infoJson)
         return;
     }
 
-    UNIGO([infoJson] {
+    QUNIGO([infoJson] {
         rpc::Client rpcClient("127.0.0.1", UNI_IPC_BACKEND_PORT, false);
         co::Json req, res;
 
@@ -248,7 +248,7 @@ void CooperationUtil::setAppConfig(const QString &key, const QString &value)
 
 void CooperationUtil::replyTransRequest(int type)
 {
-    UNIGO([=] {
+    QUNIGO([=] {
         rpc::Client rpcClient("127.0.0.1", UNI_IPC_BACKEND_COOPER_TRAN_PORT, false);
         co::Json res;
         // 获取设备名称

--- a/src/plugins/daemon/core/service/discoveryjob.cpp
+++ b/src/plugins/daemon/core/service/discoveryjob.cpp
@@ -107,7 +107,7 @@ void DiscoveryJob::announcerRun(const fastring &info)
     _announcer_p = co::make<searchlight::Announcer>("ulink_service", UNI_RPC_PORT_BASE, info);
 
     ((searchlight::Announcer*)_announcer_p)->start([this](const QString &ip){
-        UNIGO([this, ip](){
+        QUNIGO([this, ip](){
             auto selfIp = Util::getFirstIp();
             if (selfIp.empty())
                 return;

--- a/src/plugins/daemon/core/service/ipc/handleipcservice.cpp
+++ b/src/plugins/daemon/core/service/ipc/handleipcservice.cpp
@@ -542,9 +542,9 @@ void HandleIpcService::handleShareServerStart(const bool ok, const QString msg)
 
 void HandleIpcService::handleSearchDevice(co::Json json)
 {
-    UNIGO([json](){
-        SearchDevice de;
-        de.from_json(json);
+    SearchDevice de;
+    de.from_json(json);
+    QUNIGO([de](){
         DiscoveryJob::instance()->searchDeviceByIp(de.ip.c_str(), de.remove);
     });
 }

--- a/src/plugins/daemon/core/service/job/transferjob.cpp
+++ b/src/plugins/daemon/core/service/job/transferjob.cpp
@@ -160,7 +160,7 @@ void TransferJob::start()
         // 读取所有文件的信息
         DLOG << "doTransfileJob path to save:" << _savedir;
         //并行读取文件数据
-        UNIGO([this]() {
+        QUNIGO([this]() {
             co::Json pathJson;
             pathJson.parse_from(_path);
             for (uint32 i = 0; i < pathJson.array_size(); i++) {

--- a/src/plugins/daemon/core/service/jobmanager.cpp
+++ b/src/plugins/daemon/core/service/jobmanager.cpp
@@ -82,7 +82,7 @@ bool JobManager::handleRemoteRequestJob(QString json, QString *targetAppName)
         _transjob_sends.insert(jobId, job);
     }
 
-    UNIGO([job]() {
+    QUNIGO([job]() {
         // DLOG << ".........start job: sched: " << co::sched_id() << " co: " << co::coroutine_id();
         job->start();
     });

--- a/src/plugins/daemon/core/service/rpc/handlerpcservice.cpp
+++ b/src/plugins/daemon/core/service/rpc/handlerpcservice.cpp
@@ -529,7 +529,7 @@ void HandleRpcService::startRemoteServer(const quint16 port)
     Cert::instance()->removeFile(crt);
 
     QPointer<HandleRpcService> self = this;
-    UNIGO([self]() {
+    QUNIGO([self]() {
         // 这里已经是线程或者协程
         while (!self.isNull()) {
             IncomeData indata;

--- a/src/plugins/daemon/core/service/searchlight.cpp
+++ b/src/plugins/daemon/core/service/searchlight.cpp
@@ -92,7 +92,7 @@ recheck:
 
     _timer.restart();
     // 定时更新发现设备
-    UNIGO([this](){
+    QUNIGO([this](){
         while (!_stop) {
             sleep::ms(1000); //co::sleep(1000);
             remove_idle_services();

--- a/src/plugins/daemon/core/service/servicemanager.cpp
+++ b/src/plugins/daemon/core/service/servicemanager.cpp
@@ -120,10 +120,10 @@ void ServiceManager::asyncDiscovery()
 {
     connect(DiscoveryJob::instance(), &DiscoveryJob::sigNodeChanged, SendIpcService::instance(),
             &SendIpcService::nodeChanged, Qt::QueuedConnection);
-    UNIGO([]() {
+    QUNIGO([]() {
         DiscoveryJob::instance()->discovererRun();
     });
-    UNIGO([this]() {
+    QUNIGO([this]() {
         fastring baseinfo = genPeerInfo();
         DiscoveryJob::instance()->announcerRun(baseinfo);
     });


### PR DESCRIPTION
libcoost creates persistent static resources for each thread, which can cause memory leaks when threads are frequently created and released using a thread pool to avoid frequent creation and destruction of threads Log: Fix memory leaks
Bug: https://pms.uniontech.com/bug-view-266935.html