### PR TITLE
fix: [thread] Increase the initial number of threads in threadpool

### DIFF
--- a/src/plugins/daemon/core/daemoncoreplugin.cpp
+++ b/src/plugins/daemon/core/daemoncoreplugin.cpp
@@ -7,6 +7,8 @@
 
 #include "service/servicemanager.h"
 
+#include <QThreadPool>
+
 using namespace daemon_core;
 using namespace deepin_cross;
 
@@ -18,6 +20,7 @@ void daemonCorePlugin::initialize()
 
 bool daemonCorePlugin::start()
 {
+    QThreadPool::globalInstance()->setMaxThreadCount(32);
     ServiceManager *manager = new ServiceManager(this);
     manager->startRemoteServer();
     return true;


### PR DESCRIPTION
The default number of thread pools is too low, resulting in communication failure

Log: [thread] Increase the initial number of threads in threadpool
Bug: https://pms.uniontech.com/bug-view-273695.html