### PR TITLE
fix: Fix discovery issue

### DIFF
--- a/src/lib/cooperation/core/utils/cooperationutil_p.h
+++ b/src/lib/cooperation/core/utils/cooperationutil_p.h
@@ -26,7 +26,7 @@ public:
 public:
     CooperationUtil *q { nullptr };
     QSharedPointer<MainWindow> window { nullptr };
-    bool isOnline { true };
+    bool isOnline { false };
 };
 
 }


### PR DESCRIPTION
When App start up, it publics first and the compated deamon is launched later, so it do not registor into daemon, that cause other old protocol can not discovery it.

Log: Fix disvovery issue after start up.
Bug: https://pms.uniontech.com/bug-view-273665.html