### PR TITLE
fix: Fix config and new 0.9.2 tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-cooperation (0.9.2) unstable; urgency=medium
+
+  * v0.9.2 version update.
+  * fix some issues.
+
+ -- re2zero <yangwu@uniontech.com>  Tue, 08 Oct 2024 15:08:16 +0800
+
 dde-cooperation (0.9.1) unstable; urgency=medium
 
   * v0.9.1 version update.
@@ -10,7 +17,7 @@ dde-cooperation (0.9.0) unstable; urgency=medium
   * v0.9.0 version update.
   * added a new communication method that is compatible with previous versions.
 
- -- liujinchang <liujinchang@uniontech.com>  Aug, 28 Wed 2024 09:51:44  +0800
+ -- liujinchang <liujinchang@uniontech.com>  Wed, 28 Aug 2024 09:51:44  +0800
 
 dde-cooperation (0.8.0) unstable; urgency=medium
 

--- a/src/configs/settings/settings.cpp
+++ b/src/configs/settings/settings.cpp
@@ -451,7 +451,7 @@ bool Settings::setValueNoNotify(const QString &group, const QString &key, const 
 
         changed = true;
     } else {
-        changed = this->value(group, key, value) != value;
+        changed = this->value(group, key) != value;
     }
 
     d->writableData.setValue(group, key, value);


### PR DESCRIPTION
It uses the value as default value to compare, and then get no change if set value at first time.

Log: Fix config not change at first time.
Bug: https://pms.uniontech.com/bug-view-275517.html