### PR TITLE
fix: Fix share state issue

### DIFF
--- a/src/lib/cooperation/core/discover/discovercontroller.cpp
+++ b/src/lib/cooperation/core/discover/discovercontroller.cpp
@@ -416,14 +416,14 @@ void DiscoverController::compatAddDeivces(StringMap infoMap)
         QString ip = ipList[0];
         QString sharedip = ipList[1];
 
-        if(ip == CooperationUtil::localIPAddress()) {
+        if (ip == CooperationUtil::localIPAddress()) {
             WLOG << "Ignore local host ip: " << ip.toStdString();
             continue;
         }
 
         devInfo->setIpAddress(ip);
         if (devInfo->discoveryMode() == DeviceInfo::DiscoveryMode::Everyone) {
-            if (sharedip == CooperationUtil::localIPAddress())
+            if (sharedip == CooperationUtil::localIPAddress() || _connectedDevice == devInfo->ipAddress())
                 devInfo->setConnectStatus(DeviceInfo::Connected);
 
             d->onlineDeviceList.append(devInfo);
@@ -452,8 +452,9 @@ void DiscoverController::startDiscover()
 
     // 延迟,为了展示发现界面
     QTimer::singleShot(500, [this]() {
-        // 兼容，获取发现列表，refresh则清除数据
-        Q_EMIT startDiscoveryDevice();
+        // clear current list first.
         refresh();
+        // compation: start get nodes
+        Q_EMIT startDiscoveryDevice();
     });
 }

--- a/src/lib/cooperation/core/net/compatwrapper.cpp
+++ b/src/lib/cooperation/core/net/compatwrapper.cpp
@@ -84,6 +84,11 @@ void CompatWrapperPrivate::ipcCompatSlot(int type, const QString& msg)
 
         auto ip = QString::fromStdString(nodeInfo.os.ipv4);
         auto sharedip = QString::fromStdString(nodeInfo.os.share_connect_ip);
+        auto sharing = ShareHelper::instance()->selfSharing(sharedip);
+        if (sharing > 0) {
+            // self shared ip but not running, reset the sharedip as empty.
+            sharedip = "";
+        }
 
         // typedef QMap<QString, QString> StringMap;
         StringMap infoMap;

--- a/src/lib/cooperation/core/net/helper/sharehelper.h
+++ b/src/lib/cooperation/core/net/helper/sharehelper.h
@@ -37,6 +37,9 @@ public Q_SLOTS:
     // exception: network connection(ping out) or other io
     void onShareExcepted(int type, const QString &remote);
 
+    // check the self is sharing with someone
+    int selfSharing(const QString &shareIp);
+
 private:
     explicit ShareHelper(QObject *parent = nullptr);
     ~ShareHelper();

--- a/src/lib/cooperation/core/net/networkutil.cpp
+++ b/src/lib/cooperation/core/net/networkutil.cpp
@@ -362,6 +362,11 @@ void NetworkUtil::handleCompatDiscover()
         for (const auto &peerInfo : nodeList.peers) {
             auto ip = QString::fromStdString(peerInfo.os.ipv4);
             auto sharedip = QString::fromStdString(peerInfo.os.share_connect_ip);
+            auto sharing = ShareHelper::instance()->selfSharing(sharedip);
+            if (sharing > 0) {
+                // self shared ip but not running, reset the sharedip as empty.
+                sharedip = "";
+            }
             for (const auto &appInfo : peerInfo.apps) {
                 if (appInfo.appname != ipc::CooperRegisterName)
                     continue;

--- a/src/lib/cooperation/core/share/sharecooperationservice.cpp
+++ b/src/lib/cooperation/core/share/sharecooperationservice.cpp
@@ -162,6 +162,15 @@ void ShareCooperationService::setBarrierProfile(const QString &dir)
     _cooConfig->setProfileDir(dir);
 }
 
+bool ShareCooperationService::isRunning()
+{
+    if (!barrierProcess()) {
+        return false;
+    }
+
+    return barrierProcess()->state() == QProcess::Running;
+}
+
 bool ShareCooperationService::startBarrier()
 {
     LOG << "starting process";

--- a/src/lib/cooperation/core/share/sharecooperationservice.h
+++ b/src/lib/cooperation/core/share/sharecooperationservice.h
@@ -64,6 +64,9 @@ public:
 
     void setEnableCrypto(bool enable);
     void setBarrierProfile(const QString &dir);
+
+    bool isRunning();
+
 public slots:
     bool restartBarrier();
     bool startBarrier();


### PR DESCRIPTION
The shared target info is incorrect and do not check self sharing status that cause not update the share state if try to stop share.

Log: Fix share state not update.
Bug: https://pms.uniontech.com/bug-view-273413.html