### PR TITLE
fix: Fix the vnc view not change mode if mobile has changed show mode

### DIFF
--- a/src/lib/cooperation/core/gui/phone/screenmirroringwindow.cpp
+++ b/src/lib/cooperation/core/gui/phone/screenmirroringwindow.cpp
@@ -146,7 +146,33 @@ void ScreenMirroringWindow::handleSizeChange(const QSize &size)
         initShow = true;
     }
 
-    this->resize(w, h);
+    // only the size is biger current size can be resized.
+    if (w > this->width() || h > this->height()) {
+        m_expectSize = QSize(0, 0); // has been resize, reset.
+        this->resize(w, h);
+    } else {
+        m_expectSize = size; // record expected size which is not resized
+    }
+}
+
+void ScreenMirroringWindow::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::WindowStateChange) {
+        if (isMaximized() || isMinimized()) {
+            m_previousSize = size();
+        } else {
+            if (m_vncViewer) {
+                if (m_expectSize.width() > 0) {
+                    // back to previous size and then do expected changed.
+                    resize(m_previousSize);
+                    handleSizeChange(m_expectSize);
+                    return;
+                }
+            }
+        }
+    }
+
+    QWidget::changeEvent(event);
 }
 
 LockScreenWidget::LockScreenWidget(QWidget *parent)

--- a/src/lib/cooperation/core/gui/phone/screenmirroringwindow.h
+++ b/src/lib/cooperation/core/gui/phone/screenmirroringwindow.h
@@ -48,10 +48,15 @@ Q_SIGNALS:
 public slots:
     void handleSizeChange(const QSize &size);
 
+protected:
+    void changeEvent(QEvent *event);
+
 private:
     QStackedLayout *stackedLayout { nullptr };
     QWidget *bottomWidget { nullptr };
     QWidget *workWidget { nullptr };
+    QSize m_expectSize;  // record the size that vnc view expected
+    QSize m_previousSize;  // record the normal window size
 
     QPoint lastPos;
     bool isDragging = false;


### PR DESCRIPTION
Record the expect size if not resized and then do size change after window change to normal.

Log: Fix the vnc view not change mode if mobile has changed show mode.
Bug: https://pms.uniontech.com/bug-view-283569.html