### PR TITLE
fix: [memory leaks] Fix memory leaks

### DIFF
--- a/src/compat/plugins/daemon/core/daemoncoreplugin.cpp
+++ b/src/compat/plugins/daemon/core/daemoncoreplugin.cpp
@@ -7,6 +7,8 @@
 
 #include "service/servicemanager.h"
 
+#include <QThreadPool>
+
 using namespace daemon_core;
 using namespace deepin_cross;
 
@@ -18,6 +20,7 @@ void daemonCorePlugin::initialize()
 
 bool daemonCorePlugin::start()
 {
+    QThreadPool::globalInstance()->setMaxThreadCount(32);
     ServiceManager *manager = new ServiceManager(this);
     manager->startRemoteServer();
     return true;

--- a/src/compat/plugins/daemon/core/service/discoveryjob.cpp
+++ b/src/compat/plugins/daemon/core/service/discoveryjob.cpp
@@ -108,7 +108,7 @@ void DiscoveryJob::announcerRun(const fastring &info)
     _announcer_p = co::make<searchlight::Announcer>("ulink_service", UNI_RPC_PORT_BASE, info);
 
     ((searchlight::Announcer*)_announcer_p)->start([this](const QString &ip){
-        UNIGO([this, ip](){
+        QUNIGO([this, ip](){
             auto selfIp = Util::getFirstIp();
             if (selfIp.empty())
                 return;

--- a/src/compat/plugins/daemon/core/service/ipc/handleipcservice.cpp
+++ b/src/compat/plugins/daemon/core/service/ipc/handleipcservice.cpp
@@ -562,9 +562,9 @@ void HandleIpcService::handleShareServerStart(const bool ok, const QString msg)
 
 void HandleIpcService::handleSearchDevice(co::Json json)
 {
-    UNIGO([json](){
-        SearchDevice de;
-        de.from_json(json);
+    SearchDevice de;
+    de.from_json(json);
+    QUNIGO([de](){
         DiscoveryJob::instance()->searchDeviceByIp(de.ip.c_str(), de.remove);
     });
 }

--- a/src/compat/plugins/daemon/core/service/job/transferjob.cpp
+++ b/src/compat/plugins/daemon/core/service/job/transferjob.cpp
@@ -165,7 +165,7 @@ void TransferJob::start()
         // 读取所有文件的信息
         DLOG << "doTransfileJob path to save:" << _savedir;
         //并行读取文件数据
-        UNIGO([this]() {
+        QUNIGO([this]() {
             co::Json pathJson;
             pathJson.parse_from(_path);
             for (uint32 i = 0; i < pathJson.array_size(); i++) {

--- a/src/compat/plugins/daemon/core/service/jobmanager.cpp
+++ b/src/compat/plugins/daemon/core/service/jobmanager.cpp
@@ -82,7 +82,7 @@ bool JobManager::handleRemoteRequestJob(QString json, QString *targetAppName)
         _transjob_sends.insert(jobId, job);
     }
 
-    UNIGO([job]() {
+    QUNIGO([job]() {
         // DLOG << ".........start job: sched: " << co::sched_id() << " co: " << co::coroutine_id();
         job->start();
     });

--- a/src/compat/plugins/daemon/core/service/searchlight.cpp
+++ b/src/compat/plugins/daemon/core/service/searchlight.cpp
@@ -92,7 +92,7 @@ recheck:
 
     _timer.restart();
     // 定时更新发现设备
-    UNIGO([this](){
+    QUNIGO([this](){
         while (!_stop) {
             sleep::ms(1000); //co::sleep(1000);
             remove_idle_services();

--- a/src/compat/plugins/daemon/core/service/servicemanager.cpp
+++ b/src/compat/plugins/daemon/core/service/servicemanager.cpp
@@ -114,10 +114,10 @@ void ServiceManager::asyncDiscovery()
     connect(DiscoveryJob::instance(), &DiscoveryJob::sigNodeChanged, SendIpcService::instance(),
             &SendIpcService::handleNodeChanged, Qt::QueuedConnection);
 
-    UNIGO([]() {
+    QUNIGO([]() {
         DiscoveryJob::instance()->discovererRun();
     });
-    UNIGO([this]() {
+    QUNIGO([this]() {
         fastring baseinfo = genPeerInfo();
         DiscoveryJob::instance()->announcerRun(baseinfo);
     });


### PR DESCRIPTION
libcoost creates persistent static resources for each thread, which can cause memory leaks when threads are frequently created and released using a thread pool to avoid frequent creation and destruction of threads

Log: Fix memory leaks
Bug: https://pms.uniontech.com/bug-view-266935.html