### PR TITLE
fix: [win]Enable windows building after UI changed

### DIFF
--- a/src/lib/cooperation/core/CMakeLists.txt
+++ b/src/lib/cooperation/core/CMakeLists.txt
@@ -39,8 +39,6 @@ FILE(GLOB PLUGIN_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/gui/dialogs/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/gui/widgets/*.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/gui/widgets/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/gui/phone/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/gui/phone/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/utils/*.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/utils/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/gui/utils/*"
@@ -48,8 +46,8 @@ FILE(GLOB PLUGIN_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/share/*"
     "${CMAKE_CURRENT_SOURCE_DIR}/net/*.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/net/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/net/helper/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/net/helper/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/net/helper/sharehelper*"
+    "${CMAKE_CURRENT_SOURCE_DIR}/net/helper/transferhelper*"
     "${CMAKE_CURRENT_SOURCE_DIR}/net/helper/dialogs/*"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.json"
     )
@@ -75,7 +73,10 @@ elseif (CMAKE_SYSTEM MATCHES "Linux")
         "${CMAKE_SOURCE_DIR}/src/configs/dconfig/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/gui/linux/*.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/gui/linux/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/gui/phone/*.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/gui/phone/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/net/linux/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/net/helper/phonehelper*"
     )
     find_package(Dtk${DTK_VERSION_MAJOR} COMPONENTS Widget REQUIRED)
 else()
@@ -97,9 +98,12 @@ list(APPEND LINKLIBS sessionmanager)
 list(APPEND LINKLIBS sslconf)
 list(APPEND LINKLIBS vncclient)
 
-find_library(QRENCODE_LIBRARY qrencode)
-if(NOT QRENCODE_LIBRARY)
-    message(FATAL_ERROR "libqrencode not found. Please install it.")
+if (NOT WIN32)
+    find_library(QRENCODE_LIBRARY qrencode)
+    if(NOT QRENCODE_LIBRARY)
+        message(FATAL_ERROR "libqrencode not found. Please install it.")
+    endif()
+    add_definitions(-DENABLE_PHONE=1)
 endif()
 
 add_library(${PROJECT_NAME}
@@ -144,8 +148,14 @@ target_link_libraries(${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::Concurrent
     QtZeroConf
     CuteIPC
-    qrencode
 )
+
+if (NOT WIN32)
+    target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+        qrencode
+    )
+endif()
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC

--- a/src/lib/cooperation/core/cooperationcoreplugin.cpp
+++ b/src/lib/cooperation/core/cooperationcoreplugin.cpp
@@ -10,7 +10,9 @@
 #include "net/transferwrapper.h"
 #include "net/helper/transferhelper.h"
 #include "net/helper/sharehelper.h"
+#ifdef ENABLE_PHONE
 #include "net/helper/phonehelper.h"
+#endif
 #include "discover/deviceinfo.h"
 
 #include "common/commonutils.h"
@@ -77,6 +79,7 @@ bool CooperaionCorePlugin::isMinilize()
     ;
 }
 
+#ifdef ENABLE_PHONE
 void CooperaionCorePlugin::initMobileModule()
 {
     connect(PhoneHelper::instance(), &PhoneHelper::addMobileInfo, dMain.get(), &MainWindow::addMobileDevice);
@@ -85,6 +88,7 @@ void CooperaionCorePlugin::initMobileModule()
 
     PhoneHelper::instance()->registConnectBtn(dMain.get());
 }
+#endif
 
 bool CooperaionCorePlugin::start()
 {
@@ -97,7 +101,9 @@ bool CooperaionCorePlugin::start()
     } else {
         DiscoverController::instance();
         NetworkUtil::instance();
+#ifdef ENABLE_PHONE
         initMobileModule();
+#endif
 
         ShareHelper::instance()->registConnectBtn();
 

--- a/src/lib/cooperation/core/cooperationcoreplugin.h
+++ b/src/lib/cooperation/core/cooperationcoreplugin.h
@@ -27,7 +27,9 @@ public:
 private:
     void initialize();
     bool isMinilize();
+#ifdef ENABLE_PHONE
     void initMobileModule();
+#endif
     QSharedPointer<MainWindow> dMain { nullptr };
     bool onlyTransfer { false };
 };

--- a/src/lib/cooperation/core/gui/linux/mainwindow_p_linux.cpp
+++ b/src/lib/cooperation/core/gui/linux/mainwindow_p_linux.cpp
@@ -27,12 +27,14 @@ void MainWindowPrivate::initWindow()
     q->setFixedSize(500, 630);
     q->setWindowIcon(QIcon::fromTheme("dde-cooperation"));
 
-    phoneWidget = new PhoneWidget(q);
     workspaceWidget = new WorkspaceWidget(q);
 
     stackedLayout = new QStackedLayout;
     stackedLayout->addWidget(workspaceWidget);
+#ifdef ENABLE_PHONE
+    phoneWidget = new PhoneWidget(q);
     stackedLayout->addWidget(phoneWidget);
+#endif
     stackedLayout->setCurrentIndex(0);
 
     QWidget *centralWidget = new QWidget();
@@ -47,15 +49,10 @@ void MainWindowPrivate::initWindow()
     q->setCentralWidget(centralWidget);
 }
 
-void MainWindowPrivate::setIP(const QString &ip)
-{
-    bottomLabel->setIp(ip);
-}
-
 void MainWindowPrivate::initTitleBar()
 {
     auto titleBar = q->titlebar();
-
+#ifdef ENABLE_PHONE
     DButtonBox *switchBtn = new DButtonBox(q);
     QList<DButtonBoxButton *> list;
     DButtonBoxButton *PCBtn = new DButtonBoxButton(tr("Computer"));
@@ -67,7 +64,7 @@ void MainWindowPrivate::initTitleBar()
     PCBtn->setChecked(true);
     connect(PCBtn, &DButtonBoxButton::clicked, q, [this] { q->onSwitchMode(CooperationMode::kPC); });
     connect(mobileBtn, &DButtonBoxButton::clicked, q, [this] { q->onSwitchMode(CooperationMode::kMobile); });
-
+#endif
     if (qApp->property("onlyTransfer").toBool()) {
         titleBar->setMenuVisible(false);
         titleBar->addWidget(new QLabel(tr("Selection of delivery device")), Qt::AlignHCenter);

--- a/src/lib/cooperation/core/gui/mainwindow.cpp
+++ b/src/lib/cooperation/core/gui/mainwindow.cpp
@@ -91,6 +91,11 @@ void MainWindowPrivate::handleSettingMenuTriggered(int action)
     }
 }
 
+void MainWindowPrivate::setIP(const QString &ip)
+{
+    bottomLabel->setIp(ip);
+}
+
 MainWindow::MainWindow(QWidget *parent)
     : CooperationMainWindow(parent),
       d(new MainWindowPrivate(this))
@@ -173,6 +178,7 @@ void MainWindow::addDevice(const QList<DeviceInfoPointer> &infoList)
     _userAction = false;
 }
 
+#ifdef ENABLE_PHONE
 void MainWindow::addMobileDevice(const DeviceInfoPointer info)
 {
     onSwitchMode(kMobile);
@@ -193,6 +199,7 @@ void MainWindow::addMobileOperation(const QVariantMap &map)
 {
     d->phoneWidget->addOperation(map);
 }
+#endif
 
 void MainWindow::removeDevice(const QString &ip)
 {

--- a/src/lib/cooperation/core/gui/mainwindow.h
+++ b/src/lib/cooperation/core/gui/mainwindow.h
@@ -31,8 +31,9 @@ public:
     void closeEvent(QCloseEvent *event) override;
 
     void minimizedAPP();
-
+#ifdef ENABLE_PHONE
     void addMobileOperation(const QVariantMap &map);
+#endif
 
 signals:
     void refreshDevices();
@@ -49,10 +50,12 @@ public Q_SLOTS:
     void onRegistOperations(const QVariantMap &map);
     void onSwitchMode(CooperationMode mode);
 
+#ifdef ENABLE_PHONE
     //mobile
     void addMobileDevice(const DeviceInfoPointer info);
     void disconnectMobile();
     void onSetQRCode(const QString &code);
+#endif
 
 protected:
     void showCloseDialog();

--- a/src/lib/cooperation/core/gui/mainwindow_p.h
+++ b/src/lib/cooperation/core/gui/mainwindow_p.h
@@ -6,7 +6,9 @@
 #define MAINWINDOW_P_H
 
 #include "widgets/workspacewidget.h"
+#ifdef ENABLE_PHONE
 #include "phone/phonewidget.h"
+#endif
 
 #include <QObject>
 #include <QPainter>
@@ -44,7 +46,9 @@ public:
     MainWindow *q { nullptr };
     QStackedLayout *stackedLayout { nullptr };
     WorkspaceWidget *workspaceWidget { nullptr };
+#ifdef ENABLE_PHONE
     PhoneWidget *phoneWidget { nullptr };
+#endif
     bool leftButtonPressed { false };
     QPoint lastPosition;
     BottomLabel *bottomLabel { nullptr };

--- a/src/lib/cooperation/core/gui/widgets/workspacewidget.cpp
+++ b/src/lib/cooperation/core/gui/widgets/workspacewidget.cpp
@@ -53,9 +53,17 @@ void WorkspaceWidgetPrivate::initUI()
     CooperationGuiHelper::setAutoFont(deviceLabel, 14, QFont::Normal);
     QHBoxLayout *hLayout = new QHBoxLayout;
     refreshBtn = new CooperationIconButton();
-    refreshBtn->setIcon(QIcon::fromTheme("refresh_tip"));
     refreshBtn->setIconSize(QSize(16, 16));
+#ifdef __linux__
+    refreshBtn->setIcon(QIcon::fromTheme("refresh_tip"));
     refreshBtn->setFlat(true);
+#else
+    refreshBtn->setIcon(QIcon(":/icons/deepin/builtin/texts/refresh_tip_14px.svg"));
+    refreshBtn->setStyleSheet("QToolButton {"
+                              "background-color: rgba(0,0,0,0.15);"
+                              "border-radius: 8px;"
+                              "}");
+#endif
     refreshBtn->setToolTip(tr("Re-scan for devices"));
     refreshBtn->setFixedSize(24, 24);
     connect(refreshBtn, &QPushButton::clicked, q, &WorkspaceWidget::refresh);

--- a/src/lib/cooperation/core/gui/win/mainwindow_p_win.cpp
+++ b/src/lib/cooperation/core/gui/win/mainwindow_p_win.cpp
@@ -12,6 +12,9 @@
 #include <QAction>
 #include <QMenu>
 #include <QPainterPath>
+#include <QStackedLayout>
+
+#include <gui/widgets/cooperationstatewidget.h>
 
 using namespace cooperation_core;
 void MainWindowPrivate::initWindow()
@@ -22,7 +25,17 @@ void MainWindowPrivate::initWindow()
     q->setWindowIcon(QIcon::fromTheme(":/icons/deepin/builtin/icons/dde-cooperation_128px.png"));
 
     workspaceWidget = new WorkspaceWidget(q);
-    q->setCentralWidget(workspaceWidget);
+
+    QWidget *centralWidget = new QWidget();
+    QVBoxLayout *mainLayout = new QVBoxLayout;
+    bottomLabel = new BottomLabel(q);
+    mainLayout->addWidget(workspaceWidget);
+    mainLayout->addWidget(bottomLabel);
+    mainLayout->setSpacing(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
+    centralWidget->setLayout(mainLayout);
+    q->setCentralWidget(centralWidget);
+
     workspaceWidget->setStyleSheet("background-color: rgba(230,230,230, 0.1);"
                                    "border-bottom-right-radius: 10px;"
                                    "border-bottom-left-radius: 10px;");
@@ -72,17 +85,6 @@ void MainWindowPrivate::initTitleBar()
                             "border-top-left-radius: 10px;"
                             "}");
     titleBar->setFocusPolicy(Qt::ClickFocus);
-
-    QToolButton *refreshBtn = new QToolButton(q);
-    refreshBtn->setIcon(QIcon(":/icons/deepin/builtin/texts/refresh_14px.svg"));
-    refreshBtn->setIconSize(QSize(16, 16));
-    refreshBtn->setToolTip(tr("Re-scan for devices"));
-    refreshBtn->setStyleSheet("QToolButton {"
-                              "background-color: rgba(0,0,0,0.15);"
-                              "border-radius: 8px;"
-                              "}");
-    refreshBtn->setFixedSize(35, 35);
-    connect(refreshBtn, &QToolButton::clicked, q, &MainWindow::onLookingForDevices);
 
     QToolButton *closeButton = new QToolButton(titleBar);
     closeButton->setStyleSheet("QWidget {"
@@ -138,7 +140,6 @@ void MainWindowPrivate::initTitleBar()
     QHBoxLayout *titleLayout = new QHBoxLayout(titleBar);
 
     titleLayout->addWidget(iconLabel);
-    titleLayout->addWidget(refreshBtn, Qt::AlignLeft);
     titleLayout->addStretch();
     titleLayout->addWidget(helpButton, Qt::AlignHCenter);
     titleLayout->addWidget(minButton, Qt::AlignHCenter);

--- a/src/lib/cooperation/core/net/helper/transferhelper.cpp
+++ b/src/lib/cooperation/core/net/helper/transferhelper.cpp
@@ -19,6 +19,7 @@
 #include <QStandardPaths>
 #include <QTime>
 #include <QProcess>
+#include <QRegularExpression>
 
 #ifdef linux
 #    include "base/reportlog/reportlogmanager.h"

--- a/src/lib/cooperation/core/net/networkutil.cpp
+++ b/src/lib/cooperation/core/net/networkutil.cpp
@@ -13,7 +13,9 @@
 #include "discover/discovercontroller.h"
 #include "helper/transferhelper.h"
 #include "helper/sharehelper.h"
+#ifdef ENABLE_PHONE
 #include "helper/phonehelper.h"
+#endif
 #include "utils/cooperationutil.h"
 
 #include "compatwrapper.h"
@@ -135,6 +137,7 @@ NetworkUtilPrivate::NetworkUtilPrivate(NetworkUtil *qq)
             }
         }
             return true;
+#ifdef ENABLE_PHONE
         case APPLY_SCAN_CONNECT: {
             ApplyMessage req, res;
             req.from_json(json_value);
@@ -186,6 +189,7 @@ NetworkUtilPrivate::NetworkUtilPrivate(NetworkUtil *qq)
                                           Qt::QueuedConnection);
         }
             return true;
+#endif
         }
 
         // unhandle message
@@ -245,12 +249,13 @@ void NetworkUtilPrivate::handleConnectStatus(int result, QString reason)
                                       Q_ARG(int, 0),
                                       Q_ARG(QString, reason),
                                       Q_ARG(bool, false));
-
+#ifdef ENABLE_PHONE
         //mobile
         DeviceInfoPointer info(new DeviceInfo(reason, QString()));
         q->metaObject()->invokeMethod(PhoneHelper::instance(), "onDisconnect",
                                       Qt::QueuedConnection,
                                       Q_ARG(DeviceInfoPointer, info));
+#endif
     }
 }
 

--- a/src/lib/cooperation/transfer/CMakeLists.txt
+++ b/src/lib/cooperation/transfer/CMakeLists.txt
@@ -39,8 +39,6 @@ FILE(GLOB PLUGIN_FILES
     "${CORE_UI_DIR}/gui/dialogs/*.cpp"
     "${CORE_UI_DIR}/gui/widgets/*.h"
     "${CORE_UI_DIR}/gui/widgets/*.cpp"
-    "${CORE_UI_DIR}/gui/phone/*.h"
-    "${CORE_UI_DIR}/gui/phone/*.cpp"
     "${CORE_UI_DIR}/gui/utils/*"
     "${CORE_UI_DIR}/discover/deviceinfo.h"
     "${CORE_UI_DIR}/discover/deviceinfo.cpp"
@@ -78,11 +76,6 @@ endif()
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Network DBus Concurrent)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets Network DBus Concurrent)
-
-find_library(QRENCODE_LIBRARY qrencode)
-if(NOT QRENCODE_LIBRARY)
-    message(FATAL_ERROR "libqrencode not found. Please install it.")
-endif()
 
 # 根据Qt版本选择合适的命令
 if (QT_VERSION VERSION_GREATER_EQUAL "6.0")
@@ -132,7 +125,6 @@ target_link_libraries(${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::Network
     Qt${QT_VERSION_MAJOR}::Concurrent
     CuteIPC
-    qrencode
 )
 
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
After the UI change which support mobile for UOS, it blocks windows building, remove phone classes from cooperation-transfer.

Log: Enable windows building after UI changed.