### PR TITLE
fix: Fix still control caused by barrier did not exit

### DIFF
--- a/src/lib/cooperation/core/share/sharecooperationservice.cpp
+++ b/src/lib/cooperation/core/share/sharecooperationservice.cpp
@@ -43,6 +43,9 @@ ShareCooperationService::~ShareCooperationService()
 void ShareCooperationService::setBarrierType(BarrierType type)
 {
     _brrierType = type;
+
+    // terminate all current exit barrier when launchup
+    terminateAllBarriers();
 }
 
 void ShareCooperationService::setServerConfig(const DeviceInfoPointer selfDevice, const DeviceInfoPointer targetDevice)
@@ -240,6 +243,8 @@ void ShareCooperationService::stopBarrier()
     _expectedRunning = false;
 
     if (!barrierProcess()) {
+        // kill existed process.
+        terminateAllBarriers();
         return;
     }
 


### PR DESCRIPTION
If the main process exit by unkown reason, i.e crash or killed, the barrier process is running that cause cooperation did not stop. Kill them if process was recorded and app launchup in order to workaround this issue.

Log: Fix still control caused by barrier did not exit
Bug: https://pms.uniontech.com/bug-view-290819.html