### PR TITLE
fix: Fix it still continue cooperation even has been canceled

### DIFF
--- a/src/lib/cooperation/core/net/helper/sharehelper.cpp
+++ b/src/lib/cooperation/core/net/helper/sharehelper.cpp
@@ -473,6 +473,7 @@ void ShareHelper::handleCancelCooperApply()
         static QString body(tr("The other party has cancelled the connection request !"));
 #ifdef linux
         d->notifyMessage(body, {}, 3 * 1000);
+        d->notice->resetNotifyId();
 #else
         static QString title(tr("connect failed"));
         d->taskDialog()->switchInfomationPage(title, body);

--- a/src/lib/cooperation/core/net/linux/noticeutil.cpp
+++ b/src/lib/cooperation/core/net/linux/noticeutil.cpp
@@ -56,3 +56,7 @@ void NoticeUtil::closeNotification()
     notifyIfc->call("CloseNotification", recvNotifyId);
 }
 
+void NoticeUtil::resetNotifyId()
+{
+    recvNotifyId = 0;
+}

--- a/src/lib/cooperation/core/net/linux/noticeutil.h
+++ b/src/lib/cooperation/core/net/linux/noticeutil.h
@@ -21,6 +21,7 @@ public:
 
     void notifyMessage(const QString &title, const QString &body, const QStringList &actions, QVariantMap hitMap, int expireTimeout);
     void closeNotification();
+    void resetNotifyId();
 
 Q_SIGNALS:
     void ActionInvoked(const QString &action);


### PR DESCRIPTION
After request has been canceled by remote target, reset the notify id, then ignore accept action.

Log: Fix it still continue cooperation even has been canceled.
Bug: https://pms.uniontech.com/bug-view-291005.html