### PR TITLE
fix: Fix file transfer was freezed

### DIFF
--- a/src/lib/common/httpweb/fileclient.h
+++ b/src/lib/common/httpweb/fileclient.h
@@ -38,6 +38,7 @@ private:
 
 
     std::shared_ptr<HTTPFileClient> _httpClient { nullptr };
+    std::thread _download_thread;
 
     std::string _token;
     std::string _savedir;

--- a/src/lib/common/manager/filesizecounter.cpp
+++ b/src/lib/common/manager/filesizecounter.cpp
@@ -53,9 +53,19 @@ void FileSizeCounter::countFilesInDir(const QString &path)
     }
 
     QDir dir(path);
-    QFileInfoList infoList = dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+    QFileInfoList infoList = dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System);
     foreach (const QFileInfo &info, infoList) {
-        if (info.isDir()) {
+        if (info.isSymLink()) {
+            // 处理符号链接
+            QFileInfo targetInfo(info.symLinkTarget());
+            if (targetInfo.exists()) {
+                if (targetInfo.isDir()) {
+                    countFilesInDir(targetInfo.filePath());
+                } else {
+                    _totalSize += targetInfo.size();
+                }
+            }
+        } else if (info.isDir()) {
             countFilesInDir(info.filePath()); // 递归遍历子目录
         } else {
             _totalSize += info.size(); // 统计文件大小

--- a/src/lib/common/manager/transferworker.cpp
+++ b/src/lib/common/manager/transferworker.cpp
@@ -222,9 +222,9 @@ void TransferWorker::doCalculateSpeed()
         _noDataCount++;
     }
 
-    double speed = (static_cast<double>(bytesize)) / (1024 * 1024); // 计算下载速度，单位为兆字节/秒
-    QString formattedSpeed = QString::number(speed, 'f', 2); // 格式化速度为保留两位小数的字符串
-    DLOG << "Transfer speed: " << formattedSpeed.toStdString() << " M/s";
+    // double speed = (static_cast<double>(bytesize)) / (1024 * 1024); // 计算下载速度，单位为兆字节/秒
+    // QString formattedSpeed = QString::number(speed, 'f', 2); // 格式化速度为保留两位小数的字符串
+    // DLOG << "Transfer speed: " << formattedSpeed.toStdString() << " M/s";
 
     QString path = QString::fromStdString(_status.path);
     emit notifyChanged(TRANS_FILE_SPEED, path, bytesize);

--- a/src/lib/common/session/protoclient.h
+++ b/src/lib/common/session/protoclient.h
@@ -59,7 +59,7 @@ private:
     std::string _connected_host = { "" };
     // heartbeat: ping <-> pong
     std::shared_ptr<Timer> _ping_timer { nullptr };
-    std::atomic<bool> _pong_received { false };
+    std::atomic<int> _nopong_count { 0 };
 };
 
 #endif // PROTOCLIENT_H

--- a/src/lib/common/session/protoendpoint.h
+++ b/src/lib/common/session/protoendpoint.h
@@ -12,7 +12,7 @@
 #include <iostream>
 
 // hearbeat timeout
-#define HEARTBEAT_INTERVAL 3
+#define HEARTBEAT_INTERVAL 2
 
 using CppServer::Asio::Timer;
 using RpcHandler = std::function<void(int32_t type, const std::string &response)>;

--- a/src/lib/common/session/protoserver.h
+++ b/src/lib/common/session/protoserver.h
@@ -45,7 +45,7 @@ private:
     // heartbeat: ping <-> pong
     std::shared_ptr<Timer> _ping_timer { nullptr };
     // <ip, pinged>
-    std::map<std::string, std::atomic<bool>> _ping_remotes;
+    std::map<std::string, std::atomic<int>> _ping_remotes;
 };
 
 #endif // PROTOSERVER_H

--- a/src/lib/cooperation/core/net/helper/transferhelper.cpp
+++ b/src/lib/cooperation/core/net/helper/transferhelper.cpp
@@ -403,7 +403,7 @@ void TransferHelper::onConnectStatusChanged(int result, const QString &msg, cons
 void TransferHelper::onTransChanged(int status, const QString &path, quint64 size)
 {
 #ifdef QT_DEBUG
-    DLOG << "status: " << status << " path=" << path.toStdString();
+    // DLOG << "status: " << status << " path=" << path.toStdString();
 #endif
     switch (status) {
     case TRANS_CANCELED:


### PR DESCRIPTION
1. Change heartbeat timeout by 3 times. 2.Organize file download logic and supplement exception handling to avoid stuck problems during the download process.

Log: Fix file transfer was freezed
Bug: https://pms.uniontech.com/bug-view-291073.html