### PR TITLE
fix: Workaround notification incorrect issue

### DIFF
--- a/src/lib/cooperation/core/net/helper/sharehelper.cpp
+++ b/src/lib/cooperation/core/net/helper/sharehelper.cpp
@@ -21,7 +21,7 @@
 #include <QStandardPaths>
 #include <QDir>
 
-#ifdef linux
+#ifdef __linux__
 #    include "base/reportlog/reportlogmanager.h"
 #endif
 
@@ -40,7 +40,7 @@ inline constexpr char NotifyAcceptAction[] { "accept" };
 inline constexpr char ConnectButtonId[] { "connect-button" };
 inline constexpr char DisconnectButtonId[] { "disconnect-button" };
 
-#ifdef linux
+#ifdef __linux__
 inline constexpr char Kconnect[] { "connect" };
 inline constexpr char Kdisconnect[] { "disconnect" };
 #else
@@ -127,7 +127,7 @@ void ShareHelperPrivate::onAppAttributeChanged(const QString &group, const QStri
 
 void ShareHelperPrivate::reportConnectionData()
 {
-#ifdef linux
+#ifdef __linux__
     if (!targetDeviceInfo)
         return;
 
@@ -338,7 +338,7 @@ void ShareHelper::notifyConnectRequest(const QString &info)
         d->recvServerPrint = infoList[2];
     }
 
-#ifdef linux
+#ifdef __linux__
     d->notifyMessage(body.arg(CommonUitls::elidedText(d->targetDevName, Qt::ElideMiddle, 15)), actions, 10 * 1000);
 #else
     CooperationUtil::instance()->activateWindow();
@@ -471,7 +471,7 @@ void ShareHelper::handleCancelCooperApply()
         if (d->isReplied)
             return;
         static QString body(tr("The other party has cancelled the connection request !"));
-#ifdef linux
+#ifdef __linux__
         d->notifyMessage(body, {}, 3 * 1000);
         d->notice->resetNotifyId();
 #else

--- a/src/lib/cooperation/core/net/helper/transferhelper.cpp
+++ b/src/lib/cooperation/core/net/helper/transferhelper.cpp
@@ -21,7 +21,7 @@
 #include <QProcess>
 #include <QRegularExpression>
 
-#ifdef linux
+#ifdef __linux__
 #    include "base/reportlog/reportlogmanager.h"
 #    include <QDBusInterface>
 #    include <QDBusReply>
@@ -46,7 +46,7 @@ inline constexpr char NotifyViewAction[] { "view" };
 using TransHistoryInfo = QMap<QString, QString>;
 Q_GLOBAL_STATIC(TransHistoryInfo, transHistory)
 
-#ifdef linux
+#ifdef __linux__
 inline constexpr char Khistory[] { "history" };
 inline constexpr char Ksend[] { "send" };
 #else
@@ -277,6 +277,7 @@ void TransferHelper::transferResult(bool result, const QString &msg)
         if (result)
             actions << NotifyViewAction << tr("View");
         d->notifyMessage(msg, actions, 3 * 1000);
+        d->notice->resetNotifyId();
         return;
     }
 #endif
@@ -364,20 +365,12 @@ void TransferHelper::notifyTransferRequest(const QString &nick, const QString &i
 #endif
 }
 
-void TransferHelper::notifyTransferResult(bool result, const QString &msg)
-{
-    QStringList actions;
-    if (result)
-        actions << NotifyViewAction << tr("View");
-
-    d->notifyMessage(msg, actions, 3 * 1000);
-}
-
 void TransferHelper::handleCancelTransferApply()
 {
     static QString body(tr("The other party has cancelled the transfer request !"));
 #ifdef __linux__
     d->notifyMessage(body, {}, 3 * 1000);
+    d->notice->resetNotifyId();
 #else
     d->transDialog()->showResultDialog(false, body);
 #endif

--- a/src/lib/cooperation/core/net/helper/transferhelper.h
+++ b/src/lib/cooperation/core/net/helper/transferhelper.h
@@ -60,7 +60,6 @@ public Q_SLOTS:
     void openFileLocation(const QString &path);
     void onActionTriggered(const QString &action);
     void notifyTransferRequest(const QString &nick, const QString &ip);
-    void notifyTransferResult(bool result, const QString &msg);
     void handleCancelTransferApply();
 
     // compat old protocol


### PR DESCRIPTION
On some OS version, it returns last id if not click the notification, reset the id in order to workaround it.

Log: Workaround notification incorrect issue.
Bug: https://pms.uniontech.com/bug-view-299345.html