### PR TITLE
fix: Fix CI build and tag v1.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-cooperation (1.0.9) unstable; urgency=medium
+
+  * v1.0.9 version update.
+  * fix: fix CI build issue.
+
+ -- re2zero <yangwu@uniontech.com>  Mon, 20 Jan 2025 17:30:43 +0800
+
 dde-cooperation (1.0.8) unstable; urgency=medium
 
   * v1.0.8 version update.

--- a/src/lib/cooperation/dfmplugin/CMakeLists.txt
+++ b/src/lib/cooperation/dfmplugin/CMakeLists.txt
@@ -32,8 +32,6 @@ FILE(GLOB PLUGIN_FILES
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
-find_package(dfm-base REQUIRED)
-find_package(dfm-framework REQUIRED)
 find_package(Dtk${DTK_VERSION_MAJOR} COMPONENTS Widget REQUIRED)
 
 add_library(${PROJECT_NAME}
@@ -54,8 +52,6 @@ target_link_libraries(${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Widgets
     Dtk${DTK_VERSION_MAJOR}::Widget
-    ${dfm-base_LIBRARIES}
-    ${dfm-framework_LIBRARIES}
 )
 
 #install library file


### PR DESCRIPTION
Remove unused depending dfm modules which block CI build.

Log: Fix CI build and v1.0.9 release.