### PR TITLE
fix: Fix notification do not update issue

### DIFF
--- a/src/lib/cooperation/core/net/helper/sharehelper.cpp
+++ b/src/lib/cooperation/core/net/helper/sharehelper.cpp
@@ -473,7 +473,6 @@ void ShareHelper::handleCancelCooperApply()
         static QString body(tr("The other party has cancelled the connection request !"));
 #ifdef __linux__
         d->notifyMessage(body, {}, 3 * 1000);
-        d->notice->resetNotifyId();
 #else
         static QString title(tr("connect failed"));
         d->taskDialog()->switchInfomationPage(title, body);

--- a/src/lib/cooperation/core/net/helper/transferhelper.cpp
+++ b/src/lib/cooperation/core/net/helper/transferhelper.cpp
@@ -112,10 +112,10 @@ void TransferHelperPrivate::reportTransferResult(bool result)
 #endif
 }
 
-void TransferHelperPrivate::notifyMessage(const QString &body, const QStringList &actions, int expireTimeout)
+void TransferHelperPrivate::notifyMessage(const QString &body, const QStringList &actions, int expireTimeout, const QVariantMap &hitMap)
 {
 #ifdef __linux__
-    notice->notifyMessage(tr("File transfer"), body, actions, QVariantMap(), expireTimeout);
+    notice->notifyMessage(tr("File transfer"), body, actions, hitMap, expireTimeout);
 #endif
 }
 
@@ -273,11 +273,12 @@ void TransferHelper::transferResult(bool result, const QString &msg)
 {
 #ifdef __linux__
     if (d->role != Server) {
+        d->notice->closeNotification(); // close previous progress notification
+
         QStringList actions;
         if (result)
             actions << NotifyViewAction << tr("View");
         d->notifyMessage(msg, actions, 3 * 1000);
-        d->notice->resetNotifyId();
         return;
     }
 #endif
@@ -296,7 +297,7 @@ void TransferHelper::updateProgress(int value, const QString &remainTime)
         QVariantMap hitMap { { "x-deepin-ShowInNotifyCenter", false } };
         QString msg(tr("File receiving %1% | Remaining time %2").arg(QString::number(value), remainTime));
 
-        d->notifyMessage(msg, actions, 15 * 1000);
+        d->notifyMessage(msg, actions, 15 * 1000, hitMap);
         return;
     }
 #endif
@@ -370,7 +371,6 @@ void TransferHelper::handleCancelTransferApply()
     static QString body(tr("The other party has cancelled the transfer request !"));
 #ifdef __linux__
     d->notifyMessage(body, {}, 3 * 1000);
-    d->notice->resetNotifyId();
 #else
     d->transDialog()->showResultDialog(false, body);
 #endif

--- a/src/lib/cooperation/core/net/helper/transferhelper_p.h
+++ b/src/lib/cooperation/core/net/helper/transferhelper_p.h
@@ -44,7 +44,7 @@ public:
     CooperationTransDialog *transDialog();
 
     void reportTransferResult(bool result);
-    void notifyMessage(const QString &body, const QStringList &actions, int expireTimeout);
+    void notifyMessage(const QString &body, const QStringList &actions, int expireTimeout, const QVariantMap &hitMap = QVariantMap());
     void initConnect();
 
 private:

--- a/src/lib/cooperation/core/net/linux/noticeutil.cpp
+++ b/src/lib/cooperation/core/net/linux/noticeutil.cpp
@@ -44,11 +44,13 @@ void NoticeUtil::onActionTriggered(uint replacesId, const QString &action)
 
 void NoticeUtil::notifyMessage(const QString &title, const QString &body, const QStringList &actions, QVariantMap hitMap, int expireTimeout)
 {
-    QDBusReply<uint> reply = notifyIfc->call(QString("Notify"), QString("dde-cooperation"), recvNotifyId,
+
+    uint notifyId = hitMap.empty() ? 0 : recvNotifyId;
+    QDBusReply<uint> reply = notifyIfc->call(QString("Notify"), QString("dde-cooperation"), notifyId,
                                              QString("dde-cooperation"), title, body,
                                              actions, hitMap, expireTimeout);
 
-    recvNotifyId = reply.isValid() ? reply.value() : recvNotifyId;
+    recvNotifyId = reply.value();
 }
 
 void NoticeUtil::closeNotification()

--- a/src/singleton/singleapplication.cpp
+++ b/src/singleton/singleapplication.cpp
@@ -18,7 +18,9 @@ SingleApplication::SingleApplication(int &argc, char **argv, int)
     : CrossApplication(argc, argv), localServer(new QLocalServer(this))
 {
     setOrganizationName("deepin");
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
     initConnect();
 }
 


### PR DESCRIPTION
Set id as 0 in order to show new notification, otherwise it will show last notification again by id.

Log: Fix notification do not update issue.
Bug: https://pms.uniontech.com/bug-view-299345.html