### PR TITLE
fix: Fix dialog does not show in center

### DIFF
--- a/src/lib/cooperation/core/net/helper/sharehelper.cpp
+++ b/src/lib/cooperation/core/net/helper/sharehelper.cpp
@@ -61,7 +61,7 @@ ShareHelperPrivate::ShareHelperPrivate(ShareHelper *qq)
 CooperationTaskDialog *ShareHelperPrivate::taskDialog()
 {
     if (!ctDialog) {
-        ctDialog = new CooperationTaskDialog(qApp->activeWindow());
+        ctDialog = new CooperationTaskDialog(CooperationUtil::instance()->mainWindowWidget());
         ctDialog->setModal(true);
     }
     return ctDialog;

--- a/src/lib/cooperation/core/net/helper/transferhelper.cpp
+++ b/src/lib/cooperation/core/net/helper/transferhelper.cpp
@@ -96,7 +96,7 @@ void TransferHelperPrivate::initConnect()
 CooperationTransDialog *TransferHelperPrivate::transDialog()
 {
     if (!dialog) {
-        dialog = new CooperationTransDialog(qApp->activeWindow());
+        dialog = new CooperationTransDialog(CooperationUtil::instance()->mainWindowWidget());
         dialog->setModal(true);
     }
 

--- a/src/lib/cooperation/core/utils/cooperationutil.cpp
+++ b/src/lib/cooperation/core/utils/cooperationutil.cpp
@@ -57,6 +57,20 @@ void CooperationUtil::mainWindow(QSharedPointer<MainWindow> window)
     d->window = window;
 }
 
+QWidget* CooperationUtil::mainWindowWidget()
+{
+    if (d->window) {
+       return d->window->window();
+    }
+    auto windowList = qApp->topLevelWidgets();
+    for (auto w : windowList) {
+        if (w->objectName() == "MainWindow") {
+            return w->window();
+        }
+    }
+    return nullptr;
+}
+
 void CooperationUtil::activateWindow()
 {
     if (d->window) {

--- a/src/lib/cooperation/core/utils/cooperationutil.h
+++ b/src/lib/cooperation/core/utils/cooperationutil.h
@@ -22,6 +22,7 @@ public:
     static CooperationUtil *instance();
 
     void mainWindow(QSharedPointer<MainWindow> window);
+    QWidget* mainWindowWidget();
 
     void activateWindow();
 


### PR DESCRIPTION
The dialog's parent is null, get from main windows and set into dialog.

Log: Fix dialog does not show in center.
Bug: https://pms.uniontech.com/bug-view-299545.html