### PR TITLE
fix: Fix incorrect default setting

### DIFF
--- a/src/configs/settings/settings.cpp
+++ b/src/configs/settings/settings.cpp
@@ -416,13 +416,13 @@ QVariant Settings::value(const QString &group, const QString &key, const QVarian
 {
     Q_D(const Settings);
 
-    QVariant value = d->writableData.values.value(group).value(key, QVariant::Invalid);
+    QVariant value = d->writableData.values.value(group).value(key, QVariant());
 
     if (value.isValid()) {
         return value;
     }
 
-    value = d->fallbackData.values.value(group).value(key, QVariant::Invalid);
+    value = d->fallbackData.values.value(group).value(key, QVariant());
 
     if (value.isValid()) {
         return value;

--- a/src/lib/cooperation/dfmplugin/configs/settings/settings.cpp
+++ b/src/lib/cooperation/dfmplugin/configs/settings/settings.cpp
@@ -416,13 +416,13 @@ QVariant Settings::value(const QString &group, const QString &key, const QVarian
 {
     Q_D(const Settings);
 
-    QVariant value = d->writableData.values.value(group).value(key, QVariant::Invalid);
+    QVariant value = d->writableData.values.value(group).value(key, QVariant());
 
     if (value.isValid()) {
         return value;
     }
 
-    value = d->fallbackData.values.value(group).value(key, QVariant::Invalid);
+    value = d->fallbackData.values.value(group).value(key, QVariant());
 
     if (value.isValid()) {
         return value;


### PR DESCRIPTION
The QVariant::Invalid is valid value 0 if set as default since Qt6, use QVariant() replace it.

Log: Fix incorrect default setting.
Bug: https://pms.uniontech.com/bug-view-303425.html