### PR TITLE
fix: Fix close dialog not show in center

### DIFF
--- a/src/lib/cooperation/core/gui/mainwindow.cpp
+++ b/src/lib/cooperation/core/gui/mainwindow.cpp
@@ -240,7 +240,7 @@ void MainWindow::showCloseDialog()
     if (option == "Exit")
         QApplication::quit();
 
-    CooperationDialog dlg;
+    CooperationDialog dlg(this);
 
     QVBoxLayout *layout = new QVBoxLayout();
     QCheckBox *op1 = new QCheckBox(tr("Minimise to system tray"));
@@ -283,6 +283,12 @@ void MainWindow::showCloseDialog()
     dlg.setLayout(layout);
     dlg.setFixedSize(400, 200);
 #endif
+
+    // get the center position of parent window and move to center
+    QRect parentRect = this->window()->frameGeometry();
+    QRect dialogRect = dlg.frameGeometry();
+    QPoint centerPoint = parentRect.center() - dialogRect.center();
+    dlg.move(centerPoint);
 
     int code = dlg.exec();
     if (code == QDialog::Accepted) {


### PR DESCRIPTION
Move the close dialog to parent's center.

Log: Fix close dialog not show in center.
Bug: https://pms.uniontech.com/bug-view-277885.html