### PR TITLE
fix: [win] Fix win build issue and package miss bonjour

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-cooperation (1.1.0) unstable; urgency=medium
+
+  * v1.1.0 version update.
+  * feat: refactoring code structure.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 24 Apr 2025 19:55:10 +0800
+
 dde-cooperation (1.0.12) unstable; urgency=medium
 
   * v1.0.12 version update.


### PR DESCRIPTION
Fix windows build issue and the data transfer install package miss the bonjour.

Log: Fix win build issue.

## Summary by Sourcery

Fix Windows build issues by updating the Qt root path and correcting a syntax error. Ensure the Bonjour64.msi file is included in both the build script and CI workflow for Windows.

Bug Fixes:
- Fix the Windows build issue by correcting the path for the Qt root directory in the build script.
- Correct a syntax error in the ShareCooperationService.cpp file by fixing the QStringList split function call.

Build:
- Update the build script to include the Bonjour64.msi file in the installer package for Windows.

CI:
- Modify the CI workflow for Windows to ensure the Bonjour64.msi file is included in the installer package.