### PR TITLE
chore: New v1.1.1 tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,15 @@ CMake*.json
 *.o
 *.--quiet
 
+# AI configuration files
+.roomodes
+.roo/
+.roo_temp/
+.roo_temp_$$/
+.cursor/
+memory-bank/
+.cursorrules
+
 # Modules
 modules/*
 !modules/CMakeLists.txt

--- a/3rdparty/asio/CMakeLists.txt
+++ b/3rdparty/asio/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Module library
 file(GLOB SOURCE_FILES "src/*.cpp")
-add_library(${PROJECT_NAME} ${SOURCE_FILES})
+add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES})
 if(MSVC)
   set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "${PEDANTIC_COMPILE_FLAGS}")
 else()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-cooperation (1.1.1) unstable; urgency=medium
+
+  * v1.1.1 version update.
+  * fix: Fix miss the dynamic library issue.
+
+ -- re2zero <yangwu@uniontech.com>  Fri, 25 Apr 2025 15:55:10 +0800
+
 dde-cooperation (1.1.0) unstable; urgency=medium
 
   * v1.1.0 version update.

--- a/src/infrastructure/logging/CMakeLists.txt
+++ b/src/infrastructure/logging/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 file(GLOB_RECURSE LIB_HEADER_FILES "include/*.h" "src/*.h")
 file(GLOB_RECURSE LIB_INLINE_FILES "include/*.inl" "src/*.inl")
 file(GLOB_RECURSE LIB_SOURCE_FILES "src/*.cpp")
-add_library(${PROJECT_NAME} ${LIB_HEADER_FILES} ${LIB_INLINE_FILES} ${LIB_SOURCE_FILES} ${MINIZIP_FILES})
+add_library(${PROJECT_NAME} STATIC ${LIB_HEADER_FILES} ${LIB_INLINE_FILES} ${LIB_SOURCE_FILES} ${MINIZIP_FILES})
 if(MSVC)
   # zlib
   target_include_directories(${PROJECT_NAME} PRIVATE "zlib/include")


### PR DESCRIPTION
fix: Fix miss the dynamic library issue.

 New v1.1.1 tag

## Summary by Sourcery

Modify library compilation to use static linking and prepare for v1.1.1 release

Bug Fixes:
- Resolve dynamic library linking issue by switching to static library compilation

Build:
- Update CMakeLists.txt files to explicitly use STATIC library type for Asio and logging libraries

Chores:
- Prepare for v1.1.1 tag release