### PR TITLE
fix: Fix open dir in notification issue

### DIFF
--- a/src/lib/cooperation/core/net/helper/transferhelper_p.h
+++ b/src/lib/cooperation/core/net/helper/transferhelper_p.h
@@ -46,6 +46,7 @@ public:
     void reportTransferResult(bool result);
     void notifyMessage(const QString &body, const QStringList &actions, int expireTimeout, const QVariantMap &hitMap = QVariantMap());
     void initConnect();
+    QVariantMap createViewFileHints(const QString &path);
 
 private:
     TransferHelper *q;

--- a/src/lib/cooperation/core/net/linux/noticeutil.cpp
+++ b/src/lib/cooperation/core/net/linux/noticeutil.cpp
@@ -45,7 +45,7 @@ void NoticeUtil::onActionTriggered(uint replacesId, const QString &action)
 void NoticeUtil::notifyMessage(const QString &title, const QString &body, const QStringList &actions, QVariantMap hitMap, int expireTimeout)
 {
 
-    uint notifyId = hitMap.empty() ? 0 : recvNotifyId;
+    uint notifyId = 0;
     QDBusReply<uint> reply = notifyIfc->call(QString("Notify"), QString("dde-cooperation"), notifyId,
                                              QString("dde-cooperation"), title, body,
                                              actions, hitMap, expireTimeout);


### PR DESCRIPTION
Add command into notification so that it do action to open dir.

Log: Fix open dir in notification issue.
Bug: https://pms.uniontech.com/bug-view-311639.html

## Summary by Sourcery

Bug Fixes:
- Fix the 'View' action in the file transfer completion notification not opening the destination directory.