### PR TITLE
fix: Fix the compatible communication issue

### DIFF
--- a/3rdparty/coost/src/so/tcp.cc
+++ b/3rdparty/coost/src/so/tcp.cc
@@ -336,7 +336,7 @@ void ServerImpl::loop() {
             continue;
         }
 
-//        const uint32 n = this->ref() - 1;
+        const uint32 n = this->ref() - 1; // must: refcount - 1 for the current coroutine
 //        DLOG << "server " << _ip << ':' << _port
 //             << " accept connection: " << co::addr2str(&_addr, _addrlen)
 //             << ", connfd: " << _connfd << ", conn num: " << n;


### PR DESCRIPTION
The core code was comment out that cause can not receive next message.

Log: Fix the compatible communication issue.
Bug: https://pms.uniontech.com/bug-view-314957.html

## Summary by Sourcery

Bug Fixes:
- Uncomment the calculation for active connections/references in the TCP server loop to resolve an issue preventing subsequent message reception.