### PR TITLE
fix: Fix crash issue if network disconnected.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ CMakeLists.txt.user
 CMake*.json
 *.o
 *.--quiet
+.cache/
 
 # AI configuration files
 .roomodes

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-cooperation (1.1.2) unstable; urgency=medium
+
+  * v1.1.2 version update.
+  * fix: Fix crash issue after network change.
+
+ -- re2zero <yangwu@uniontech.com>  Tue, 29 Apr 2025 19:21:18 +0800
+
 dde-cooperation (1.1.1) unstable; urgency=medium
 
   * v1.1.1 version update.

--- a/src/lib/cooperation/core/gui/widgets/deviceitem.cpp
+++ b/src/lib/cooperation/core/gui/widgets/deviceitem.cpp
@@ -90,6 +90,8 @@ DeviceItem::DeviceItem(QWidget *parent)
 
 DeviceItem::~DeviceItem()
 {
+    devInfo.reset();
+    disconnect(btnBoxWidget, &ButtonBoxWidget::buttonClicked, this, &DeviceItem::onButtonClicked);
 }
 
 void DeviceItem::setDeviceInfo(const DeviceInfoPointer info)
@@ -212,6 +214,10 @@ void DeviceItem::setOperations(const QList<Operation> &operations)
 
 void DeviceItem::updateOperations()
 {
+    // this device item may be not visible after it's been removed from the list, e.g. network disconnected.
+    if (!isVisible())
+        return;
+
     auto iter = indexOperaMap.begin();
     for (; iter != indexOperaMap.end(); ++iter) {
         if (!iter.value().visibleCb)


### PR DESCRIPTION
When device item update after network disconnected, it crashed.

Log: Fix crash issue if network disconnected.
Bug: https://pms.uniontech.com/bug-view-311269.html

## Summary by Sourcery

Prevent crash in DeviceItem when network disconnects during operation update.

Bug Fixes:
- Avoid updating operations on a DeviceItem if it is no longer visible, such as after network disconnection.
- Ensure proper resource cleanup in the DeviceItem destructor.