### PR TITLE
chore: [tag] New tag v1.1.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-cooperation (1.1.3) unstable; urgency=medium
+
+  * v1.1.3 version update.
+  * fix: Fix start avahi service failed issue.
+
+ -- re2zero <yangwu@uniontech.com>  Mon, 19 May 2025 19:20:35 +0800
+
 dde-cooperation (1.1.2) unstable; urgency=medium
 
   * v1.1.2 version update.

--- a/src/lib/cooperation/core/discover/discovercontroller.cpp
+++ b/src/lib/cooperation/core/discover/discovercontroller.cpp
@@ -165,7 +165,7 @@ bool DiscoverController::openZeroConfDaemonDailog()
 
     int code = dlg.exec();
     if (code == 0)
-        QProcess::startDetached("systemctl start avahi-daemon.service");
+        QProcess::startDetached("systemctl", QStringList() << "start" << "avahi-daemon.service");
     return true;
 #else
     int choice = QMessageBox::warning(nullptr, tr("Please click to confirm to enable the LAN discovery service!"),


### PR DESCRIPTION
Fix start avahi service failed issue and v1.1.3 release.

Log: v1.1.3 release.

## Summary by Sourcery

Tag a new release v1.1.3 and resolve the issue where starting the avahi-daemon service failed

Bug Fixes:
- Adjust QProcess::startDetached call to pass arguments separately when starting avahi-daemon.service

Chores:
- Add v1.1.3 entry to the Debian changelog and bump the release tag