### PR TITLE
fix: Improve device item handling and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ CMake*.json
 .cursor/
 memory-bank/
 .cursorrules
+.cursorindexingignore
+.specstory/
 
 # Modules
 modules/*

--- a/src/lib/cooperation/core/gui/widgets/deviceitem.h
+++ b/src/lib/cooperation/core/gui/widgets/deviceitem.h
@@ -12,6 +12,7 @@
 
 #include <QIcon>
 #include <QMap>
+#include <atomic>
 
 namespace cooperation_core {
 
@@ -59,6 +60,9 @@ public:
     void setOperations(const QList<Operation> &operations);
     void updateOperations();
 
+    // Check if the object is still alive
+    bool isAlive() const { return !isDestroyed.load(std::memory_order_acquire); }
+
 public Q_SLOTS:
     void onButtonClicked(int index);
 
@@ -83,6 +87,9 @@ private:
 
     QMap<int, Operation> indexOperaMap;
     DeviceInfoPointer devInfo;
+
+    // Atomic flag to mark if the object has been destroyed
+    std::atomic<bool> isDestroyed { false };
 };
 
 }   // namespace cooperation_core

--- a/src/lib/cooperation/core/gui/widgets/devicelistwidget.cpp
+++ b/src/lib/cooperation/core/gui/widgets/devicelistwidget.cpp
@@ -94,6 +94,11 @@ void DeviceListWidget::insertItem(int index, const DeviceInfoPointer info)
 
 void DeviceListWidget::updateItem(int index, const DeviceInfoPointer info)
 {
+    if (!info || index < 0 || index >= mainLayout->count()) {
+        WLOG << "Invalid index or info, index: " << index;
+        return;
+    }
+
     QLayoutItem *item = mainLayout->itemAt(index);
     DeviceItem *devItem = qobject_cast<DeviceItem *>(item->widget());
     if (!devItem) {

--- a/src/lib/cooperation/core/share/sharecooperationservice.cpp
+++ b/src/lib/cooperation/core/share/sharecooperationservice.cpp
@@ -149,7 +149,7 @@ void ShareCooperationService::terminateAllBarriers()
     // Windows
     QProcess process;
     process.start("tasklist");
-    process.waitForFinished();
+    process.waitForFinished(200);
 
     QString output = process.readAllStandardOutput();
     QStringList processList = output.split('\n', SKIP_EMPTY_PARTS);
@@ -168,7 +168,7 @@ void ShareCooperationService::terminateAllBarriers()
     // Linux
     QProcess process;
     process.start("pgrep", QStringList() << "barrier");
-    process.waitForFinished();
+    process.waitForFinished(200);
 
     QString output = process.readAllStandardOutput();
 


### PR DESCRIPTION
- Added atomic flag to track if DeviceItem is destroyed to prevent operations on invalid objects.
- Updated logging messages for better clarity during device item operations.
- Enhanced input validation in DeviceListWidget to handle invalid indices or null device info.
- Adjusted wait time for process termination in ShareCooperationService to ensure proper execution.

Log: Improve device item handling and logging.
Bug: https://pms.uniontech.com/bug-view-311269.html

## Summary by Sourcery

Enhance device item lifecycle handling and logging, add validation in the device list widget, and ensure timely process termination in sharing service.

Bug Fixes:
- Prevent operations on destroyed DeviceItem by introducing an isAlive check.
- Avoid invalid widget access in DeviceListWidget by validating indices and device info.

Enhancements:
- Introduce an atomic destruction flag in DeviceItem to track lifecycle.
- Improve logging messages in DeviceItem and DeviceListWidget for clearer diagnostics.
- Add a 200ms timeout to process.waitForFinished calls in ShareCooperationService.