### PR TITLE
fix: Enhance device discovery and history management

### DIFF
--- a/src/lib/cooperation/core/discover/discovercontroller.cpp
+++ b/src/lib/cooperation/core/discover/discovercontroller.cpp
@@ -38,20 +38,78 @@ DiscoverController::~DiscoverController()
 void DiscoverController::init()
 {
     DLOG << "Initializing discovery controller";
+
+    // Connect signals immediately, not dependent on avahi service status
+    initConnect();
+
+    // Always create ZeroConf object regardless of service status
+    initZeroConf();
+
     if (isZeroConfDaemonActive()) {
-        initZeroConf();
+        // Service is running, start publishing and discovery immediately
+        DLOG << "Avahi service is active, starting discovery";
+        updatePublish();
+        // Delay a bit to let service fully start
+        QTimer::singleShot(1000, this, [this]() {
+            startDiscover();
+        });
         return;
     }
 
-    openZeroConfDaemonDailog();
-    QTimer *timer = new QTimer(this);
-    connect(timer, &QTimer::timeout, this, [timer, this] {
+    // Service not running, try to start it and wait
+    DLOG << "Avahi service not active, attempting to start service";
+
+    if (!openZeroConfDaemonDailog()) {
+        // User refused to start service or platform not supported
+        DLOG << "User refused or platform not supported, starting compatibility mode only";
+        // Still start discovery for compatibility mode
+        QTimer::singleShot(1000, this, [this]() {
+            startDiscover();
+        });
+        return;
+    }
+
+    // Wait for service to become available with unified timeout
+    startServiceWaitLoop();
+}
+
+void DiscoverController::startServiceWaitLoop()
+{
+    QTimer *serviceTimer = new QTimer(this);
+    int retryCount = 0;
+    const int maxRetries = 5; // 5 retries with 2 second intervals = 10 seconds total
+
+    connect(serviceTimer, &QTimer::timeout, this, [serviceTimer, retryCount, maxRetries, this]() mutable {
+        retryCount++;
+
         if (isZeroConfDaemonActive()) {
-            initZeroConf();
-            timer->stop();
+            serviceTimer->stop();
+            DLOG << "Avahi service became active after" << retryCount << "retries";
+            
+            // Start browser when service becomes available
+            if (!d->zeroConf->browserExists()) {
+                DLOG << "Starting ZeroConf browser";
+                d->zeroConf->startBrowser(UNI_CHANNEL);
+            }
+            
+            // Update publishing when service becomes available
+            updatePublish();
+            // Start discovery
+            QTimer::singleShot(500, this, [this]() {
+                startDiscover();
+            });
+            return;
+        }
+
+        if (retryCount >= maxRetries) {
+            serviceTimer->stop();
+            WLOG << "Avahi service startup timeout after" << maxRetries << "retries";
+            // Start discovery anyway for compatibility mode
+            startDiscover();
         }
     });
-    timer->start(5000);
+
+    serviceTimer->start(2000); // Check every 2 seconds
 }
 
 void DiscoverController::initZeroConf()
@@ -60,16 +118,40 @@ void DiscoverController::initZeroConf()
     d->zeroConf = new QZeroConf();
     d->zeroconfname = QSysInfo::machineUniqueId();
 
-    // publish();
-    initConnect();
-    // connect signal should before  browser
-    if (!d->zeroConf->browserExists())
+    // Connect ZeroConf signals
+    connectZeroConfSignals();
+
+    // Only start browser when avahi service is active
+    if (isZeroConfDaemonActive() && !d->zeroConf->browserExists()) {
+        DLOG << "Starting ZeroConf browser";
         d->zeroConf->startBrowser(UNI_CHANNEL);
+    }
+}
+
+void DiscoverController::connectZeroConfSignals()
+{
+    if (!d->zeroConf) {
+        WLOG << "Cannot connect ZeroConf signals - ZeroConf not initialized";
+        return;
+    }
+
+    connect(d->zeroConf, &QZeroConf::serviceAdded, this, &DiscoverController::addService);
+    connect(d->zeroConf, &QZeroConf::serviceRemoved, this, &DiscoverController::removeService);
+    connect(d->zeroConf, &QZeroConf::serviceUpdated, this, &DiscoverController::updateService);
 }
 
 void DiscoverController::initConnect()
 {
     DLOG << "Setting up discovery controller connections";
+
+    // Ensure signals are connected only once, avoid duplicate connections
+    static bool connected = false;
+    if (connected) {
+        DLOG << "Signals already connected, skipping";
+        return;
+    }
+    connected = true;
+
     connect(CooperationUtil::instance(), &CooperationUtil::onlineStateChanged, this, [this](const QString &validIP) {
         if (validIP.isEmpty())
             return;
@@ -80,9 +162,9 @@ void DiscoverController::initConnect()
     connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, &DiscoverController::onDConfigValueChanged);
 #endif
     connect(ConfigManager::instance(), &ConfigManager::appAttributeChanged, this, &DiscoverController::onAppAttributeChanged);
-    connect(d->zeroConf, &QZeroConf::serviceAdded, this, &DiscoverController::addService);
-    connect(d->zeroConf, &QZeroConf::serviceRemoved, this, &DiscoverController::removeService);
-    connect(d->zeroConf, &QZeroConf::serviceUpdated, this, &DiscoverController::updateService);
+
+    // ZeroConf related connections need to be established after ZeroConf initialization
+    // These connections will be established when needed through connectZeroConfSignals() method
 }
 
 bool DiscoverController::isVaildDevice(const DeviceInfoPointer info)
@@ -167,17 +249,18 @@ bool DiscoverController::openZeroConfDaemonDailog()
     dlg.setMessage(tr("Unable to discover and be discovered by other devices when LAN discovery service is not turned on"));
 
     int code = dlg.exec();
-    if (code == 0)
+    if (code == 0) {
         QProcess::startDetached("systemctl", QStringList() << "start" << "avahi-daemon.service");
-    return true;
+        return true;
+    }
 #else
     int choice = QMessageBox::warning(nullptr, tr("Please click to confirm to enable the LAN discovery service!"),
                                       tr("Unable to discover and be discovered by other devices when LAN discovery service is not turned on"
                                          "Right click on Windows Start menu ->Computer Management ->Services and Applications ->Services to enable Bonjour service"),
                                       QMessageBox::Ok);
     QDesktopServices::openUrl(QUrl("services.msc"));
-    return false;
 #endif
+    return false;
 }
 
 bool DiscoverController::isZeroConfDaemonActive()
@@ -316,14 +399,21 @@ void DiscoverController::removeService(QZeroConfService zcs)
 void DiscoverController::updateHistoryDevices(const QMap<QString, QString> &connectMap)
 {
     _historyDevices.clear();
+    d->historyDeviceMap.clear(); // Store complete history device info
+
     QList<DeviceInfoPointer> offlineDevList;
     auto iter = connectMap.begin();
     for (; iter != connectMap.end(); ++iter) {
-        _historyDevices.append(iter.key());
-        if (findDeviceByIP(iter.key()))
+        QString ip = iter.key();
+        QString deviceName = iter.value();
+
+        _historyDevices.append(ip);
+        d->historyDeviceMap[ip] = deviceName; // Store complete info
+
+        if (findDeviceByIP(ip))
             continue;
 
-        DeviceInfoPointer info(new DeviceInfo(iter.key(), iter.value()));
+        DeviceInfoPointer info(new DeviceInfo(ip, deviceName));
         info->setConnectStatus(DeviceInfo::Offline);
         offlineDevList << info;
     }
@@ -341,10 +431,9 @@ DiscoverController *DiscoverController::instance()
 void DiscoverController::publish()
 {
     DLOG << "Publishing device info via ZeroConf";
-    d->zeroConf->clearServiceTxtRecords();
 
     QVariantMap deviceInfo = CooperationUtil::deviceInfo();
-    //设置为局域网不发现
+    // Set to not discoverable on LAN
     if (deviceInfo.value(AppSettings::DiscoveryModeKey) == 1) {
         unpublish();
         return;
@@ -354,20 +443,33 @@ void DiscoverController::publish()
     d->ipfilter = selfIP.lastIndexOf(".") != -1 ? selfIP.left(selfIP.lastIndexOf(".")) : "";
 
     LOG << "publish " << d->zeroconfname.toStdString() << " on: " << selfIP.toStdString();
-    for (const auto &key : deviceInfo.keys())
-        d->zeroConf->addServiceTxtRecord(key, deviceInfo.value(key).toString().toUtf8().toBase64());
 
-    d->zeroConf->startServicePublish(d->zeroconfname.toUtf8(), UNI_CHANNEL, "local", UNI_RPC_PORT_UDP);
-
+    // Always emit compatibility mode info (UDP multicast discovery)
     auto doc = QJsonDocument::fromVariant(deviceInfo);
     Q_EMIT registCompatAppInfo(true, doc.toJson());
+    
+    // Only publish via avahi if service is available
+    if (isZeroConfDaemonActive() && d->zeroConf) {
+        d->zeroConf->clearServiceTxtRecords();
+        for (const auto &key : deviceInfo.keys())
+            d->zeroConf->addServiceTxtRecord(key, deviceInfo.value(key).toString().toUtf8().toBase64());
+        d->zeroConf->startServicePublish(d->zeroconfname.toUtf8(), UNI_CHANNEL, "local", UNI_RPC_PORT_UDP);
+    } else {
+        DLOG << "Avahi service not available, skipping ZeroConf publishing";
+    }
 }
 
 void DiscoverController::unpublish()
 {
     DLOG << "Stopping ZeroConf service publishing";
-    d->zeroConf->stopServicePublish();
+
+    // Always stop compatibility mode (UDP multicast discovery)
     Q_EMIT registCompatAppInfo(false, "");
+
+    // Only stop avahi publishing if service is available and object exists
+    if (d->zeroConf && isZeroConfDaemonActive()) {
+        d->zeroConf->stopServicePublish();
+    }
 }
 
 void DiscoverController::updatePublish()
@@ -386,29 +488,135 @@ void DiscoverController::refresh()
 {
     if (!d->zeroConf) {
         WLOG << "Cannot refresh - ZeroConf not initialized";
+        finishDiscoveryWithError("ZeroConf not initialized for refresh");
         return;
     }
 
     DLOG << "Refreshing discovered devices list";
+
+    // Clear current list and collect new devices
+    refreshDeviceList();
+
+    // Notify results
+    finishDiscovery();
+}
+
+void DiscoverController::refreshDeviceList()
+{
+    // Preserve current online/connected history devices before clearing
+    QList<DeviceInfoPointer> preservedHistoryDevices;
+    for (const auto &device : d->onlineDeviceList) {
+        if (_historyDevices.contains(device->ipAddress()) && 
+            device->connectStatus() != DeviceInfo::Offline) {
+            preservedHistoryDevices.append(device);
+            DLOG << "Preserving online history device:" << device->ipAddress().toStdString();
+        }
+    }
+
     d->onlineDeviceList.clear();
+
+    // Collect devices from different sources
+    collectAvahiDevices();
+    addPreservedHistoryDevices(preservedHistoryDevices);
+    collectOfflineHistoryDevices();
+    addSearchDeviceIfExists();
+}
+
+void DiscoverController::addPreservedHistoryDevices(const QList<DeviceInfoPointer> &preservedDevices)
+{
+    for (const auto &device : preservedDevices) {
+        // Check if device was found by avahi (might have updated status)
+        auto existingDevice = findDeviceByIP(device->ipAddress());
+        if (!existingDevice) {
+            // Device not found by avahi, keep its previous status
+            d->onlineDeviceList.append(device);
+            DLOG << "Re-added preserved history device:" << device->ipAddress().toStdString();
+        } else {
+            DLOG << "History device found by avahi, using avahi info:" << device->ipAddress().toStdString();
+        }
+    }
+}
+
+void DiscoverController::collectOfflineHistoryDevices()
+{
+    DLOG << "Collecting offline history devices, count:" << _historyDevices.size();
+
+    // Add offline history devices that are not already in the list
+    for (const QString &historyIP : _historyDevices) {
+        if (findDeviceByIP(historyIP)) {
+            DLOG << "History device already in list:" << historyIP.toStdString();
+            continue; // Already in list (from avahi, search, or preserved)
+        }
+
+        // Get complete device info from stored map
+        QString deviceName = d->historyDeviceMap.value(historyIP, "Unknown Device");
+        DeviceInfoPointer historyDevice(new DeviceInfo(historyIP, deviceName));
+        historyDevice->setConnectStatus(DeviceInfo::Offline);
+        d->onlineDeviceList.append(historyDevice);
+        DLOG << "Added offline history device:" << historyIP.toStdString() << "name:" << deviceName.toStdString();
+    }
+}
+
+void DiscoverController::collectAvahiDevices()
+{
+    // Check if avahi service is available for actual discovery
+    if (!isZeroConfDaemonActive()) {
+        DLOG << "Avahi service not active, skipping avahi device discovery";
+        return;
+    }
+
     auto allServices = d->zeroConf->getServices();
+    DLOG << "Found" << allServices.size() << "avahi services";
 
     for (const auto &key : allServices.keys()) {
         QZeroConfService zcs = allServices.value(key);
         auto devInfo = parseDeviceService(zcs);
 
-        if (devInfo && devInfo->ipAddress() != CooperationUtil::localIPAddress()) {
-            if (_connectedDevice == devInfo->ipAddress()) {
-                devInfo->setConnectStatus(DeviceInfo::Connected);
-            }
-            d->onlineDeviceList.append(devInfo);
+        if (!devInfo || devInfo->ipAddress() == CooperationUtil::localIPAddress()) {
+            continue;
         }
-    }
-    if (d->searchDevice)
-        d->onlineDeviceList.append(d->searchDevice);
 
+        // Check if device already exists and merge status
+        auto existingDevice = findDeviceByIP(devInfo->ipAddress());
+        if (existingDevice) {
+            // Update existing device with latest avahi info
+            existingDevice->setConnectStatus(devInfo->connectStatus());
+            DLOG << "Updated existing device:" << devInfo->ipAddress().toStdString();
+            continue;
+        }
+
+        // Update connection status for known connected device
+        if (_connectedDevice == devInfo->ipAddress()) {
+            devInfo->setConnectStatus(DeviceInfo::Connected);
+        }
+
+        d->onlineDeviceList.append(devInfo);
+        DLOG << "Added avahi device:" << devInfo->ipAddress().toStdString();
+    }
+}
+
+void DiscoverController::addSearchDeviceIfExists()
+{
+    if (!d->searchDevice) {
+        return;
+    }
+
+    // Check if search device is already in the list
+    auto existingDevice = findDeviceByIP(d->searchDevice->ipAddress());
+    if (existingDevice) {
+        DLOG << "Search device already exists in list, skipping";
+        return;
+    }
+
+    DLOG << "Adding search device to list:" << d->searchDevice->ipAddress().toStdString();
+    d->onlineDeviceList.append(d->searchDevice);
+}
+
+void DiscoverController::finishDiscovery()
+{
     Q_EMIT deviceOnline({ d->onlineDeviceList });
     bool hasFound = !d->onlineDeviceList.isEmpty();
+    DLOG << "Discovery finished, found" << d->onlineDeviceList.size() << "devices";
     Q_EMIT discoveryFinished(hasFound);
 }
 
@@ -417,7 +625,7 @@ void DiscoverController::addSearchDeivce(const QString &info)
     DLOG << "Adding device from search result";
     auto devInfo = parseDeviceJson(info);
     if (!devInfo) {
-        Q_EMIT discoveryFinished(false);
+        finishDiscoveryWithError("Failed to parse search device info");
         return;
     }
     d->searchDevice = devInfo;
@@ -438,7 +646,7 @@ void DiscoverController::compatAddDeivces(StringMap infoMap)
             continue;
         }
 
-        // 解析 combinedIP
+        // Parse combinedIP
         QString combinedIP = it.value();
         QStringList ipList = combinedIP.split(", ");
         if (ipList.size() != 2) {
@@ -479,15 +687,23 @@ void DiscoverController::startDiscover()
 {
     if (!d->zeroConf) {
         WLOG << "Cannot start discovery - ZeroConf not initialized";
+        finishDiscoveryWithError("ZeroConf not initialized");
         return;
     }
 
     DLOG << "Starting device discovery";
-    // 延迟,为了展示发现界面
+
+    // Delay to show discovery interface
     QTimer::singleShot(500, [this]() {
         // clear current list first.
         refresh();
         // compation: start get nodes
         Q_EMIT startDiscoveryDevice();
     });
+}
+
+void DiscoverController::finishDiscoveryWithError(const QString &errorMsg)
+{
+    WLOG << "Discovery failed:" << errorMsg.toStdString();
+    Q_EMIT discoveryFinished(false);
 }

--- a/src/lib/cooperation/core/discover/discovercontroller.h
+++ b/src/lib/cooperation/core/discover/discovercontroller.h
@@ -69,6 +69,15 @@ private:
 
     void initZeroConf();
     void initConnect();
+    void connectZeroConfSignals();
+    void startServiceWaitLoop();
+    void collectAvahiDevices();
+    void collectOfflineHistoryDevices();
+    void addPreservedHistoryDevices(const QList<DeviceInfoPointer> &preservedDevices);
+    void addSearchDeviceIfExists();
+    void refreshDeviceList();
+    void finishDiscovery();
+    void finishDiscoveryWithError(const QString &errorMsg);
     bool isVaildDevice(const DeviceInfoPointer info);
     DeviceInfoPointer parseDeviceJson(const QString &info);
     DeviceInfoPointer parseDeviceService(QZeroConfService zcs);

--- a/src/lib/cooperation/core/discover/discovercontroller_p.h
+++ b/src/lib/cooperation/core/discover/discovercontroller_p.h
@@ -26,6 +26,8 @@ private:
     QString ipfilter;
     //发现服务名，需要为局域网唯一
     QString zeroconfname;
+    // Store complete history device info (IP -> DeviceName)
+    QMap<QString, QString> historyDeviceMap;
 };
 
 }   // namespace cooperation_core


### PR DESCRIPTION
- Introduced a new QMap to store complete history device information (IP -> DeviceName).
- Improved the initialization process for ZeroConf, ensuring signals are connected immediately.
- Added a service wait loop to handle Avahi service startup with retries.
- Enhanced device list refreshing to preserve online history devices.
- Implemented error handling for discovery failures with appropriate logging.

Log: Enhance device discovery and history management.
Bug: https://pms.uniontech.com/bug-view-317267.html

## Summary by Sourcery

Enhance the device discovery workflow by storing full history information, handling Avahi daemon startup with retries, preserving history devices during refresh, and improving conditional publishing and error reporting.

New Features:
- Add a retry loop to wait for Avahi daemon startup before enabling full discovery
- Persist complete history of discovered devices (IP→name) to restore offline and online history devices
- Always emit compatibility‐mode discovery data while optionally publishing via Avahi when available
- Introduce structured error handling callbacks to report discovery failures with logs

Enhancements:
- Refactor initialization to connect ZeroConf signals immediately and avoid duplicate connections
- Extract discovery steps into dedicated methods for clearer refresh, preservation, and collection logic
- Conditionally perform Avahi service publication and unpublication based on daemon availability
- Improve logging throughout discovery, publishing, and refresh processes