### PR TITLE
chore: Bump version to 1.1.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-cooperation (1.1.4) unstable; urgency=medium
+
+  * update New version 1.1.4 
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 12 Jun 2025 17:36:06 +0800
+
 dde-cooperation (1.1.3) unstable; urgency=medium
 
   * v1.1.3 version update.


### PR DESCRIPTION
Bump version to 1.1.4

Log: Bump version to 1.1.4

## Summary by Sourcery

Chores:
- Update Debian changelog version to 1.1.4