### PR TITLE
chore: New  1.1.4 tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-cooperation (1.1.4) unstable; urgency=medium
+
+  * v1.1.4 version update.
+  * feat: Add NAT IP mapping solution.
+  * fix: Enhance wallpaper setting functionality.
+  * fix: Fix some issues.
+  * more logs.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 12 Jun 2025 18:55:00 +0800
+
 dde-cooperation (1.1.3) unstable; urgency=medium
 
   * v1.1.3 version update.


### PR DESCRIPTION
Update changelog for version 1.1.4 with new features and fixes.

 Log: New v1.1.4 tag.

## Summary by Sourcery

Document and tag the 1.1.4 release by updating the Debian changelog entry.

Chores:
- Update Debian changelog with version 1.1.4 entry and release notes
- Add new v1.1.4 tag entry to changelog