### PR TITLE
chore: New 1.1.5 tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-cooperation (1.1.5) unstable; urgency=medium
+
+  * v1.1.5 version update.
+  * fix: Introduce IPC name generation for service management.
+  * fix: Fix coredump.
+
+ -- re2zero <yangwu@uniontech.com>  Wed, 18 Jun 2025 11:49:02 +0800
+
 dde-cooperation (1.1.4) unstable; urgency=medium
 
   * v1.1.4 version update.


### PR DESCRIPTION
Update changelog for version 1.1.5 with new features and fixes.

 Log: New v1.1.5 tag.

## Summary by Sourcery

Chores:
- Update Debian changelog to document the v1.1.5 release tag