### PR TITLE
chore: New 1.1.6 tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-cooperation (1.1.6) unstable; urgency=medium
+
+  * v1.1.6 version update.
+  * fix: Handle network errors.
+  * chore: Update dman's resources.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 19 Jun 2025 20:13:15 +0800
+
 dde-cooperation (1.1.5) unstable; urgency=medium
 
   * v1.1.5 version update.


### PR DESCRIPTION
Update changelog for version 1.1.6.

 Log: New v1.1.6 tag.

## Summary by Sourcery

Update the changelog for version 1.1.6 and tag the new release.

Documentation:
- Update changelog with release notes for version 1.1.6

Chores:
- Add new v1.1.6 tag