### PR TITLE
fix: [setting] Filter file paths to limit depth to two directories

### DIFF
--- a/src/plugins/data-transfer/core/utils/settinghepler.cpp
+++ b/src/plugins/data-transfer/core/utils/settinghepler.cpp
@@ -258,8 +258,21 @@ bool SettingHelper::setFile(QJsonObject jsonObj, QString filepath)
         const QJsonArray &userFileArray = userFileValue.toArray();
         for (const auto &value : userFileArray) {
             QString filename = value.toString();
+            
+            // 过滤路径深度，确保不超过二级目录 /xx/xx
+            QStringList pathParts = filename.split('/', QString::SkipEmptyParts);
+            if (pathParts.size() > 2) {
+                // 只保留最后的二级目录及文件名
+                pathParts = pathParts.mid(pathParts.size() - 2);
+                filename = "/" + pathParts.join("/");
+            }
+            
             QString targetFile = QDir::homePath() + "/" + filename;
-            QString file = filepath + filename.mid(filename.indexOf('/'));
+            
+            // 只保留文件名部分 /filename
+            int lastSlash = filename.lastIndexOf('/');
+            QString file = filepath + filename.mid(lastSlash);
+            
             QFileInfo info = QFileInfo(targetFile);
             auto dir = info.dir();
             if (!dir.exists())


### PR DESCRIPTION
Implement a check in the setFile function to ensure that file paths do not exceed two directory levels. This change modifies the filename to retain only the last two directories and the file name itself, enhancing path management.

Log: Filter file paths to limit depth to two directories.

## Summary by Sourcery

Filter file paths in setFile to limit depth to two directories and adjust how the target file path is constructed

Bug Fixes:
- Trim file paths exceeding two directory levels to only the last two path segments and file name
- Construct the target file path by appending only the final file name segment