### PR TITLE
chore: more logs for datatransfer

### DIFF
--- a/src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp
+++ b/src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp
@@ -53,23 +53,27 @@ void UnzipWorker::run()
 
 int UnzipWorker::getNumFiles(QString filepath)
 {
+    LOG << "UnzipWorker::getNumFiles started with file:" << filepath.toStdString();
     const char *zipFilePath = filepath.toLocal8Bit().constData();
     struct zip *archive = zip_open(zipFilePath, 0, NULL);
 
     if (archive) {
         int fileCount = zip_get_num_files(archive);
         LOG << "Number of files in ZIP file:" << fileCount;
+        DLOG << "Successfully opened ZIP file and got file count:" << fileCount;
 
         zip_close(archive);
         return fileCount;
     } else {
         LOG << "Unable to open ZIP file";
+        DLOG << "Failed to open ZIP file:" << filepath.toStdString();
         return 0;
     }
 }
 
 bool UnzipWorker::isValid(QString filepath)
 {
+    LOG << "UnzipWorker::isValid started with file:" << filepath.toStdString();
     const char *zipFilePath = filepath.toLocal8Bit().constData();
     struct zip *z = zip_open(zipFilePath, 0, nullptr);
 
@@ -108,12 +112,13 @@ bool UnzipWorker::isValid(QString filepath)
     zip_close(z);
     bool res = TransferUtil::checkSize(tempfile);
     QFile::remove(tempfile);
+    LOG << "UnzipWorker::isValid validation result:" << res;
     return res;
 }
 
 bool UnzipWorker::extract()
 {
-
+    LOG << "UnzipWorker::extract started with file:" << filepath.toStdString();
     QStringList arguments;
     arguments << "-O"
               << "utf-8"
@@ -150,11 +155,13 @@ bool UnzipWorker::extract()
     if (process.exitCode() != 0)
         LOG << "Error message:" << process.errorString().toStdString();
     process.waitForFinished();
+    LOG << "UnzipWorker::extract extraction result:" << process.exitCode();
     return true;
 }
 
 bool UnzipWorker::set()
 {
+    LOG << "UnzipWorker::set started with file:" << filepath.toStdString();
     QFile file(targetDir + "/" + datajson);
     if (!file.open(QIODevice::ReadOnly)) {
         WLOG << "could not open datajson file";
@@ -173,13 +180,16 @@ bool UnzipWorker::set()
     //Place the file in the corresponding user directory
     setUesrFile(jsonObj);
 
+    DLOG << "UnzipWorker::set finished with result true";
     return true;
 }
 
 bool UnzipWorker::setUesrFile(QJsonObject jsonObj)
 {
+    DLOG << "UnzipWorker::setUesrFile started with jsonObj";
     QJsonValue userFileValue = jsonObj["user_file"];
     if (userFileValue.isArray()) {
+        DLOG << "user_file is an array";
         const QJsonArray &userFileArray = userFileValue.toArray();
         for (const auto &value : userFileArray) {
             QString file = value.toString();

--- a/src/lib/data-transfer/core/gui/connect/choosewidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/choosewidget.cpp
@@ -36,6 +36,7 @@ ChooseWidget::~ChooseWidget()
 
 void ChooseWidget::initUI()
 {
+    DLOG << "ChooseWidget initUI";
     setStyleSheet(".ChooseWidget{background-color: white; border-radius: 10px;}");
 
     QVBoxLayout *mainLayout = new QVBoxLayout();
@@ -92,11 +93,14 @@ void ChooseWidget::initUI()
 
     connect(TransferHelper::instance(), &TransferHelper::onlineStateChanged,
             [this, tiptextlabel](bool online) {
+                DLOG << "Online state changed:" << online;
                 if (online) {
+                    DLOG << "Network is online";
                     tiptextlabel->setVisible(false);
                     winItem->setIcon(QIcon(":/icon/select1.png"));
                     nextButton->setEnabled(true);
                 } else {
+                    DLOG << "Network is offline";
                     tiptextlabel->setVisible(true);
                     winItem->checked = false;
                     nextButton->setEnabled(false);
@@ -109,6 +113,7 @@ void ChooseWidget::initUI()
         if (state == true) {
             DLOG << "User selected network transmission mode";
             if (packageItem->checked == true) {
+                DLOG << "Package item was checked, unchecking";
                 packageItem->checked = false;
                 packageItem->update();
             }
@@ -116,6 +121,7 @@ void ChooseWidget::initUI()
             nextpage = selecPage1;
             transferMethod = TransferMethod::kNetworkTransmission;
         } else {
+            DLOG << "User deselected network transmission mode";
             nextButton->setEnabled(false);
         }
     });
@@ -123,6 +129,7 @@ void ChooseWidget::initUI()
         if (state == true) {
             DLOG << "User selected local export mode";
             if (winItem->checked == true) {
+                DLOG << "Win item was checked, unchecking";
                 winItem->checked = false;
                 winItem->update();
             }
@@ -131,24 +138,30 @@ void ChooseWidget::initUI()
 
             transferMethod = TransferMethod::kLocalExport;
         } else {
+            DLOG << "User deselected local export mode";
             nextButton->setEnabled(false);
         }
     });
+    DLOG << "ChooseWidget initUI finished";
 }
 
 void ChooseWidget::sendOptions()
 {
+    DLOG << "ChooseWidget sendOptions";
     QStringList method;
     method << transferMethod;
 
     OptionsManager::instance()->addUserOption(Options::kTransferMethod, method);
+    DLOG << "ChooseWidget sendOptions finished";
 }
 
 void ChooseWidget::nextPage()
 {
+    DLOG << "ChooseWidget nextPage";
     sendOptions();
     emit TransferHelper::instance()->changeWidgetText();
     emit TransferHelper::instance()->changeWidget((PageName)nextpage);
+    DLOG << "ChooseWidget nextPage finished";
 }
 
 void ChooseWidget::themeChanged(int theme)
@@ -157,18 +170,22 @@ void ChooseWidget::themeChanged(int theme)
 
     // light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".ChooseWidget{ background-color: rgba(255,255,255,1); border-radius: 10px;}");
     } else {
         // dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".ChooseWidget{background-color: rgba(37, 37, 37,1); border-radius: 10px;}");
     }
     winItem->themeChanged(theme);
     packageItem->themeChanged(theme);
+    DLOG << "ChooseWidget themeChanged finished";
 }
 
 ModeItem::ModeItem(QString text, QIcon icon, QWidget *parent)
     : itemText(text), QFrame(parent)
 {
+    DLOG << "ModeItem constructor called with text:" << text.toStdString();
     setStyleSheet(".ModeItem{"
                   "border-radius: 8px;"
                   "opacity: 1;"
@@ -187,6 +204,7 @@ ModeItem::ModeItem(QString text, QIcon icon, QWidget *parent)
     setLayout(mainLayout);
     mainLayout->setSpacing(0);
     mainLayout->addWidget(iconLabel);
+    DLOG << "ModeItem constructor finished";
 }
 
 ModeItem::~ModeItem() {}
@@ -195,8 +213,10 @@ void ModeItem::setEnable(bool able)
 {
     enable = able;
 #ifdef linux
+    DLOG << "Linux platform, setting enabled state:" << able;
     setEnabled(able);
 #else
+    DLOG << "Non-Linux platform, setting stylesheet based on enabled state:" << able;
     if (able)
         setStyleSheet(".ModeItem{"
                       "border-radius: 8px;"
@@ -221,8 +241,10 @@ void ModeItem::setIcon(QIcon icon)
 
 void ModeItem::themeChanged(int theme)
 {
+    DLOG << "ModeItem themeChanged called with theme:" << theme;
     // light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".ModeItem{"
                       "border-radius: 8px;"
                       "opacity: 1;"
@@ -232,6 +254,7 @@ void ModeItem::themeChanged(int theme)
         dark = false;
     } else {
         // dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".ModeItem{"
                       "border-radius: 8px;"
                       "opacity: 1;"
@@ -245,9 +268,12 @@ void ModeItem::themeChanged(int theme)
 void ModeItem::mousePressEvent(QMouseEvent *event)
 {
     if (enable) {
+        DLOG << "Mouse pressed and item is enabled";
         checked = !checked;
         emit clicked(checked);
         update();
+    } else {
+        DLOG << "Mouse pressed but item is disabled";
     }
     return QFrame::mousePressEvent(event);
 }
@@ -257,22 +283,29 @@ void ModeItem::paintEvent(QPaintEvent *event)
     QPainter paint(this);
     paint.setRenderHint(QPainter::Antialiasing);
     if (!enable) {
+        // DLOG << "Item is disabled, setting opacity to 0.4";
         paint.setOpacity(0.4);
     } else {
+        // DLOG << "Item is enabled, setting opacity to 1";
         paint.setOpacity(1);
     }
 
     if (checked) {
+        // DLOG << "Item is checked, drawing blue ellipse";
         paint.setPen(QPen(QColor(0, 129, 255, 255), 5));
         paint.drawEllipse(12, 12, 16, 16);
     } else {
+        // DLOG << "Item is not checked, drawing gray ellipse";
         paint.setPen(QPen(QColor(65, 77, 104, 255), 1));
         paint.drawEllipse(12, 12, 16, 16);
     }
-    if (dark)
+    if (dark) {
+        // DLOG << "Theme is dark, setting pen color to light gray";
         paint.setPen(QColor(192, 198, 212, 255));
-    else
+    } else {
+        // DLOG << "Theme is light, setting pen color to dark gray";
         paint.setPen(QColor(65, 77, 104, 255));
+    }
     paint.drawText(36, 24, itemText);
     return QFrame::paintEvent(event);
 }

--- a/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
@@ -28,6 +28,7 @@ ConnectWidget::~ConnectWidget()
 
 void ConnectWidget::initUI()
 {
+    DLOG << "ConnectWidget initUI";
     setStyleSheet(".ConnectWidget{background-color: white; border-radius: 10px;}");
 
     QVBoxLayout *mainLayout = new QVBoxLayout();
@@ -49,6 +50,7 @@ void ConnectWidget::initUI()
     downloadLabel->setContentsMargins(0, 10, 0, 0);
     downloadLabel->setText(QString("<a href=\"https://\" style=\"text-decoration:none;\">%1</a>").arg(tr("Download Windows client")));
     connect(downloadLabel, &QLabel::linkActivated, this, [] {
+        DLOG << "Download Windows client link activated";
         QDesktopServices::openUrl(QUrl("https://www.chinauos.com/resource/deepin-data-transfer"));
     });
 
@@ -93,10 +95,12 @@ void ConnectWidget::initUI()
     mainLayout->addLayout(buttonLayout);
     mainLayout->addSpacing(10);
     mainLayout->addLayout(indexLayout);
+    DLOG << "ConnectWidget initUI finished";
 }
 
 void ConnectWidget::initConnectLayout()
 {
+    DLOG << "ConnectWidget initConnectLayout";
     //ipLayout
     QList<QHostAddress> address = QNetworkInterface::allAddresses();
     QString ipaddress = address.count() > 2 ? address[2].toString() : "";
@@ -169,10 +173,12 @@ void ConnectWidget::initConnectLayout()
     QTimer *timer = new QTimer();
     connect(timer, &QTimer::timeout, [refreshLabel, tipLabel, passwordLabel, nullLabel, timer, this]() {
         if (remainingTime > 0 && !passwordLabel->text().isEmpty()) {
+            DLOG << "Remaining time:" << remainingTime << "s";
             remainingTime--;
             QString tip = QString("%1<font color='#6199CA'> %2s </font>%3").arg(tr("The code will be expired in")).arg(QString::number(remainingTime)).arg(tr("please input connect code as soon as possible"));
             tipLabel->setText(tip);
         } else {
+            DLOG << "Connect code expired or password label is empty";
             tipLabel->setVisible(false);
             passwordLabel->setVisible(false);
             nullLabel->setVisible(true);
@@ -218,6 +224,7 @@ void ConnectWidget::initConnectLayout()
     connectLayout->addLayout(passwordVLayout);
     connectLayout->setSpacing(15);
     connectLayout->setAlignment(Qt::AlignCenter);
+    DLOG << "ConnectWidget initConnectLayout finished";
 }
 
 void ConnectWidget::nextPage()
@@ -231,9 +238,11 @@ void ConnectWidget::backPage()
     DLOG << "Returning to previous page";
     QStackedWidget *stackedWidget = qobject_cast<QStackedWidget *>(this->parent());
     if (stackedWidget) {
+        DLOG << "Stacked widget found, setting current index to previous page";
         stackedWidget->setCurrentIndex(stackedWidget->currentIndex() - 1);
     } else {
         WLOG << "Jump to next page failed, qobject_cast<QStackedWidget *>(this->parent()) = nullptr";
+        DLOG << "Stacked widget not found";
     }
 }
 
@@ -243,12 +252,14 @@ void ConnectWidget::themeChanged(int theme)
 
     // light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".ConnectWidget{background-color: rgba(255,255,255,1); border-radius: 10px;}");
         separatorLabel->setStyleSheet("QLabel { background-color: rgba(0, 0, 0, 0.1); width: 2px; }");
         ipLabel->setStyleSheet(" ");
         ipLabel1->setStyleSheet(" ");
     } else {
         // dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".ConnectWidget{background-color: rgba(37, 37, 37,1); border-radius: 10px;}");
         separatorLabel->setStyleSheet("background-color: rgba(220, 220, 220,0.1); width: 2px;");
         ipLabel->setStyleSheet("color: rgb(192, 192, 192);");

--- a/src/lib/data-transfer/core/gui/connect/custommessagebox.cpp
+++ b/src/lib/data-transfer/core/gui/connect/custommessagebox.cpp
@@ -30,6 +30,7 @@ void CustomMessageBox::paintEvent(QPaintEvent *event)
 
 void CustomMessageBox::initUi()
 {
+    DLOG << "CustomMessageBox initUi";
     setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
     setAttribute(Qt::WA_TranslucentBackground);
     setFixedSize(385, 160);
@@ -49,6 +50,7 @@ void CustomMessageBox::initUi()
                                  "font-weight: 500;"
                                  "font-style: normal;"
                                  " text-align: center;}");
+    DLOG << "message1Label stylesheet set";
     QLabel *message2Label = new QLabel(message2, this);
     message2Label->setAlignment(Qt::AlignCenter);
     message2Label->setWordWrap(true);
@@ -61,6 +63,7 @@ void CustomMessageBox::initUi()
                                  "font-weight: 400;"
                                  "font-style: normal;"
                                  " text-align: center;}");
+    DLOG << "message2Label stylesheet set";
 
     QVBoxLayout *mainLayout = new QVBoxLayout();
     setLayout(mainLayout);
@@ -134,14 +137,18 @@ void CustomMessageBox::initUi()
     QObject::connect(closeButton, &QPushButton::clicked, this, &CustomMessageBox::reject);
     QObject::connect(continueButton, &QPushButton::clicked, this, &CustomMessageBox::accept);
     QObject::connect(cancelButton, &QPushButton::clicked, this, &CustomMessageBox::reject);
+    DLOG << "CustomMessageBox initUi finished";
 }
 
 bool CustomMessageBox::SelectContinueTransfer()
 {
     DLOG << "Checking for outstanding transfer tasks";
     CustomMessageBox messageBox(tr("The presence of outstanding transfer tasks between you and the target device has been detected."), tr("Do you want to continue with the last transfer?"));
-    if (messageBox.exec() == QDialog::Accepted)
+    if (messageBox.exec() == QDialog::Accepted) {
+        DLOG << "User accepted to continue transfer";
         return true;
-    else
+    } else {
+        DLOG << "User rejected to continue transfer";
         return false;
+    }
 }

--- a/src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp
@@ -22,6 +22,7 @@ NetworkDisconnectionWidget::~NetworkDisconnectionWidget()
 
 void NetworkDisconnectionWidget::initUI()
 {
+    DLOG << "NetworkDisconnectionWidget initUI";
     setStyleSheet(".NetworkDisconnectionWidget{background-color: white; border-radius: 10px;}");
 
     QVBoxLayout *mainLayout = new QVBoxLayout();
@@ -62,6 +63,7 @@ void NetworkDisconnectionWidget::initUI()
     mainLayout->addLayout(buttonLayout);
     mainLayout->addSpacing(10);
     mainLayout->addLayout(indexLayout);
+    DLOG << "NetworkDisconnectionWidget initUI finished";
 }
 
 void NetworkDisconnectionWidget::backPage()
@@ -81,8 +83,10 @@ void NetworkDisconnectionWidget::themeChanged(int theme)
     DLOG << "Theme changed to:" << (theme == 1 ? "light" : "dark");
     //light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".NetworkDisconnectionWidget{background-color: white; border-radius: 10px;}");
     } else {
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".NetworkDisconnectionWidget{background-color: rgb(37, 37, 37); border-radius: 10px;}");
         //dark
     }

--- a/src/lib/data-transfer/core/gui/connect/promptwidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/promptwidget.cpp
@@ -25,6 +25,7 @@ PromptWidget::~PromptWidget()
 
 void PromptWidget::initUI()
 {
+    DLOG << "Initializing UI";
     setStyleSheet(".PromptWidget{background-color: white; border-radius: 10px;}");
 
     QVBoxLayout *mainLayout = new QVBoxLayout();
@@ -77,6 +78,7 @@ void PromptWidget::initUI()
     mainLayout->addLayout(promptLayout);
     mainLayout->addSpacing(220);
     mainLayout->addLayout(buttonLayout);
+    DLOG << "UI initialization complete";
 }
 
 void PromptWidget::nextPage()
@@ -102,10 +104,12 @@ void PromptWidget::themeChanged(int theme)
     DLOG << "Theme changed to:" << (theme == 1 ? "light" : "dark");
     // light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".PromptWidget{background-color: white; border-radius: 10px;}");
 
     } else {
         // dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".PromptWidget{background-color: rgb(37, 37, 37); border-radius: 10px;}");
     }
 }

--- a/src/lib/data-transfer/core/gui/connect/readywidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/readywidget.cpp
@@ -28,16 +28,19 @@ ReadyWidget::~ReadyWidget()
 
 void ReadyWidget::clear()
 {
+    DLOG << "ReadyWidget clear";
     ipInput->clear();
     captchaInput->clear();
     tiptextlabel->setVisible(false);
     setnextButEnable(false);
     tiptextlabel->setStyleSheet(StyleHelper::textStyle(StyleHelper::normal));
     tiptextlabel->setText(tr("connect..."));
+    DLOG << "ReadyWidget clear finished";
 }
 
 void ReadyWidget::initUI()
 {
+    DLOG << "ReadyWidget initUI";
     setStyleSheet(".ReadyWidget{background-color: white; border-radius: 10px;}");
 
     // init timer
@@ -74,6 +77,7 @@ void ReadyWidget::initUI()
     QObject::connect(ipInput, &QLineEdit::textChanged, [=]() {
         bool isEmpty = ipInput->text().isEmpty();
         ipInput->setClearButtonEnabled(!isEmpty);
+        DLOG << "IP input text changed, clear button enabled:" << !isEmpty;
     });
     QHBoxLayout *editLayout1 = new QHBoxLayout(this);
     editLayout1->setAlignment(Qt::AlignCenter);
@@ -104,6 +108,7 @@ void ReadyWidget::initUI()
     QObject::connect(captchaInput, &QLineEdit::textChanged, [=]() {
         bool isEmpty = captchaInput->text().isEmpty();
         captchaInput->setClearButtonEnabled(!isEmpty);
+        DLOG << "Captcha input text changed, clear button enabled:" << !isEmpty;
     });
 
     QHBoxLayout *editLayout2 = new QHBoxLayout(this);
@@ -162,10 +167,12 @@ void ReadyWidget::initUI()
     QObject::connect(timer, &QTimer::timeout, [this]() {
         connectFailed();
     });
+    DLOG << "ReadyWidget initUI finished";
 }
 
 void ReadyWidget::tryConnect()
 {
+    DLOG << "ReadyWidget tryConnect";
     tiptextlabel->setText(
             QString("<font size='3' color='#000000'>%1</font>").arg(tr("connect...")));
     tiptextlabel->setVisible(true);
@@ -173,11 +180,13 @@ void ReadyWidget::tryConnect()
 
     TransferHelper::instance()->tryConnect(ipInput->text(), captchaInput->text());
     timer->start();
+    DLOG << "ReadyWidget tryConnect finished";
 }
 
 void ReadyWidget::setnextButEnable(bool enabel)
 {
     if (enabel) {
+        DLOG << "Enabling next button";
         nextButton->setEnabled(true);
         nextButton->setStyleSheet(".QPushButton{border-radius: 8px;"
                                   "opacity: 1;"
@@ -191,6 +200,7 @@ void ReadyWidget::setnextButEnable(bool enabel)
                                   "text-align: center;"
                                   "}");
     } else {
+        DLOG << "Disabling next button";
         nextButton->setEnabled(false);
         nextButton->setStyleSheet(".QPushButton{border-radius: 8px;"
                                   "opacity: 1;"
@@ -208,9 +218,11 @@ void ReadyWidget::setnextButEnable(bool enabel)
 
 void ReadyWidget::nextPage()
 {
+    DLOG << "ReadyWidget nextPage";
     // tiptextlabel->setVisible(false);
     QStackedWidget *stackedWidget = qobject_cast<QStackedWidget *>(this->parent());
     if (stackedWidget) {
+        DLOG << "Jump to next page";
         stackedWidget->setCurrentIndex(stackedWidget->currentIndex() + 1);
     } else {
         WLOG << "Jump to next page failed, qobject_cast<QStackedWidget *>(this->parent()) = "
@@ -218,10 +230,12 @@ void ReadyWidget::nextPage()
     }
 
     clear();
+    DLOG << "ReadyWidget nextPage finished";
 }
 
 void ReadyWidget::backPage()
 {
+    DLOG << "ReadyWidget backPage";
     QStackedWidget *stackedWidget = qobject_cast<QStackedWidget *>(this->parent());
     if (stackedWidget) {
         stackedWidget->setCurrentIndex(stackedWidget->currentIndex() - 1);
@@ -231,15 +245,18 @@ void ReadyWidget::backPage()
     }
 
     clear();
+    DLOG << "ReadyWidget backPage finished";
 }
 
 void ReadyWidget::onLineTextChange()
 {
+    DLOG << "ReadyWidget onLineTextChange";
     QRegularExpression ipRegex(
             "^((\\d{1,2}|1\\d{2}|2[0-4]\\d|25[0-5])\\.){3}(\\d{1,2}|1\\d{2}|2[0-4]\\d|25[0-5])$");
     QRegularExpressionMatch ipMatch = ipRegex.match(ipInput->text());
 
     if (!ipMatch.hasMatch()) {
+        DLOG << "IP input does not match regex, disabling next button";
         setnextButEnable(false);
         return;
     }
@@ -248,16 +265,19 @@ void ReadyWidget::onLineTextChange()
     QRegularExpressionMatch captchaMatch = captchaRegex.match(captchaInput->text());
 
     if (!captchaMatch.hasMatch()) {
+        DLOG << "Captcha input does not match regex, disabling next button";
         setnextButEnable(false);
         return;
     }
 
     DLOG << "Input validation passed, enabling connect button";
     setnextButEnable(true);
+    DLOG << "ReadyWidget onLineTextChange finished";
 }
 
 void ReadyWidget::connectFailed()
 {
+    DLOG << "ReadyWidget connectFailed";
     tiptextlabel->setStyleSheet(StyleHelper::textStyle(StyleHelper::error));
     tiptextlabel->setText(tr("Failed to connect, please check your input"));
 }

--- a/src/lib/data-transfer/core/gui/connect/startwidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/startwidget.cpp
@@ -25,6 +25,7 @@ StartWidget::~StartWidget()
 
 void StartWidget::initUI()
 {
+    DLOG << "StartWidget initUI";
     setStyleSheet(".StartWidget{background-color: white; border-radius: 10px;}");
 
     QVBoxLayout *mainLayout = new QVBoxLayout();
@@ -55,6 +56,7 @@ void StartWidget::initUI()
     mainLayout->addWidget(textLabel2);
     mainLayout->addSpacing(60);
     mainLayout->addLayout(buttonLayout);
+    DLOG << "StartWidget initUI finished";
 }
 
 void StartWidget::nextPage()
@@ -69,9 +71,11 @@ void StartWidget::themeChanged(int theme)
 
     //light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".StartWidget{background-color: white; border-radius: 10px;}");
     } else {
         //dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".StartWidget{background-color: rgb(37, 37, 37); border-radius: 10px;}");
     }
 }

--- a/src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp
+++ b/src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp
@@ -26,6 +26,7 @@ ZipFileProcessResultWidget::~ZipFileProcessResultWidget()
 
 void ZipFileProcessResultWidget::initUI()
 {
+    DLOG << "ZipFileProcessResultWidget initUI";
     setStyleSheet("background-color: white; border-radius: 10px;");
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
@@ -77,11 +78,12 @@ void ZipFileProcessResultWidget::initUI()
 
     QObject::connect(TransferHelper::instance(), &TransferHelper::zipTransferContent, this,
                      &ZipFileProcessResultWidget::upWidgetToFailed);
+    DLOG << "ZipFileProcessResultWidget initUI finished";
 }
 
 void ZipFileProcessResultWidget::successed()
 {
-    DLOG << "Backup process completed successfully";
+    DLOG << "ZipFileProcessResultWidget successed";
     icon = new QLabel(this);
     icon->setPixmap(QIcon(":/icon/success-128.svg").pixmap(128, 128));
     icon->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
@@ -111,13 +113,16 @@ void ZipFileProcessResultWidget::successed()
     this->layout()->addWidget(tipLabel2);
     ((QHBoxLayout *)(this->layout()))->addSpacing(100);
     this->layout()->addWidget(displayLabel);
+    DLOG << "ZipFileProcessResultWidget successed finished";
 }
 
 void ZipFileProcessResultWidget::upWidgetToFailed(const QString &content, int progressbar,
                                                   int estimatedtime)
 {
+    DLOG << "ZipFileProcessResultWidget upWidgetToFailed";
     Q_UNUSED(estimatedtime)
     if (progressbar != -1) {
+        DLOG << "Progressbar is not -1, returning";
         return;
     }
     DLOG << "Backup process failed with error:" << content.toStdString();
@@ -147,6 +152,7 @@ void ZipFileProcessResultWidget::backPage()
 
 void ZipFileProcessResultWidget::informationPage()
 {
+    DLOG << "ZipFileProcessResultWidget informationPage";
     QString folderPath = OptionsManager::instance()->getUserOption(Options::kBackupFileSavePath)[0];
     QDesktopServices::openUrl(QUrl::fromLocalFile(folderPath));
 }

--- a/src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp
+++ b/src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp
@@ -30,6 +30,7 @@ void ZipFileProcessWidget::updateProcess(const QString &content, int processbar,
 {
     if (OptionsManager::instance()->getUserOption(Options::kTransferMethod)[0]
         == TransferMethod::kNetworkTransmission) {
+        DLOG << "Transfer method is NetworkTransmission, skipping updateProcess";
         return;
     }
     // Transfer success or failure to go to the next page
@@ -61,6 +62,7 @@ void ZipFileProcessWidget::changeTimeLabel(const int &time)
                 tr("Transfer will be completed in %1 minutes").arg(QString::number(textTime))));
         DLOG << "Converted to minutes:" << textTime;
     } else {
+        DLOG << "Time is 60 seconds or less, displaying in seconds";
         timeLabel->setText(QString(
                 tr("Transfer will be completed in %1 secondes").arg(QString::number(time))));
     }
@@ -74,6 +76,7 @@ void ZipFileProcessWidget::changeProgressBarLabel(const int &processbar)
 
 void ZipFileProcessWidget::initUI()
 {
+    DLOG << "ZipFileProcessWidget initUI";
     setStyleSheet(".ZipFileProcessWidget{background-color: white; border-radius: 10px;}");
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
@@ -134,6 +137,7 @@ void ZipFileProcessWidget::initUI()
 
     QObject::connect(TransferHelper::instance(), &TransferHelper::zipTransferContent, this,
                      &ZipFileProcessWidget::updateProcess);
+    DLOG << "ZipFileProcessWidget initUI finished";
 }
 
 void ZipFileProcessWidget::nextPage()

--- a/src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp
+++ b/src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp
@@ -47,6 +47,7 @@ void MainWindowPrivate::initWindow()
     layout->setContentsMargins(8, 8, 8, 8);
 
     q->setCentralWidget(centerWidget);
+    DLOG << "Main window initialized";
 }
 
 void MainWindowPrivate::initWidgets()
@@ -103,14 +104,20 @@ void MainWindowPrivate::initWidgets()
 
     connect(TransferHelper::instance(), &TransferHelper::onlineStateChanged,
             [this, errorwidget](bool online) {
-                if (online)
+                DLOG << "Online state changed:" << online;
+                if (online) {
+                    DLOG << "Network is online, returning";
                     return;
+                }
                 int index = stackedWidget->currentIndex();
                 //only these need jump to networkdisconnectwidget
-                if (index == PageName::connectwidget || index == PageName::waitwidget || index == PageName::promptwidget)
+                if (index == PageName::connectwidget || index == PageName::waitwidget || index == PageName::promptwidget) {
+                    DLOG << "Current page is connect, wait, or prompt widget, switching to networkdisconnectwidget";
                     stackedWidget->setCurrentIndex(PageName::networkdisconnectwidget);
+                }
                 if (index == PageName::transferringwidget) {
                     WLOG << "receiver > network offline, jump to errorwidget";
+                    DLOG << "Current page is transferring widget, switching to errorwidget due to network offline";
                     stackedWidget->setCurrentIndex(PageName::errorwidget);
                     errorwidget->setErrorType(ErrorType::networkError);
                 }
@@ -119,12 +126,16 @@ void MainWindowPrivate::initWidgets()
     //disconect transfer
     connect(TransferHelper::instance(), &TransferHelper::disconnected,
             [this, errorwidget]() {
+                DLOG << "Disconnected signal received";
                 int index = stackedWidget->currentIndex();
-                if (index == PageName::errorwidget)
+                if (index == PageName::errorwidget) {
+                    DLOG << "Current page is errorwidget, returning";
                     return;
+                }
 
                 if (index == PageName::transferringwidget || index == PageName::waitwidget) {
                     WLOG << "receiver > disconnected, jump to errorwidget";
+                    DLOG << "Current page is transferring or wait widget, switching to errorwidget due to disconnection";
                     stackedWidget->setCurrentIndex(PageName::errorwidget);
                     errorwidget->setErrorType(ErrorType::networkError);
                 }
@@ -159,4 +170,5 @@ void MainWindowPrivate::initWidgets()
         stackedWidget->setCurrentIndex(index);
     });
     q->centralWidget()->layout()->addWidget(stackedWidget);
+    DLOG << "Main window widgets initialized";
 }

--- a/src/lib/data-transfer/core/gui/mainwindow.cpp
+++ b/src/lib/data-transfer/core/gui/mainwindow.cpp
@@ -15,6 +15,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags /*flags*/)
     d->initWindow();
     d->initWidgets();
     d->moveCenter();
+    DLOG << "Main window initialized";
 }
 
 MainWindow::~MainWindow()
@@ -25,19 +26,27 @@ MainWindow::~MainWindow()
 #if defined(_WIN32) || defined(_WIN64)
 void MainWindow::paintEvent(QPaintEvent *event)
 {
+    DLOG << "Paint event triggered (Windows)";
     d->paintEvent(event);
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
     Q_UNUSED(event);
+    DLOG << "Close event triggered (Windows), quitting application";
     QApplication::quit();
 }
 #endif
 
-MainWindowPrivate::MainWindowPrivate(MainWindow *qq) : q(qq) { }
+MainWindowPrivate::MainWindowPrivate(MainWindow *qq) : q(qq)
+{
+    DLOG << "MainWindowPrivate init";
+}
 
-MainWindowPrivate::~MainWindowPrivate() { }
+MainWindowPrivate::~MainWindowPrivate()
+{
+    DLOG << "MainWindowPrivate destroy";
+}
 
 void MainWindowPrivate::moveCenter()
 {
@@ -51,6 +60,7 @@ void MainWindowPrivate::moveCenter()
     QList<QScreen *>::const_iterator it = screens.begin();
     for (; it != screens.end(); ++it) {
         if ((*it)->geometry().contains(cursorPos)) {
+            DLOG << "Cursor is on this screen:" << (*it)->name().toStdString();
             cursorScreen = *it;
             break;
         }
@@ -60,8 +70,10 @@ void MainWindowPrivate::moveCenter()
         DLOG << "No screen contains cursor, using primary screen";
         cursorScreen = qApp->primaryScreen();
     }
-    if (!cursorScreen)
+    if (!cursorScreen) {
+        DLOG << "No primary screen found, cannot center window";
         return;
+    }
 
     int x = (cursorScreen->availableGeometry().width() - q->width()) / 2;
     int y = (cursorScreen->availableGeometry().height() - q->height()) / 2;

--- a/src/lib/data-transfer/core/gui/select/appselectwidget.cpp
+++ b/src/lib/data-transfer/core/gui/select/appselectwidget.cpp
@@ -76,6 +76,7 @@ void AppSelectWidget::initUI()
     mainLayout->addWidget(selectFrame);
     mainLayout->addSpacing(10);
     mainLayout->addLayout(buttonLayout);
+    DLOG << "Application selection widget initialized";
 }
 
 void AppSelectWidget::initSelectFrame()
@@ -114,6 +115,7 @@ void AppSelectWidget::initSelectFrame()
         item->setIcon(QIcon(iterator.value()));
         item->setCheckable(true);
         model->appendRow(item);
+        DLOG << "Added transferable app:" << iterator.key().toStdString();
     }
 
     for (auto iterator = noRecommendList.begin(); iterator != noRecommendList.end(); ++iterator) {
@@ -124,14 +126,17 @@ void AppSelectWidget::initSelectFrame()
         item->setData(2, Qt::ToolTipPropertyRole);
         QPixmap pix = DrapWindowsData::instance()->getAppIcon(iterator.value());
         if (pix.isNull()) {
+            DLOG << "App icon is null, using default file icon";
             item->setIcon(QIcon(":/icon/file@2x.png"));
         } else {
+            DLOG << "App icon found, setting it";
             item->setIcon(QIcon(pix));
         }
 
         item->setCheckable(false);
 
         model->appendRow(item);
+        DLOG << "Added non-suitable app:" << iterator.key().toStdString();
     }
 
     selectframeLayout->addWidget(titlebar);
@@ -144,26 +149,35 @@ void AppSelectWidget::initSelectFrame()
     auto sortBtn = titlebar->getSortButton1();
     sortBtn->setVisible(true);
     QObject::connect(sortBtn, &SortButton::sort, appView, &SelectListView::sortListview);
+    DLOG << "Application selection frame initialized";
 }
 
 void AppSelectWidget::changeText()
 {
+    DLOG << "Updating application selection widget text";
     QString method = OptionsManager::instance()->getUserOption(Options::kTransferMethod)[0];
     if (method == TransferMethod::kLocalExport) {
+        DLOG << "Transfer method is LocalExport, setting title to LocalText";
         titileLabel->setText(LocalText);
     } else if (method == TransferMethod::kNetworkTransmission) {
+        DLOG << "Transfer method is NetworkTransmission, setting title to InternetText";
         titileLabel->setText(InternetText);
+    } else {
+        DLOG << "Unknown transfer method:" << method.toStdString();
     }
+    DLOG << "Application selection widget text updated";
 }
 
 void AppSelectWidget::clear()
 {
+    DLOG << "Clearing selected applications";
     QStandardItemModel *configmodel = appView->getModel();
     for (int row = 0; row < configmodel->rowCount(); ++row) {
         QModelIndex itemIndex = configmodel->index(row, 0);
         configmodel->setData(itemIndex, Qt::Unchecked, Qt::CheckStateRole);
     }
     OptionsManager::instance()->addUserOption(Options::kApp, QStringList());
+    DLOG << "Selected applications cleared";
 }
 
 void AppSelectWidget::sendOptions()
@@ -185,6 +199,7 @@ void AppSelectWidget::sendOptions()
     OptionsManager::instance()->addUserOption(Options::kApp, appName);
 
     emit isOk(SelectItemName::APP);
+    DLOG << "Selected application options sent";
 }
 
 void AppSelectWidget::delOptions()
@@ -205,6 +220,7 @@ void AppSelectWidget::delOptions()
 
     // Deselect
     emit isOk(SelectItemName::APP);
+    DLOG << "Selected application options cleared";
 }
 
 void AppSelectWidget::nextPage()

--- a/src/lib/data-transfer/core/gui/select/configselectwidget.cpp
+++ b/src/lib/data-transfer/core/gui/select/configselectwidget.cpp
@@ -74,6 +74,7 @@ void ConfigSelectWidget::initUI()
     mainLayout->addWidget(selectConfigFrame);
     mainLayout->addSpacing(10);
     mainLayout->addLayout(buttonLayout);
+    DLOG << "UI components initialized";
 }
 
 void ConfigSelectWidget::initSelectBrowerBookMarkFrame()
@@ -109,6 +110,7 @@ void ConfigSelectWidget::initSelectBrowerBookMarkFrame()
         item->setIcon(QIcon(iterator.value()));
         item->setCheckable(true);
         model->appendRow(item);
+        // DLOG << "Added browser bookmark:" << iterator.key().toStdString();
     }
 
     selectframeLayout->addWidget(titlebar);
@@ -118,6 +120,7 @@ void ConfigSelectWidget::initSelectBrowerBookMarkFrame()
     QObject::connect(browserView, &SelectListView::currentSelectState, titlebar,
                      &ItemTitlebar::updateSelectAllButState);
     QObject::connect(titlebar, &ItemTitlebar::sort, browserView, &SelectListView::sortListview);
+    DLOG << "Browser bookmark selection frame initialized";
 }
 
 void ConfigSelectWidget::initSelectConfigFrame()
@@ -151,6 +154,7 @@ void ConfigSelectWidget::initSelectConfigFrame()
     item->setData(tr("Transferable"), Qt::ToolTipRole);
     item->setCheckable(true);
     model->appendRow(item);
+    DLOG << "Added customized wallpaper item";
 
     selectframeLayout->addWidget(titlebar);
     selectframeLayout->addWidget(configView);
@@ -159,6 +163,7 @@ void ConfigSelectWidget::initSelectConfigFrame()
     QObject::connect(configView, &SelectListView::currentSelectState, titlebar,
                      &ItemTitlebar::updateSelectAllButState);
     QObject::connect(titlebar, &ItemTitlebar::sort, configView, &SelectListView::sortListview);
+    DLOG << "Config selection frame initialized";
 }
 
 void ConfigSelectWidget::sendOptions()
@@ -172,6 +177,7 @@ void ConfigSelectWidget::sendOptions()
         QVariant checkboxData = model->data(index, Qt::CheckStateRole);
         Qt::CheckState checkState = static_cast<Qt::CheckState>(checkboxData.toInt());
         if (checkState == Qt::Checked) {
+            DLOG << "Browser bookmark at row" << row << "is checked";
             browser << model->data(index, Qt::DisplayRole).toString();
         }
     }
@@ -186,6 +192,7 @@ void ConfigSelectWidget::sendOptions()
         QVariant checkboxData = model->data(index, Qt::CheckStateRole);
         Qt::CheckState checkState = static_cast<Qt::CheckState>(checkboxData.toInt());
         if (checkState == Qt::Checked) {
+            DLOG << "Config item at row" << row << "is checked";
             config << model->data(index, Qt::DisplayRole).toString();
         }
     }
@@ -194,6 +201,7 @@ void ConfigSelectWidget::sendOptions()
     OptionsManager::instance()->addUserOption(Options::kConfig, config);
 
     emit isOk(SelectItemName::CONFIG);
+    DLOG << "Selected options sent";
 }
 
 void ConfigSelectWidget::delOptions()
@@ -225,10 +233,12 @@ void ConfigSelectWidget::delOptions()
 
     // Deselect
     emit isOk(SelectItemName::CONFIG);
+    DLOG << "Selected options cleared";
 }
 
 void ConfigSelectWidget::changeText()
 {
+    DLOG << "Updating title text";
     QString method = OptionsManager::instance()->getUserOption(Options::kTransferMethod)[0];
     if (method == TransferMethod::kLocalExport) {
         titileLabel->setText(LocalText);
@@ -239,6 +249,7 @@ void ConfigSelectWidget::changeText()
 
 void ConfigSelectWidget::clear()
 {
+    DLOG << "Clearing selection";
     QStandardItemModel *browsermodel = browserView->getModel();
     for (int row = 0; row < browsermodel->rowCount(); ++row) {
         QModelIndex itemIndex = browsermodel->index(row, 0);

--- a/src/lib/data-transfer/core/gui/select/item.cpp
+++ b/src/lib/data-transfer/core/gui/select/item.cpp
@@ -19,6 +19,7 @@ ItemTitlebar::ItemTitlebar(const QString &label1_, const QString &label2_,
       iconPosSize(iconPosSize_),
       iconRadius(iconRadius_)
 {
+    DLOG << "Creating titlebar";
     selectAllButton = new SelectAllButton(this);
     selectAllButton->move(iconPosSize.x(), iconPosSize.y());
 
@@ -74,6 +75,7 @@ void ItemTitlebar::updateSelectAllButState(ListSelectionState selectState)
 
 void ItemTitlebar::initUI()
 {
+    DLOG << "Initializing UI";
     setProperty("class", "myqframe");
     setContentsMargins(0, 0, 0, 0);
     setStyleSheet(".QLabel{"
@@ -101,6 +103,8 @@ void ItemTitlebar::initUI()
     sortButton2 = new SortButton(this);
     sortButton2->move(label2LeftMargin + 115, iconPosSize.y());
     sortButton2->setVisible(false);
+
+    DLOG << "UI initialized";
 }
 
 SortButton *ItemTitlebar::getSortButton1() const
@@ -165,6 +169,7 @@ ItemDelegate::ItemDelegate(const qreal &filenameTextLeftMargin_, const qreal &fi
       iconPos(iconPos_),
       checkBoxPos(checkBoxPos_)
 {
+    DLOG << "Creating delegate with specified parameters";
 }
 
 void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
@@ -197,10 +202,12 @@ void ItemDelegate::paintIcon(QPainter *painter, const QStyleOptionViewItem &opti
 
     if (index.data(Qt::BackgroundRole).toBool() == true) {
         painter->setOpacity(opacity);
+        // DLOG << "Setting opacity for background role";
     }
     painter->setRenderHint(QPainter::Antialiasing);
     QIcon icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
     if (!icon.isNull()) {
+        // DLOG << "Icon is not null, painting icon";
         QPoint pos = option.rect.topLeft();
         pos += iconPos;
 
@@ -219,11 +226,13 @@ void ItemDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem
 
     if (index.data(Qt::BackgroundRole).toBool() == true) {
         painter->setOpacity(opacity);
+        // DLOG << "Setting opacity for background role";
     }
     QColor evencolor = QColor(0, 0, 0, 20);
     QPoint topleft = option.rect.topLeft();
     QRect positon(backgroundColorLeftMargin, topleft.y(), 440, 36);
     if (index.row() % 2 != 0) {
+        // DLOG << "Row is odd, drawing rounded rectangle with even color";
         painter->setBrush(evencolor);
         painter->drawRoundedRect(positon, 10, 10);
     }
@@ -266,6 +275,7 @@ void ItemDelegate::paintCheckbox(QPainter *painter, const QStyleOptionViewItem &
 
     if (index.data(Qt::BackgroundRole).toBool() == true) {
         painter->setOpacity(opacity);
+        // DLOG << "Setting opacity for background role";
     }
     painter->setRenderHint(QPainter::Antialiasing);
     QPoint pos = option.rect.topLeft() + checkBoxPos;
@@ -275,6 +285,7 @@ void ItemDelegate::paintCheckbox(QPainter *painter, const QStyleOptionViewItem &
     painter->drawRoundedRect(checkBoxRect, 4, 4);
 
     if (index.data(Qt::CheckStateRole).value<Qt::CheckState>() == Qt::Checked) {
+    //    DLOG << "Checkbox is checked, drawing checkmark";
        QRect iconRect(checkBoxRect.left() + 3, checkBoxRect.top() + 3, 13, 11);
 //        QSvgRenderer render(QString(":/icon/check_black.svg"));
 //        render.render(painter, iconRect);
@@ -293,13 +304,17 @@ bool ItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
     // make sure that the item is checkable
     Qt::ItemFlags flags = model->flags(index);
     if (!(flags & Qt::ItemIsUserCheckable) || !(option.state & QStyle::State_Enabled)
-        || !(flags & Qt::ItemIsEnabled))
+        || !(flags & Qt::ItemIsEnabled)) {
+        DLOG << "Item is not checkable, enabled, or user-enabled, returning false";
         return false;
+    }
 
     // make sure that we have a check state
     QVariant value = index.data(Qt::CheckStateRole);
-    if (!value.isValid())
+    if (!value.isValid()) {
+        DLOG << "Check state value is invalid, returning false";
         return false;
+    }
     if ((event->type() == QEvent::MouseButtonRelease)
         || (event->type() == QEvent::MouseButtonDblClick)
         || (event->type() == QEvent::MouseButtonPress)) {
@@ -308,21 +323,26 @@ bool ItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
         QRect checkBoxRect = QRect(pos.x(), pos.y(), 18, 18);
 
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        if (mouseEvent->button() != Qt::LeftButton || !checkBoxRect.contains(mouseEvent->pos()))
+        if (mouseEvent->button() != Qt::LeftButton || !checkBoxRect.contains(mouseEvent->pos())) {
+            DLOG << "Mouse event is not left click or not within checkbox, returning false";
             return false;
+        }
 
         // eat the double click events inside the check rect
         if ((event->type() == QEvent::MouseButtonPress)
             || (event->type() == QEvent::MouseButtonDblClick)) {
+            DLOG << "Eating double click or mouse press event";
             return true;
         }
 
         if (checkBoxRect.contains(mouseEvent->pos())) {
+            DLOG << "Checkbox clicked, toggling check state";
             Qt::CheckState state = static_cast<Qt::CheckState>(value.toInt());
             state = (state == Qt::Checked) ? Qt::Unchecked : Qt::Checked;
             return model->setData(index, state, Qt::CheckStateRole);
         }
     }
+    return false;
 }
 
 void ItemDelegate::setCheckBoxPos(QPoint newCheckBoxPos)
@@ -394,9 +414,11 @@ void SaveItemDelegate::paintIcon(QPainter *painter, const QStyleOptionViewItem &
     painter->save();
     if (index.data(Qt::BackgroundRole).toBool() == true) {
         painter->setOpacity(opacity);
+        // DLOG << "Setting opacity for background role";
     }
     QIcon icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
     if (!icon.isNull()) {
+        // DLOG << "Icon is not null, painting icon";
         QPoint pos = option.rect.topLeft();
         pos += iconPos;
         QRect positon = QRect(pos, QSize(32, 32));
@@ -416,6 +438,7 @@ void SaveItemDelegate::paintBackground(QPainter *painter, const QStyleOptionView
     QRect positon(topleft.x(), topleft.y(), 440, 48);
 
     if (index.data(Qt::CheckStateRole).value<Qt::CheckState>() == Qt::Checked) {
+        // DLOG << "Item is checked, setting pen and brush for checked state";
         QPen pen;
         pen.setColor(QColor(0, 129, 255, 100));
         pen.setWidth(2);
@@ -427,6 +450,7 @@ void SaveItemDelegate::paintBackground(QPainter *painter, const QStyleOptionView
         QIcon icon(":/icon/select.svg");
         icon.paint(painter, QRect(topleft.x() + 408, topleft.y() + 13, 32, 32));
     } else {
+        // DLOG << "Item is unchecked, setting pen and brush for unchecked state";
         QColor evencolor(0, 0, 0, 12);
 
         painter->setPen(Qt::NoPen);
@@ -470,6 +494,7 @@ void SaveItemDelegate::paintCheckbox(QPainter *painter, const QStyleOptionViewIt
     painter->save();
     if (index.data(Qt::BackgroundRole).toBool() == true) {
         painter->setOpacity(opacity);
+        // DLOG << "Setting opacity for background role";
     }
     QPoint pos = option.rect.topLeft() + checkBoxPos;
     QRect checkBoxRect = QRect(pos.x(), pos.y(), 18, 18);
@@ -488,45 +513,61 @@ bool SaveItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
     // make sure that the item is checkable
     Qt::ItemFlags flags = model->flags(index);
     if (!(flags & Qt::ItemIsUserCheckable) || !(option.state & QStyle::State_Enabled)
-        || !(flags & Qt::ItemIsEnabled))
+        || !(flags & Qt::ItemIsEnabled)) {
+        DLOG << "Item is not checkable, enabled, or user-enabled, returning false";
         return false;
+    }
 
     // make sure that we have a check state
     QVariant value = index.data(Qt::CheckStateRole);
-    if (!value.isValid())
+    if (!value.isValid()) {
+        DLOG << "Check state value is invalid, returning false";
         return false;
+    }
 
     // make sure that we have the right event type
     if ((event->type() == QEvent::MouseButtonRelease)
         || (event->type() == QEvent::MouseButtonDblClick)
         || (event->type() == QEvent::MouseButtonPress)) {
+        DLOG << "Mouse button event detected";
 
         QRect checkBoxRect = option.rect;
 
         QRect emptyRect;
         doLayout(option, &checkBoxRect, &emptyRect, &emptyRect, false);
         QMouseEvent *me = static_cast<QMouseEvent *>(event);
-        if (me->button() != Qt::LeftButton || !checkBoxRect.contains(me->pos()))
+        if (me->button() != Qt::LeftButton || !checkBoxRect.contains(me->pos())) {
+            DLOG << "Mouse event is not left click or not within checkbox, returning false";
             return false;
+        }
 
         // eat the double click events inside the check rect
         if ((event->type() == QEvent::MouseButtonPress)
-            || (event->type() == QEvent::MouseButtonDblClick))
+            || (event->type() == QEvent::MouseButtonDblClick)) {
+            DLOG << "Eating double click or mouse press event";
             return true;
+        }
 
     } else if (event->type() == QEvent::KeyPress) {
+        DLOG << "Key press event detected";
         if (static_cast<QKeyEvent *>(event)->key() != Qt::Key_Space
-            && static_cast<QKeyEvent *>(event)->key() != Qt::Key_Select)
+            && static_cast<QKeyEvent *>(event)->key() != Qt::Key_Select) {
+            DLOG << "Key is not Space or Select, returning false";
             return false;
+        }
     } else {
+        DLOG << "Unknown event type, returning false";
         return false;
     }
 
     Qt::CheckState state = static_cast<Qt::CheckState>(value.toInt());
-    if (flags & Qt::ItemIsUserTristate)
+    if (flags & Qt::ItemIsUserTristate) {
+        DLOG << "Item is tristate, cycling through states";
         state = ((Qt::CheckState)((state + 1) % 3));
-    else
+    } else {
+        DLOG << "Item is not tristate, toggling checked/unchecked";
         state = (state == Qt::Checked) ? Qt::Unchecked : Qt::Checked;
+    }
     return model->setData(index, state, Qt::CheckStateRole);
 }
 
@@ -589,9 +630,11 @@ void SidebarItemDelegate::paintCheckbox(QPainter *painter, const QStyleOptionVie
     QColor color;
     QString icon;
     if (index.data(Qt::CheckStateRole).value<Qt::CheckState>() == Qt::Checked) {
+        // DLOG << "Item is checked, setting white color and check_white icon";
         color = QColor(255, 255, 255, 255);
         icon = ":/icon/check_white.svg";
     } else {
+        // DLOG << "Item is unchecked, setting black color and check_black icon";
         color = QColor(0, 0, 0, 255);
         icon = ":/icon/check_black.svg";
     }
@@ -602,11 +645,13 @@ void SidebarItemDelegate::paintCheckbox(QPainter *painter, const QStyleOptionVie
     painter->drawRoundedRect(checkBoxRect, 4, 4);
 
     if (index.data(Qt::StatusTipRole).value<int>() == 0) {
+        // DLOG << "StatusTipRole is 0, drawing checkmark icon";
         QRect iconRect(checkBoxRect.left() + 3, checkBoxRect.top() + 3, 13, 11);
 //        QSvgRenderer render(icon);
         QPixmap pixmap = QIcon(icon).pixmap(13,11);
         painter->drawPixmap(iconRect,pixmap);
     } else if (index.data(Qt::StatusTipRole).value<int>() == 1) {
+        // DLOG << "StatusTipRole is 1, drawing line";
         int y = checkBoxRect.top() + 9;
         int x1 = checkBoxRect.left() + 4;
         int x2 = checkBoxRect.left() + 14;
@@ -622,9 +667,11 @@ void SidebarItemDelegate::paintBackground(QPainter *painter, const QStyleOptionV
     QRect positon(option.rect);
     painter->setPen(Qt::NoPen);
     if (index.data(Qt::CheckStateRole).value<Qt::CheckState>() == Qt::Checked) {
+        // DLOG << "Item is checked, setting brush to checked color";
         painter->setBrush(QColor(0, 129, 255, 255));
 
     } else {
+        // DLOG << "Item is unchecked, setting brush to unchecked color";
         painter->setBrush(QColor(255, 255, 255));
     }
 
@@ -678,6 +725,7 @@ bool SidebarItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
 
 SelectAllButton::SelectAllButton(QWidget *parent) : QFrame(parent)
 {
+    DLOG << "SelectAllButton constructor";
     setFixedSize(20, 20);
 }
 
@@ -685,6 +733,7 @@ SelectAllButton::~SelectAllButton() { }
 
 void SelectAllButton::changeState(ListSelectionState state)
 {
+    DLOG << "SelectAllButton changeState to" << (int)state;
     if (curState == state)
         return;
     curState = state;
@@ -731,6 +780,7 @@ void SelectAllButton::mousePressEvent(QMouseEvent *event)
 
 SelectListView::SelectListView(QFrame *parent) : QListView(parent)
 {
+    DLOG << "SelectListView constructor";
     QStandardItemModel *model = new QStandardItemModel(this);
     setStyleSheet(".SelectListView{"
                   "border: none;"
@@ -751,6 +801,7 @@ SelectListView::~SelectListView() { }
 
 void SelectListView::setAllSize(int size)
 {
+    DLOG << "SelectListView setAllSize to" << size;
     allSize = size;
 }
 
@@ -761,11 +812,13 @@ QStandardItemModel *SelectListView::getModel()
 
 void SelectListView::setSortRole(bool flag)
 {
+    DLOG << "SelectListView setSortRole to" << flag;
     proxyModel->setFlag(flag);
 }
 
 void SelectListView::selectorDelAllItem()
 {
+    DLOG << "SelectListView selectorDelAllItem";
     QStandardItemModel *model = getModel();
     Qt::CheckState state = Qt::Unchecked;
     for (int row = 0; row < model->rowCount(); ++row) {
@@ -787,12 +840,16 @@ void SelectListView::selectorDelAllItem()
 
 void SelectListView::updateCurSelectItem(QStandardItem *item)
 {
+    DLOG << "SelectListView updateCurSelectItem";
     if (item->data(Qt::CheckStateRole) == Qt::Checked) {
+        DLOG << "SelectListView updateCurSelectItem checked";
         curSelectItemNum++;
     } else {
+        DLOG << "SelectListView updateCurSelectItem unchecked";
         curSelectItemNum--;
     }
     if (curSelectItemNum < 0) {
+        DLOG << "SelectListView updateCurSelectItem curSelectItemNum < 0";
         curSelectItemNum = 0;
         return;
     }
@@ -801,17 +858,22 @@ void SelectListView::updateCurSelectItem(QStandardItem *item)
     int tempAllsize = allSize == -1 ? model()->rowCount() : allSize;
 
     if (curSelectItemNum == 0) {
+        DLOG << "SelectListView updateCurSelectItem curSelectItemNum == 0";
         state = ListSelectionState::unselected;
     } else if (curSelectItemNum < tempAllsize) {
+        DLOG << "SelectListView updateCurSelectItem curSelectItemNum < tempAllsize";
         state = ListSelectionState::selecthalf;
     } else {
+        DLOG << "SelectListView updateCurSelectItem curSelectItemNum >= tempAllsize";
         state = ListSelectionState::selectall;
     }
     if (state == curSelectState) {
+        DLOG << "SelectListView updateCurSelectItem state == curSelectState";
         return;
     }
     curSelectState = state;
     emit currentSelectState(curSelectState);
+    DLOG << "SelectListView currentSelectState to" << (int)state;
 }
 
 void SelectListView::sortListview()
@@ -828,6 +890,7 @@ void SelectListView::sortListview()
 
 SortButton::SortButton(QWidget *parent) : QPushButton(parent)
 {
+    DLOG << "SortButton constructor";
     setIcon(QIcon(":/icon/arrow_black.svg"));
     setStyleSheet(".SortButton { border: none; }");
     setIconSize(QSize(16, 16));
@@ -849,17 +912,21 @@ void SortButton::mousePressEvent(QMouseEvent *event)
     return QPushButton::mouseMoveEvent(event);
 }
 
-SortProxyModel::SortProxyModel(QObject *parent) : QSortFilterProxyModel(parent) { }
+SortProxyModel::SortProxyModel(QObject *parent) : QSortFilterProxyModel(parent) {
+    DLOG << "SortProxyModel constructor";
+}
 
 SortProxyModel::~SortProxyModel() { }
 
 void SortProxyModel::setMode(bool Model)
 {
+    DLOG << "SortProxyModel setMode to" << Model;
     sortModel = Model;
 }
 
 void SortProxyModel::setFlag(bool flag)
 {
+    DLOG << "SortProxyModel setFlag to" << flag;
     flagDisplayrole = flag;
 }
 

--- a/src/lib/data-transfer/core/gui/select/selectmainwidget.cpp
+++ b/src/lib/data-transfer/core/gui/select/selectmainwidget.cpp
@@ -33,15 +33,19 @@ void SelectMainWidget::changeSelectframeState(const SelectItemName &name)
     if (name == SelectItemName::APP) {
         QStringList list = OptionsManager::instance()->getUserOption(Options::kApp);
         if (list.isEmpty()) {
+            DLOG << "App list is empty, setting appItem to not OK";
             appItem->isOk = false;
         } else {
+            DLOG << "App list is not empty, setting appItem to OK";
             appItem->isOk = true;
         }
         appItem->updateSelectSize(QString::number(list.size()));
     } else if (name == SelectItemName::FILES) {
         if (OptionsManager::instance()->getUserOption(Options::kFile).isEmpty()) {
+            DLOG << "File list is empty, setting fileItem to not OK";
             fileItem->isOk = false;
         } else {
+            DLOG << "File list is not empty, setting fileItem to OK";
             fileItem->isOk = true;
         }
     } else if (name == SelectItemName::CONFIG) {
@@ -49,11 +53,15 @@ void SelectMainWidget::changeSelectframeState(const SelectItemName &name)
         QStringList BrowserList =
                 OptionsManager::instance()->getUserOption(Options::kBrowserBookmarks);
         if (ConfigList.isEmpty() && BrowserList.isEmpty()) {
+            DLOG << "Config and Browser lists are empty, setting configItem to not OK";
             configItem->isOk = false;
         } else {
+            DLOG << "Config or Browser list is not empty, setting configItem to OK";
             configItem->isOk = true;
         }
         configItem->updateSelectSize(QString::number(ConfigList.size() + BrowserList.size()));
+    } else {
+        DLOG << "Unknown SelectItemName:" << name;
     }
 }
 
@@ -63,15 +71,19 @@ void SelectMainWidget::changeText()
 
     QString method = OptionsManager::instance()->getUserOption(Options::kTransferMethod)[0];
     if (method == TransferMethod::kLocalExport) {
+        DLOG << "Transfer method is LocalExport";
         titileLabel->setText(LocalText);
         nextButton->setText(BtnLocalText);
         LocalIndelabel->setVisible(true);
         InternetIndelabel->setVisible(false);
     } else if (method == TransferMethod::kNetworkTransmission) {
+        DLOG << "Transfer method is NetworkTransmission";
         titileLabel->setText(InternetText);
         nextButton->setText(BtnInternetText);
         LocalIndelabel->setVisible(false);
         InternetIndelabel->setVisible(true);
+    } else {
+        DLOG << "Unknown transfer method:" << method.toStdString();
     }
 }
 
@@ -148,6 +160,7 @@ void SelectMainWidget::initUi()
     mainLayout->addLayout(buttonLayout);
     mainLayout->addSpacing(4);
     mainLayout->addLayout(indexLayout);
+    DLOG << "SelectMainWidget initUi done";
 }
 void SelectMainWidget::nextPage()
 {
@@ -155,6 +168,7 @@ void SelectMainWidget::nextPage()
 
     // If the selected file is being calculated ,return
     if (!UserSelectFileSize::instance()->done()) {
+        DLOG << "File size calculation not done, returning";
         return;
     }
 
@@ -168,12 +182,16 @@ void SelectMainWidget::nextPage()
     PageName next;
     QString method = OptionsManager::instance()->getUserOption(Options::kTransferMethod)[0];
     if (method == TransferMethod::kLocalExport) {
+        DLOG << "Transfer method is LocalExport, setting next page to createbackupfilewidget";
         next = PageName::createbackupfilewidget;
         emit updateBackupFileSize();
     } else if (method == TransferMethod::kNetworkTransmission) {
+        DLOG << "Transfer method is NetworkTransmission, setting next page to transferringwidget and starting transfer";
         next = PageName::transferringwidget;
         // transfer
         TransferHelper::instance()->startTransfer();
+    } else {
+        DLOG << "Unknown transfer method:" << method.toStdString();
     }
 
     // ui
@@ -187,9 +205,13 @@ void SelectMainWidget::backPage()
     PageName back;
     QString method = OptionsManager::instance()->getUserOption(Options::kTransferMethod)[0];
     if (method == TransferMethod::kLocalExport) {
+        DLOG << "Transfer method is LocalExport, setting back page to choosewidget";
         back = PageName::choosewidget;
     } else if (method == TransferMethod::kNetworkTransmission) {
+        DLOG << "Transfer method is NetworkTransmission, setting back page to readywidget";
         back = PageName::readywidget;
+    } else {
+        DLOG << "Unknown transfer method:" << method.toStdString();
     }
     TransferHelper::instance()->disconnectRemote();
     emit TransferHelper::instance()->changeWidget(back);
@@ -203,15 +225,19 @@ void SelectMainWidget::selectPage()
     QStackedWidget *stackedWidget = qobject_cast<QStackedWidget *>(this->parent());
     int pageNum = -1;
     if (selectitem->name == SelectItemName::FILES) {
+        DLOG << "Selected item is FILES";
         pageNum = PageName::filewselectidget;
     } else if (selectitem->name == SelectItemName::APP) {
+        DLOG << "Selected item is APP";
         pageNum = PageName::appselectwidget;
     } else if (selectitem->name == SelectItemName::CONFIG) {
+        DLOG << "Selected item is CONFIG";
         pageNum = PageName::configselectwidget;
     }
     if (pageNum == -1) {
         WLOG << "Jump to next page failed, qobject_cast<QStackedWidget *>(this->parent()) = "
                 "nullptr";
+        DLOG << "Page number is -1, cannot jump to next page";
     } else {
         stackedWidget->setCurrentIndex(pageNum);
     }
@@ -220,6 +246,7 @@ void SelectMainWidget::selectPage()
 SelectItem::SelectItem(QString text, QIcon icon, SelectItemName itemName, QWidget *parent)
     : QFrame(parent), name(itemName)
 {
+    DLOG << "SelectItem constructor";
     setStyleSheet(" background-color: rgba(0, 0, 0,0.08); border-radius: 8px;");
     setFixedSize(160, 185);
 
@@ -248,6 +275,7 @@ SelectItem::SelectItem(QString text, QIcon icon, SelectItemName itemName, QWidge
 
     QObject::connect(this, &SelectItem::changePage, qobject_cast<SelectMainWidget *>(parent),
                      &SelectMainWidget::selectPage);
+    DLOG << "SelectItem constructor done";
 }
 SelectItem::~SelectItem()
 {
@@ -257,10 +285,13 @@ SelectItem::~SelectItem()
 void SelectItem::updateSelectSize(QString num)
 {
     if (name == SelectItemName::APP) {
+        DLOG << "Updating select size for APP:" << num.toStdString();
         sizeLabel->setText(QString(tr("Selected:%1")).arg(num));
     } else if (name == SelectItemName::FILES) {
+        DLOG << "Updating select size for FILES:" << num.toStdString();
         sizeLabel->setText(QString(tr("Selected:%1")).arg(num));
     } else if (name == SelectItemName::CONFIG) {
+        DLOG << "Updating select size for CONFIG:" << num.toStdString();
         sizeLabel->setText(QString(tr("Selected:%1")).arg(num));
     } else {
         DLOG << "selectItemName is error!";
@@ -289,6 +320,7 @@ void SelectItem::paintEvent(QPaintEvent *event)
     QFrame::paintEvent(event);
 
     if (isOk) {
+        // DLOG << "Item is OK, setting background and drawing checkmark";
         this->setStyleSheet(".SelectItem{background-color:rgba(0,129,255,0.1);}");
         QPainter painter(this);
 
@@ -308,11 +340,13 @@ void SelectItem::paintEvent(QPaintEvent *event)
         QRect iconRect(this->width() - 15, 5, scaledSize.width(), scaledSize.height());
         painter.drawPixmap(iconRect, scaledPixmap);
     } else {
+        // DLOG << "Item is not OK, setting default background";
         this->setStyleSheet(".SelectItem{background-color: rgba(0, 0, 0,0.08);}");
     }
 }
 void SelectItem::initEditFrame()
 {
+    DLOG << "SelectItem initEditFrame";
     editFrame = new QFrame(this);
     editFrame->setStyleSheet("background-color: rgba(0, 0, 0, 0.3);");
     editFrame->setGeometry(0, 0, width(), height());
@@ -340,6 +374,7 @@ void SelectItem::initEditFrame()
     editLayout->addWidget(iconLabel);
     editLayout->addWidget(textLabel);
     editLayout->setSpacing(10);
+    DLOG << "SelectItem initEditFrame done";
 }
 
 void SelectItem::changeState(const bool &ok)

--- a/src/lib/data-transfer/core/gui/transfer/errorwidget.cpp
+++ b/src/lib/data-transfer/core/gui/transfer/errorwidget.cpp
@@ -104,10 +104,12 @@ void ErrorWidget::initUI()
 
     // 默认设置为无错误状态
     currentErrorType = noError;
+    DLOG << "Error widget initialized";
 }
 
 bool ErrorWidget::checkNetworkAndUpdate()
 {
+    DLOG << "Checking network and updating state";
     // 检查当前网络状态
     bool isNetworkAvailable = deepin_cross::CommonUitls::getFirstIp().size() > 0;
 
@@ -119,6 +121,7 @@ bool ErrorWidget::checkNetworkAndUpdate()
         return true;
     }
 
+    DLOG << "Network is not available, updating offline state";
     return isNetworkAvailable;
 }
 
@@ -150,27 +153,37 @@ void ErrorWidget::themeChanged(int theme)
 
     // light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".ErrorWidget{background-color: white; border-radius: 10px;}");
     } else {
         // dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".ErrorWidget{background-color: rgb(37, 37, 37); border-radius: 10px;}");
     }
 }
 
 void ErrorWidget::setErrorType(ErrorType type, int size)
 {
+    DLOG << "Setting error type to:" << (int)type;
     currentErrorType = type;
 
     if (type == ErrorType::networkError) {
+        DLOG << "Setting error type to networkError";
         titleLabel->setText(internetError);
         promptLabel->setText(internetErrorPrompt);
     } else if (type == ErrorType::outOfStorageError) {
+        DLOG << "Setting error type to outOfStorageError";
         titleLabel->setText(transferError);
         QString prompt;
-        if (size == 0)
+        if (size == 0) {
+            DLOG << "Size is 0, setting prompt for Windows";
             prompt = QString(transferErrorPromptWin);
-        else
+        } else {
+            DLOG << "Size is not 0, setting prompt for UOS with size";
             prompt = QString(transferErrorPromptUOS).arg(size);
+        }
         promptLabel->setText(prompt);
+    } else {
+        DLOG << "Unknown error type:" << type;
     }
 }

--- a/src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp
+++ b/src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp
@@ -77,6 +77,7 @@ void ResultDisplayWidget::initUI()
         TransferHelper::instance()->sendMessage("add_result", processText);
     });
 #endif
+    DLOG << "Result display widget initialized";
 }
 
 void ResultDisplayWidget::nextPage()
@@ -87,11 +88,14 @@ void ResultDisplayWidget::nextPage()
     QTimer::singleShot(1000, this, [this] {
         QStackedWidget *stackedWidget = qobject_cast<QStackedWidget *>(this->parent());
         if (stackedWidget) {
-            if (stackedWidget->currentIndex() == PageName::resultwidget)
+            if (stackedWidget->currentIndex() == PageName::resultwidget) {
+                DLOG << "Current index is resultwidget, setting to choosewidget";
                 stackedWidget->setCurrentIndex(PageName::choosewidget);
+            }
         } else {
             WLOG << "Jump to next page failed, qobject_cast<QStackedWidget *>(this->parent()) = "
                     "nullptr";
+            DLOG << "Stacked widget not found";
         }
         emit TransferHelper::instance()->clearWidget();
     });
@@ -117,8 +121,10 @@ void ResultDisplayWidget::addResult(QString name, bool success, QString reason)
              << "Success:" << success << "Reason:" << reason.toStdString();
 
     QString info, color;
-    if (!success)
+    if (!success) {
+        DLOG << "Transfer not successful, setting status to false";
         setStatus(false);
+    }
 
     resultWindow->updateContent(name, reason, success);
     QString res = success ? "true" : "false";
@@ -140,9 +146,11 @@ void ResultDisplayWidget::setStatus(bool success)
 
     tiptextlabel->setVisible(!success);
     if (success) {
+        DLOG << "Setting status to success";
         titileLabel->setText(tr("Transfer completed"));
         iconLabel->setPixmap(QIcon(":/icon/success-128.svg").pixmap(96, 96));
     } else {
+        DLOG << "Setting status to partial success";
         titileLabel->setText(tr("Transfer completed partially"));
         iconLabel->setPixmap(QIcon(":/icon/success half-96.svg").pixmap(96, 96));
     }
@@ -175,6 +183,7 @@ void ResultWindow::updateContent(const QString &name, const QString &type, bool 
         QModelIndex index = model->index(0, col);
         QString itemName = model->data(index, Qt::DisplayRole).toString();
         if (itemName == nameT) {
+            DLOG << "Item found, updating ToolTipRole";
             model->setData(index, typeT, Qt::ToolTipRole);
             return;
         }
@@ -184,8 +193,10 @@ void ResultWindow::updateContent(const QString &name, const QString &type, bool 
     item->setData(nameT, Qt::DisplayRole);
     item->setData(typeT, Qt::ToolTipRole);
     if (success) {
+        DLOG << "Setting StatusTipRole to 0 for success";
         item->setData(0, Qt::StatusTipRole);
     } else {
+        DLOG << "Setting StatusTipRole to 1 for failure";
         item->setData(1, Qt::StatusTipRole);
     }
 
@@ -197,12 +208,14 @@ void ResultWindow::changeTheme(int theme)
     DLOG << "Changing theme to:" << (theme == 1 ? "Light" : "Dark");
 
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".ResultWindow{background-color: rgba(0, 0, 0, 0.08);"
                       "border-radius: 10px;"
                       "padding: 10px 5px 10px 0px;"
                       "}");
     } else {
         // dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".ResultWindow{background-color: rgba(255,255,255, 0.08);"
                       "border-radius: 10px;"
                       "padding: 10px 5px 10px 0px;"

--- a/src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp
+++ b/src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp
@@ -67,6 +67,7 @@ void WaitTransferWidget::initUI()
     mainLayout->addLayout(buttonLayout);
     mainLayout->addSpacing(10);
     mainLayout->addLayout(indexLayout);
+    DLOG << "UI initialization complete";
 }
 
 void WaitTransferWidget::nextPage()
@@ -90,9 +91,11 @@ void WaitTransferWidget::themeChanged(int theme)
 
     //light
     if (theme == 1) {
+        DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".WaitTransferWidget{background-color: white; border-radius: 10px;}");
     } else {
         //dark
+        DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".WaitTransferWidget{background-color: rgb(37, 37, 37); border-radius: 10px;}");
     }
 }
@@ -120,6 +123,8 @@ void WaitTransferWidget::cancel()
         DLOG << "User confirmed cancel, disconnecting";
         backPage();
         TransferHelper::instance()->disconnectRemote();
+    } else {
+        DLOG << "User cancelled dialog, not disconnecting";
     }
 }
 

--- a/src/lib/data-transfer/core/gui/type_defines.cpp
+++ b/src/lib/data-transfer/core/gui/type_defines.cpp
@@ -46,12 +46,17 @@ void ButtonLayout::setCount(int count)
 
     switch (count) {
     case 1:
+        DLOG << "Setting button count to 1, hiding button2";
         button1->setFixedSize(250, 36);
         button2->setVisible(false);
         break;
     case 2:
+        DLOG << "Setting button count to 2, showing button2";
         button1->setFixedSize(120, 36);
         button2->setVisible(true);
+        break;
+    default:
+        DLOG << "Unknown button count:" << count;
         break;
     }
 }
@@ -71,17 +76,21 @@ QFont StyleHelper::font(int type)
     QFont font;
     switch (type) {
     case 1:
+        DLOG << "Font type 1: pixel size 24, demi-bold";
         font.setPixelSize(24);
         font.setWeight(QFont::DemiBold);
         break;
     case 2:
+        DLOG << "Font type 2: pixel size 17, demi-bold";
         font.setPixelSize(17);
         font.setWeight(QFont::DemiBold);
         break;
     case 3:
+        DLOG << "Font type 3: pixel size 12";
         font.setPixelSize(12);
         break;
     default:
+        DLOG << "Unknown font type:" << type;
         break;
     }
     return font;
@@ -92,32 +101,41 @@ void StyleHelper::setAutoFont(QWidget *widget, int size, int weight)
 #ifdef linux
     switch (size) {
     case 54:
+        DLOG << "Setting font size 54 (T1)";
         DFontSizeManager::instance()->setFontPixelSize(DFontSizeManager::T1, 54);
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T1, weight);
         break;
     case 24:
+        DLOG << "Setting font size 24 (T3)";
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T3, weight);
         break;
     case 17:
+        DLOG << "Setting font size 17 (T5)";
         DFontSizeManager::instance()->setFontPixelSize(DFontSizeManager::T5, 17);
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T5, weight);
         break;
     case 14:
+        DLOG << "Setting font size 14 (T6)";
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T6, weight);
         break;
     case 12:
+        DLOG << "Setting font size 12 (T8)";
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T8, weight);
         break;
     case 11:
+        DLOG << "Setting font size 11 (T9)";
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T9, weight);
         break;
     case 10:
+        DLOG << "Setting font size 10 (T10)";
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T10, weight);
         break;
     default:
+        DLOG << "Setting default font size (T6)";
         DFontSizeManager::instance()->bind(widget, DFontSizeManager::T6, weight);
     }
 #else
+    DLOG << "Non-Linux platform, setting font directly";
     QFont font;
     font.setPixelSize(size);
     font.setWeight(weight);
@@ -130,10 +148,15 @@ QString StyleHelper::textStyle(StyleHelper::TextStyle type)
     QString style;
     switch (type) {
     case normal:
+        DLOG << "Text style: normal";
         style = "color: #000000; font-size: 12px;";
         break;
     case error:
+        DLOG << "Text style: error";
         style = "color: #FF5736;";
+        break;
+    default:
+        DLOG << "Unknown text style:" << type;
         break;
     }
     return style;
@@ -144,6 +167,7 @@ QString StyleHelper::buttonStyle(int type)
     QString style;
     switch (type) {
     case gray:
+        DLOG << "Button style: gray";
         style = ".QPushButton{"
                 "border-radius: 8px;"
                 "opacity: 1;"
@@ -170,6 +194,7 @@ QString StyleHelper::buttonStyle(int type)
                 "}";
         break;
     case blue:
+        DLOG << "Button style: blue";
         style = ".QPushButton{"
                 "border-radius: 8px;"
                 "opacity: 1;"
@@ -183,6 +208,9 @@ QString StyleHelper::buttonStyle(int type)
                 "text-align: center;"
                 "}";
         break;
+    default:
+        DLOG << "Unknown button style:" << type;
+        break;
     }
     return style;
 }
@@ -192,6 +220,7 @@ QString StyleHelper::textBrowserStyle(int type)
     QString style;
     switch (type) {
     case 1:
+        DLOG << "Text browser style: type 1 (light)";
         style = "QTextBrowser {"
                 "border-radius: 10px;"
                 "padding-top: 10px;"
@@ -205,6 +234,7 @@ QString StyleHelper::textBrowserStyle(int type)
                 "background-color:rgba(0, 0, 0,0.08);}";
         break;
     case 0:
+        DLOG << "Text browser style: type 0 (dark)";
         style = "QTextBrowser {"
                 "border-radius: 10px;"
                 "padding-top: 10px;"
@@ -216,6 +246,9 @@ QString StyleHelper::textBrowserStyle(int type)
                 "color: rgb(82, 106, 127);"
                 "line-height: 300%;"
                 "background-color:rgba(255,255,255, 0.1);}";
+        break;
+    default:
+        DLOG << "Unknown text browser style type:" << type;
         break;
     }
     return style;
@@ -245,10 +278,13 @@ void IndexLabel::paintEvent(QPaintEvent *event)
     QColor brushColor;
     brushColor.setNamedColor("#0081FF");
     for (int i = 0; i < 4; i++) {
-        if (i == index)
+        if (i == index) {
+            // DLOG << "Setting brush color alpha to 190 for index:" << i;
             brushColor.setAlpha(190);
-        else
+        } else {
+            // DLOG << "Setting brush color alpha to 40 for index:" << i;
             brushColor.setAlpha(40);
+        }
 
         painter.setBrush(brushColor);
         painter.drawEllipse((diam + 8) * i + 6, 0, diam, diam);
@@ -352,13 +388,16 @@ void ProcessWindowItemDelegate::paintText(QPainter *painter, const QStyleOptionV
     QColor fontNameColor;
     QColor fontStageColor;
     if (theme == 0) {
+        // DLOG << "Theme is dark, setting font colors for dark theme";
         fontNameColor = QColor(255, 255, 255, 155);
         fontStageColor = QColor(123, 159, 191, 255);
     } else {
+        // DLOG << "Theme is light, setting font colors for light theme";
         fontNameColor = QColor(0, 0, 0, 155);
         fontStageColor = QColor(0, 130, 250, 100);
     }
     if (StatusTipRole != 0) {
+        // DLOG << "StatusTipRole is not 0, setting fontStageColor to stageTextColor";
         fontStageColor = stageTextColor;
     }
 #ifdef linux
@@ -374,8 +413,10 @@ void ProcessWindowItemDelegate::paintText(QPainter *painter, const QStyleOptionV
 
     QRect remarkTextPos;
     if (!pixmaps.isEmpty()) {
+        // DLOG << "Pixmaps is not empty, adjusting remarkTextPos";
         remarkTextPos = option.rect.adjusted(40, 0, 0, 0);
     } else {
+        // DLOG << "Pixmaps is empty, adjusting remarkTextPos";
         remarkTextPos = option.rect.adjusted(20, 0, 0, 0);
     }
     painter->drawText(remarkTextPos, Qt::AlignLeft | Qt::AlignVCenter, processName);
@@ -394,8 +435,10 @@ void ProcessWindowItemDelegate::paintText(QPainter *painter, const QStyleOptionV
 void ProcessWindowItemDelegate::paintIcon(QPainter *painter, const QStyleOptionViewItem &option,
                                           const QModelIndex &index) const
 {
-    if (pixmaps.isEmpty())
+    if (pixmaps.isEmpty()) {
+        // DLOG << "Pixmaps is empty, returning";
         return;
+    }
 
     painter->save();
     int num = index.data(Qt::UserRole).toInt();

--- a/src/lib/data-transfer/quazip/compressutil.cpp
+++ b/src/lib/data-transfer/quazip/compressutil.cpp
@@ -7,71 +7,104 @@
 
 static bool copyData(QIODevice &inFile, QIODevice &outFile)
 {
+    qInfo() << "Copying data between IODevices";
     while (!inFile.atEnd()) {
         char buf[4096];
         qint64 readLen = inFile.read(buf, 4096);
-        if (readLen <= 0)
+        if (readLen <= 0) {
+            qInfo() << "read file failed";
             return false;
-        if (outFile.write(buf, readLen) != readLen)
+        }
+        if (outFile.write(buf, readLen) != readLen) {
+            qInfo() << "write file failed";
             return false;
+        }
     }
     return true;
 }
 
 bool CompressUtil::compressFile(QuaZip* zip, QString fileName, QString fileDest) {
+    qInfo() << "Compressing file:" << fileName << "to destination:" << fileDest;
     // zip: oggetto dove aggiungere il file
     // fileName: nome del file reale
     // fileDest: nome del file all'interno del file compresso
 
     // Controllo l'apertura dello zip
-    if (!zip) return false;
+    if (!zip) {
+        qInfo() << "zip is null";
+        return false;
+    }
     if (zip->getMode()!=QuaZip::mdCreate &&
         zip->getMode()!=QuaZip::mdAppend &&
-        zip->getMode()!=QuaZip::mdAdd) return false;
+        zip->getMode()!=QuaZip::mdAdd) {
+        qInfo() << "zip mode is not create, append or add";
+        return false;
+    }
 
     // Apro il file originale
     QFile inFile;
     inFile.setFileName(fileName);
-    if(!inFile.open(QIODevice::ReadOnly)) return false;
+    if(!inFile.open(QIODevice::ReadOnly)) {
+        qInfo() << "open file failed:" << fileName;
+        return false;
+    }
 
     // Apro il file risulato
     QuaZipFile outFile(zip);
-    if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(fileDest, inFile.fileName()))) return false;
+    if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(fileDest, inFile.fileName()))) {
+        qInfo() << "open quazip file failed:" << fileDest;
+        return false;
+    }
 
     // Copio i dati
     if (!copyData(inFile, outFile) || outFile.getZipError()!=UNZ_OK) {
+        qInfo() << "copy data failed, error:" << outFile.getZipError();
         return false;
     }
 
     // Chiudo i file
     outFile.close();
-    if (outFile.getZipError()!=UNZ_OK) return false;
+    if (outFile.getZipError()!=UNZ_OK) {
+        qInfo() << "close quazip file failed, error:" << outFile.getZipError();
+        return false;
+    }
     inFile.close();
 
     return true;
 }
 
 bool CompressUtil::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool recursive, QDir::Filters filters) {
+    qInfo() << "Compressing sub-directory:" << dir << "original base:" << origDir << "recursive:" << recursive;
     // zip: oggetto dove aggiungere il file
     // dir: cartella reale corrente
     // origDir: cartella reale originale
     // (path(dir)-path(origDir)) = path interno all'oggetto zip
 
     // Controllo l'apertura dello zip
-    if (!zip) return false;
+    if (!zip) {
+        qInfo() << "zip is null";
+        return false;
+    }
     if (zip->getMode()!=QuaZip::mdCreate &&
         zip->getMode()!=QuaZip::mdAppend &&
-        zip->getMode()!=QuaZip::mdAdd) return false;
+        zip->getMode()!=QuaZip::mdAdd) {
+        qInfo() << "zip mode is not create, append or add";
+        return false;
+    }
 
     // Controllo la cartella
     QDir directory(dir);
-    if (!directory.exists()) return false;
+    if (!directory.exists()) {
+        qInfo() << "directory not exists:" << dir;
+        return false;
+    }
 
     QDir origDirectory(origDir);
 	if (dir != origDir) {
 		QuaZipFile dirZipFile(zip);
 		if (!dirZipFile.open(QIODevice::WriteOnly,
 			QuaZipNewInfo(origDirectory.relativeFilePath(dir) + "/", dir), 0, 0, 0)) {
+                qInfo() << "open quazip file failed!";
 				return false;
 		}
 		dirZipFile.close();
@@ -84,7 +117,10 @@ bool CompressUtil::compressSubDir(QuaZip* zip, QString dir, QString origDir, boo
         QFileInfoList files = directory.entryInfoList(QDir::AllDirs|QDir::NoDotAndDotDot|filters);
         Q_FOREACH (QFileInfo file, files) {
             // Comprimo la sotto cartella
-            if(!compressSubDir(zip,file.absoluteFilePath(),origDir,recursive,filters)) return false;
+            if(!compressSubDir(zip,file.absoluteFilePath(),origDir,recursive,filters)) {
+                qInfo() << "compress sub dir failed!";
+                return false;
+            }
         }
     }
 
@@ -92,48 +128,70 @@ bool CompressUtil::compressSubDir(QuaZip* zip, QString dir, QString origDir, boo
     QFileInfoList files = directory.entryInfoList(QDir::Files|filters);
     Q_FOREACH (QFileInfo file, files) {
         // Se non e un file o e il file compresso che sto creando
-        if(!file.isFile()||file.absoluteFilePath()==zip->getZipName()) continue;
+        if(!file.isFile()||file.absoluteFilePath()==zip->getZipName()) {
+            qInfo() << "file is not a file or is the zip file itself";
+            continue;
+        }
 
         // Creo il nome relativo da usare all'interno del file compresso
         QString filename = origDirectory.relativeFilePath(file.absoluteFilePath());
 
         // Comprimo il file
-        if (!compressFile(zip,file.absoluteFilePath(),filename)) return false;
+        if (!compressFile(zip,file.absoluteFilePath(),filename)) {
+            qInfo() << "compress file failed!";
+            return false;
+        }
     }
 
     return true;
 }
 
 bool CompressUtil::extractFile(QuaZip* zip, QString fileName, QString fileDest) {
+    qInfo() << "Extracting file:" << fileName << "to destination:" << fileDest;
     // zip: oggetto dove aggiungere il file
     // filename: nome del file reale
     // fileincompress: nome del file all'interno del file compresso
 
     // Controllo l'apertura dello zip
-    if (!zip) return false;
-    if (zip->getMode()!=QuaZip::mdUnzip) return false;
+    if (!zip) {
+        qInfo() << "zip is null";
+        return false;
+    }
+    if (zip->getMode()!=QuaZip::mdUnzip) {
+        qInfo() << "zip mode is not unzip";
+        return false;
+    }
 
     // Apro il file compresso
-    if (!fileName.isEmpty())
+    if (!fileName.isEmpty()) {
+        qInfo() << "set current file:" << fileName;
         zip->setCurrentFile(fileName);
+    }
     QuaZipFile inFile(zip);
-    if(!inFile.open(QIODevice::ReadOnly) || inFile.getZipError()!=UNZ_OK) return false;
+    if(!inFile.open(QIODevice::ReadOnly) || inFile.getZipError()!=UNZ_OK) {
+        qInfo() << "open quazip file failed, error:" << inFile.getZipError();
+        return false;
+    }
 
     // Controllo esistenza cartella file risultato
     QDir curDir;
     if (fileDest.endsWith('/')) {
         if (!curDir.mkpath(fileDest)) {
+            qInfo() << "mkpath failed:" << fileDest;
             return false;
         }
     } else {
         if (!curDir.mkpath(QFileInfo(fileDest).absolutePath())) {
+            qInfo() << "mkpath failed:" << QFileInfo(fileDest).absolutePath();
             return false;
         }
     }
 
     QuaZipFileInfo64 info;
-    if (!zip->getCurrentFileInfo(&info))
+    if (!zip->getCurrentFileInfo(&info)) {
+        qInfo() << "get current file info failed";
         return false;
+    }
 
     QFile::Permissions srcPerm = info.getPermissions();
     if (fileDest.endsWith('/') && QFileInfo(fileDest).isDir()) {
@@ -146,10 +204,14 @@ bool CompressUtil::extractFile(QuaZip* zip, QString fileName, QString fileDest) 
     // Apro il file risultato
     QFile outFile;
     outFile.setFileName(fileDest);
-    if(!outFile.open(QIODevice::WriteOnly)) return false;
+    if(!outFile.open(QIODevice::WriteOnly)) {
+        qInfo() << "open file failed:" << fileDest;
+        return false;
+    }
 
     // Copio i dati
     if (!copyData(inFile, outFile) || inFile.getZipError()!=UNZ_OK) {
+        qInfo() << "copy data failed, error:" << inFile.getZipError();
         outFile.close();
         removeFile(QStringList(fileDest));
         return false;
@@ -159,6 +221,7 @@ bool CompressUtil::extractFile(QuaZip* zip, QString fileName, QString fileDest) 
     // Chiudo i file
     inFile.close();
     if (inFile.getZipError()!=UNZ_OK) {
+        qInfo() << "close quazip file failed, error:" << inFile.getZipError();
         removeFile(QStringList(fileDest));
         return false;
     }
@@ -170,6 +233,7 @@ bool CompressUtil::extractFile(QuaZip* zip, QString fileName, QString fileDest) 
 }
 
 bool CompressUtil::removeFile(QStringList listFile) {
+    qInfo() << "Removing files:" << listFile.size();
     bool ret = true;
     // Per ogni file
     for (int i=0; i<listFile.count(); i++) {
@@ -180,16 +244,19 @@ bool CompressUtil::removeFile(QStringList listFile) {
 }
 
 bool CompressUtil::compressFile(QString fileCompressed, QString file) {
+    qInfo() << "Compressing single file:" << file << "into new archive:" << fileCompressed;
     // Creo lo zip
     QuaZip zip(fileCompressed);
     QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
     if(!zip.open(QuaZip::mdCreate)) {
+        qInfo() << "open quazip file failed:" << fileCompressed;
         QFile::remove(fileCompressed);
         return false;
     }
 
     // Aggiungo il file
     if (!compressFile(&zip,file,QFileInfo(file).fileName())) {
+        qInfo() << "compress file failed:" << file;
         QFile::remove(fileCompressed);
         return false;
     }
@@ -197,6 +264,7 @@ bool CompressUtil::compressFile(QString fileCompressed, QString file) {
     // Chiudo il file zip
     zip.close();
     if(zip.getZipError()!=0) {
+        qInfo() << "close quazip file failed, error:" << zip.getZipError();
         QFile::remove(fileCompressed);
         return false;
     }
@@ -205,10 +273,12 @@ bool CompressUtil::compressFile(QString fileCompressed, QString file) {
 }
 
 bool CompressUtil::compressFiles(QString fileCompressed, QStringList files) {
+    qInfo() << "Compressing multiple files into new archive:" << fileCompressed;
     // Creo lo zip
     QuaZip zip(fileCompressed);
     QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
     if(!zip.open(QuaZip::mdCreate)) {
+        qInfo() << "open quazip file failed:" << fileCompressed;
         QFile::remove(fileCompressed);
         return false;
     }
@@ -218,6 +288,7 @@ bool CompressUtil::compressFiles(QString fileCompressed, QStringList files) {
     Q_FOREACH (QString file, files) {
         info.setFile(file);
         if (!info.exists() || !compressFile(&zip,file,info.fileName())) {
+            // qInfo() << "compress file failed:" << file;
             QFile::remove(fileCompressed);
             return false;
         }
@@ -226,6 +297,7 @@ bool CompressUtil::compressFiles(QString fileCompressed, QStringList files) {
     // Chiudo il file zip
     zip.close();
     if(zip.getZipError()!=0) {
+        qInfo() << "close quazip file failed, error:" << zip.getZipError();
         QFile::remove(fileCompressed);
         return false;
     }
@@ -234,22 +306,26 @@ bool CompressUtil::compressFiles(QString fileCompressed, QStringList files) {
 }
 
 bool CompressUtil::compressDir(QString fileCompressed, QString dir, bool recursive) {
+    qInfo() << "Compressing directory";
     return compressDir(fileCompressed, dir, recursive, QDir::NoFilter);
 }
 
 bool CompressUtil::compressDir(QString fileCompressed, QString dir,
                              bool recursive, QDir::Filters filters)
 {
+    qInfo() << "Compressing directory with filters:" << dir << "into new archive:" << fileCompressed << "recursive:" << recursive;
     // Creo lo zip
     QuaZip zip(fileCompressed);
     QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
     if(!zip.open(QuaZip::mdCreate)) {
+        qInfo() << "open quazip file failed:" << fileCompressed;
         QFile::remove(fileCompressed);
         return false;
     }
 
     // Aggiungo i file e le sotto cartelle
     if (!compressSubDir(&zip,dir,dir,recursive, filters)) {
+        qInfo() << "compress sub dir failed:" << dir;
         QFile::remove(fileCompressed);
         return false;
     }
@@ -257,6 +333,7 @@ bool CompressUtil::compressDir(QString fileCompressed, QString dir,
     // Chiudo il file zip
     zip.close();
     if(zip.getZipError()!=0) {
+        qInfo() << "close quazip file failed, error:" << zip.getZipError();
         QFile::remove(fileCompressed);
         return false;
     }
@@ -265,6 +342,7 @@ bool CompressUtil::compressDir(QString fileCompressed, QString dir,
 }
 
 QString CompressUtil::extractFile(QString fileCompressed, QString fileName, QString fileDest) {
+    qInfo() << "Extracting file:" << fileName << "from archive:" << fileCompressed << "to:" << fileDest;
     // Apro lo zip
     QuaZip zip(fileCompressed);
     return extractFile(zip, fileName, fileDest);
@@ -272,7 +350,9 @@ QString CompressUtil::extractFile(QString fileCompressed, QString fileName, QStr
 
 QString CompressUtil::extractFile(QuaZip &zip, QString fileName, QString fileDest)
 {
+    qInfo() << "Extracting file:" << fileName << "to:" << fileDest << "using existing QuaZip object";
     if(!zip.open(QuaZip::mdUnzip)) {
+        qInfo() << "open quazip file failed";
         return QString();
     }
 
@@ -280,12 +360,14 @@ QString CompressUtil::extractFile(QuaZip &zip, QString fileName, QString fileDes
     if (fileDest.isEmpty())
         fileDest = fileName;
     if (!extractFile(&zip,fileName,fileDest)) {
+        qInfo() << "extract file failed:" << fileName;
         return QString();
     }
 
     // Chiudo il file zip
     zip.close();
     if(zip.getZipError()!=0) {
+        qInfo() << "close quazip file failed, error:" << zip.getZipError();
         removeFile(QStringList(fileDest));
         return QString();
     }
@@ -293,6 +375,7 @@ QString CompressUtil::extractFile(QuaZip &zip, QString fileName, QString fileDes
 }
 
 QStringList CompressUtil::extractFiles(QString fileCompressed, QStringList files, QString dir) {
+    qInfo() << "Extracting multiple files from archive:" << fileCompressed << "to directory:" << dir;
     // Creo lo zip
     QuaZip zip(fileCompressed);
     return extractFiles(zip, files, dir);
@@ -300,7 +383,9 @@ QStringList CompressUtil::extractFiles(QString fileCompressed, QStringList files
 
 QStringList CompressUtil::extractFiles(QuaZip &zip, const QStringList &files, const QString &dir)
 {
+    qInfo() << "Extracting multiple files to directory:" << dir << "using existing QuaZip object";
     if(!zip.open(QuaZip::mdUnzip)) {
+        qInfo() << "open quazip file failed";
         return QStringList();
     }
 
@@ -309,6 +394,7 @@ QStringList CompressUtil::extractFiles(QuaZip &zip, const QStringList &files, co
     for (int i=0; i<files.count(); i++) {
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
         if (!extractFile(&zip, files.at(i), absPath)) {
+            // qInfo() << "extract file failed:" << files.at(i);
             removeFile(extracted);
             return QStringList();
         }
@@ -318,6 +404,7 @@ QStringList CompressUtil::extractFiles(QuaZip &zip, const QStringList &files, co
     // Chiudo il file zip
     zip.close();
     if(zip.getZipError()!=0) {
+        qInfo() << "close quazip file failed, error:" << zip.getZipError();
         removeFile(extracted);
         return QStringList();
     }
@@ -326,6 +413,7 @@ QStringList CompressUtil::extractFiles(QuaZip &zip, const QStringList &files, co
 }
 
 QStringList CompressUtil::extractDir(QString fileCompressed, QString dir) {
+    qInfo() << "Extracting entire directory from archive:" << fileCompressed << "to:" << dir;
     // Apro lo zip
     QuaZip zip(fileCompressed);
     return extractDir(zip, dir);
@@ -333,19 +421,23 @@ QStringList CompressUtil::extractDir(QString fileCompressed, QString dir) {
 
 QStringList CompressUtil::extractDir(QuaZip &zip, const QString &dir)
 {
+    qInfo() << "Extracting entire directory to:" << dir << "using existing QuaZip object";
     if(!zip.open(QuaZip::mdUnzip)) {
+        qInfo() << "open quazip file failed";
         return QStringList();
     }
 
     QDir directory(dir);
     QStringList extracted;
     if (!zip.goToFirstFile()) {
+        qInfo() << "go to first file failed";
         return QStringList();
     }
     do {
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         if (!extractFile(&zip, "", absFilePath)) {
+            qInfo() << "extract file failed:" << name;
             removeFile(extracted);
             return QStringList();
         }
@@ -355,6 +447,7 @@ QStringList CompressUtil::extractDir(QuaZip &zip, const QString &dir)
     // Chiudo il file zip
     zip.close();
     if(zip.getZipError()!=0) {
+        qInfo() << "close quazip file failed, error:" << zip.getZipError();
         removeFile(extracted);
         return QStringList();
     }
@@ -363,6 +456,7 @@ QStringList CompressUtil::extractDir(QuaZip &zip, const QString &dir)
 }
 
 QStringList CompressUtil::getFileList(QString fileCompressed) {
+    qInfo() << "Getting file list from archive:" << fileCompressed;
     // Apro lo zip
     QuaZip* zip = new QuaZip(QFileInfo(fileCompressed).absoluteFilePath());
     return getFileList(zip);
@@ -370,7 +464,9 @@ QStringList CompressUtil::getFileList(QString fileCompressed) {
 
 QStringList CompressUtil::getFileList(QuaZip *zip)
 {
+    qInfo() << "Getting file list using existing QuaZip object";
     if(!zip->open(QuaZip::mdUnzip)) {
+        qInfo() << "open quazip file failed";
         delete zip;
         return QStringList();
     }
@@ -380,6 +476,7 @@ QStringList CompressUtil::getFileList(QuaZip *zip)
     QuaZipFileInfo64 info;
     for(bool more=zip->goToFirstFile(); more; more=zip->goToNextFile()) {
       if(!zip->getCurrentFileInfo(&info)) {
+          qInfo() << "get current file info failed";
           delete zip;
           return QStringList();
       }
@@ -390,6 +487,7 @@ QStringList CompressUtil::getFileList(QuaZip *zip)
     // Chiudo il file zip
     zip->close();
     if(zip->getZipError()!=0) {
+        qInfo() << "close quazip file failed, error:" << zip->getZipError();
         delete zip;
         return QStringList();
     }
@@ -399,24 +497,28 @@ QStringList CompressUtil::getFileList(QuaZip *zip)
 
 QStringList CompressUtil::extractDir(QIODevice *ioDevice, QString dir)
 {
+    qInfo() << "Extracting directory from IODevice to:" << dir;
     QuaZip zip(ioDevice);
     return extractDir(zip, dir);
 }
 
 QStringList CompressUtil::getFileList(QIODevice *ioDevice)
 {
+    qInfo() << "Getting file list from IODevice";
     QuaZip *zip = new QuaZip(ioDevice);
     return getFileList(zip);
 }
 
 QString CompressUtil::extractFile(QIODevice *ioDevice, QString fileName, QString fileDest)
 {
+    qInfo() << "Extracting file from IODevice, source:" << fileName << "dest:" << fileDest;
     QuaZip zip(ioDevice);
     return extractFile(zip, fileName, fileDest);
 }
 
 QStringList CompressUtil::extractFiles(QIODevice *ioDevice, QStringList files, QString dir)
 {
+    qInfo() << "Extracting multiple files from IODevice to directory:" << dir;
     QuaZip zip(ioDevice);
     return extractFiles(zip, files, dir);
 }

--- a/src/lib/data-transfer/quazip/qioapi.cpp
+++ b/src/lib/data-transfer/quazip/qioapi.cpp
@@ -10,6 +10,7 @@
 #include "ioapi.h"
 #include "exportdefine.h"
 #include <QIODevice>
+#include <QDebug>
 #if (QT_VERSION >= 0x050100)
 #define QSAVEFILE_BUG_WORKAROUND
 #endif
@@ -33,39 +34,49 @@
 
 voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,voidpf file,int mode)
 {
-    if (pfilefunc->zfile_func64.zopen64_file != NULL)
+    qInfo() << "Entering call_zopen64, mode:" << mode;
+    if (pfilefunc->zfile_func64.zopen64_file != NULL) {
+        qInfo() << "calling zopen64_file";
         return (*(pfilefunc->zfile_func64.zopen64_file)) (pfilefunc->zfile_func64.opaque,file,mode);
-    else
-    {
+    } else {
+        qInfo() << "calling zopen32_file";
         return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque,file,mode);
     }
 }
 
 int call_zseek64 (const zlib_filefunc64_32_def* pfilefunc,voidpf filestream, ZPOS64_T offset, int origin)
 {
-    if (pfilefunc->zfile_func64.zseek64_file != NULL)
+    qInfo() << "Entering call_zseek64, offset:" << offset << "origin:" << origin;
+    if (pfilefunc->zfile_func64.zseek64_file != NULL) {
+        qInfo() << "calling zseek64_file";
         return (*(pfilefunc->zfile_func64.zseek64_file)) (pfilefunc->zfile_func64.opaque,filestream,offset,origin);
-    else
-    {
+    } else {
         uLong offsetTruncated = (uLong)offset;
-        if (offsetTruncated != offset)
+        if (offsetTruncated != offset) {
+            qInfo() << "offset truncated";
             return -1;
-        else
+        } else {
+            qInfo() << "calling zseek32_file";
             return (*(pfilefunc->zseek32_file))(pfilefunc->zfile_func64.opaque,filestream,offsetTruncated,origin);
+        }
     }
 }
 
 ZPOS64_T call_ztell64 (const zlib_filefunc64_32_def* pfilefunc,voidpf filestream)
 {
-    if (pfilefunc->zfile_func64.zseek64_file != NULL)
+    qInfo() << "Entering call_ztell64";
+    if (pfilefunc->zfile_func64.zseek64_file != NULL) {
+        qInfo() << "calling ztell64_file";
         return (*(pfilefunc->zfile_func64.ztell64_file)) (pfilefunc->zfile_func64.opaque,filestream);
-    else
-    {
+    } else {
+        qInfo() << "calling ztell32_file";
         uLong tell_uLong = (*(pfilefunc->ztell32_file))(pfilefunc->zfile_func64.opaque,filestream);
-        if ((tell_uLong) == ((uLong)-1))
+        if ((tell_uLong) == ((uLong)-1)) {
+            qInfo() << "ztell32_file failed";
             return (ZPOS64_T)-1;
-        else
+        } else {
             return tell_uLong;
+        }
     }
 }
 
@@ -84,42 +95,57 @@ voidpf ZCALLBACK qiodevice_open_file_func (
    voidpf file,
    int mode)
 {
+    qInfo() << "qiodevice_open_file_func, mode:" << mode;
     QIODevice_descriptor *d = reinterpret_cast<QIODevice_descriptor*>(opaque);
     QIODevice *iodevice = reinterpret_cast<QIODevice*>(file);
     QIODevice::OpenMode desiredMode;
-    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ) {
+        qInfo() << "mode is ReadOnly";
         desiredMode = QIODevice::ReadOnly;
-    else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+    } else if (mode & ZLIB_FILEFUNC_MODE_EXISTING) {
+        qInfo() << "mode is ReadWrite";
         desiredMode = QIODevice::ReadWrite;
-    else if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+    } else if (mode & ZLIB_FILEFUNC_MODE_CREATE) {
+        qInfo() << "mode is WriteOnly";
         desiredMode = QIODevice::WriteOnly;
+    }
     if (iodevice->isOpen()) {
+        qInfo() << "iodevice is already open";
         if ((iodevice->openMode() & desiredMode) == desiredMode) {
+            qInfo() << "iodevice open mode is compatible";
             if (desiredMode != QIODevice::WriteOnly
                     && iodevice->isSequential()) {
                 // We can use sequential devices only for writing.
+                qInfo() << "sequential device can not be read";
                 delete d;
                 return NULL;
             } else {
                 if ((desiredMode & QIODevice::WriteOnly) != 0) {
+                    qInfo() << "open for writing, seeking to 0";
                     // open for writing, need to seek existing device
                     if (!iodevice->isSequential()) {
+                        qInfo() << "not sequential, seeking to 0";
                         iodevice->seek(0);
                     } else {
+                        qInfo() << "sequential, saving pos";
                         d->pos = iodevice->pos();
                     }
                 }
             }
             return iodevice;
         } else {
+            qInfo() << "iodevice open mode is not compatible";
             delete d;
             return NULL;
         }
     }
+    qInfo() << "iodevice is not open, opening with desired mode";
     iodevice->open(desiredMode);
     if (iodevice->isOpen()) {
+        qInfo() << "iodevice opened successfully";
         if (desiredMode != QIODevice::WriteOnly && iodevice->isSequential()) {
             // We can use sequential devices only for writing.
+            qInfo() << "sequential device can not be read";
             iodevice->close();
             delete d;
             return NULL;
@@ -127,6 +153,7 @@ voidpf ZCALLBACK qiodevice_open_file_func (
             return iodevice;
         }
     } else {
+        qInfo() << "iodevice open failed";
         delete d;
         return NULL;
     }
@@ -139,6 +166,7 @@ uLong ZCALLBACK qiodevice_read_file_func (
    void* buf,
    uLong size)
 {
+    qInfo() << "qiodevice_read_file_func, requested size:" << size;
     QIODevice_descriptor *d = reinterpret_cast<QIODevice_descriptor*>(opaque);
     QIODevice *iodevice = reinterpret_cast<QIODevice*>(stream);
     qint64 ret64 = iodevice->read((char*)buf,size);
@@ -146,6 +174,8 @@ uLong ZCALLBACK qiodevice_read_file_func (
     ret = (uLong) ret64;
     if (ret64 != -1) {
         d->pos += ret64;
+    } else {
+        qInfo() << "read failed";
     }
     return ret;
 }
@@ -157,12 +187,15 @@ uLong ZCALLBACK qiodevice_write_file_func (
    const void* buf,
    uLong size)
 {
+    qInfo() << "qiodevice_write_file_func, requested size:" << size;
     QIODevice_descriptor *d = reinterpret_cast<QIODevice_descriptor*>(opaque);
     QIODevice *iodevice = reinterpret_cast<QIODevice*>(stream);
     uLong ret;
     qint64 ret64 = iodevice->write((char*)buf,size);
     if (ret64 != -1) {
         d->pos += ret64;
+    } else {
+        qInfo() << "write failed";
     }
     ret = (uLong) ret64;
     return ret;
@@ -172,13 +205,16 @@ uLong ZCALLBACK qiodevice_tell_file_func (
    voidpf opaque,
    voidpf stream)
 {
+    qInfo() << "qiodevice_tell_file_func (32-bit)";
     QIODevice_descriptor *d = reinterpret_cast<QIODevice_descriptor*>(opaque);
     QIODevice *iodevice = reinterpret_cast<QIODevice*>(stream);
     uLong ret;
     qint64 ret64;
     if (iodevice->isSequential()) {
+        qInfo() << "device is sequential";
         ret64 = d->pos;
     } else {
+        qInfo() << "device is not sequential";
         ret64 = iodevice->pos();
     }
     ret = static_cast<uLong>(ret64);
@@ -189,12 +225,15 @@ ZPOS64_T ZCALLBACK qiodevice64_tell_file_func (
    voidpf opaque,
    voidpf stream)
 {
+    qInfo() << "qiodevice64_tell_file_func (64-bit)";
     QIODevice_descriptor *d = reinterpret_cast<QIODevice_descriptor*>(opaque);
     QIODevice *iodevice = reinterpret_cast<QIODevice*>(stream);
     qint64 ret;
     if (iodevice->isSequential()) {
+        qInfo() << "device is sequential";
         ret = d->pos;
     } else {
+        qInfo() << "device is not sequential";
         ret = iodevice->pos();
     }
     return static_cast<ZPOS64_T>(ret);
@@ -206,14 +245,18 @@ int ZCALLBACK qiodevice_seek_file_func (
    uLong offset,
    int origin)
 {
+    qInfo() << "qiodevice_seek_file_func (32-bit), offset:" << offset << "origin:" << origin;
     QIODevice *iodevice = reinterpret_cast<QIODevice*>(stream);
     if (iodevice->isSequential()) {
+        qInfo() << "device is sequential";
         if (origin == ZLIB_FILEFUNC_SEEK_END
                 && offset == 0) {
             // sequential devices are always at end (needed in mdAppend)
+            qInfo() << "seeking to end of sequential device";
             return 0;
         } else {
             qWarning("qiodevice_seek_file_func() called for sequential device");
+            qInfo() << "can not seek on sequential device";
             return -1;
         }
     }
@@ -222,18 +265,23 @@ int ZCALLBACK qiodevice_seek_file_func (
     switch (origin)
     {
     case ZLIB_FILEFUNC_SEEK_CUR :
+        qInfo() << "seeking from current";
         qiodevice_seek_result = ((QIODevice*)stream)->pos() + offset;
         break;
     case ZLIB_FILEFUNC_SEEK_END :
+        qInfo() << "seeking from end";
         qiodevice_seek_result = ((QIODevice*)stream)->size() - offset;
         break;
     case ZLIB_FILEFUNC_SEEK_SET :
+        qInfo() << "seeking from set";
         qiodevice_seek_result = offset;
         break;
     default:
+        qInfo() << "invalid origin";
         return -1;
     }
     ret = !iodevice->seek(qiodevice_seek_result);
+    qInfo() << "seek result:" << ret;
     return ret;
 }
 
@@ -243,14 +291,18 @@ int ZCALLBACK qiodevice64_seek_file_func (
    ZPOS64_T offset,
    int origin)
 {
+    qInfo() << "qiodevice64_seek_file_func (64-bit), offset:" << offset << "origin:" << origin;
     QIODevice *iodevice = reinterpret_cast<QIODevice*>(stream);
     if (iodevice->isSequential()) {
+        qInfo() << "device is sequential";
         if (origin == ZLIB_FILEFUNC_SEEK_END
                 && offset == 0) {
             // sequential devices are always at end (needed in mdAppend)
+            qInfo() << "seeking to end of sequential device";
             return 0;
         } else {
             qWarning("qiodevice_seek_file_func() called for sequential device");
+            qInfo() << "can not seek on sequential device";
             return -1;
         }
     }
@@ -259,18 +311,23 @@ int ZCALLBACK qiodevice64_seek_file_func (
     switch (origin)
     {
     case ZLIB_FILEFUNC_SEEK_CUR :
+        qInfo() << "seeking from current";
         qiodevice_seek_result = ((QIODevice*)stream)->pos() + offset;
         break;
     case ZLIB_FILEFUNC_SEEK_END :
+        qInfo() << "seeking from end";
         qiodevice_seek_result = ((QIODevice*)stream)->size() - offset;
         break;
     case ZLIB_FILEFUNC_SEEK_SET :
+        qInfo() << "seeking from set";
         qiodevice_seek_result = offset;
         break;
     default:
+        qInfo() << "invalid origin";
         return -1;
     }
     ret = !iodevice->seek(qiodevice_seek_result);
+    qInfo() << "seek result:" << ret;
     return ret;
 }
 
@@ -278,6 +335,7 @@ int ZCALLBACK qiodevice_close_file_func (
    voidpf opaque,
    voidpf stream)
 {
+    qInfo() << "qiodevice_close_file_func";
     QIODevice_descriptor *d = reinterpret_cast<QIODevice_descriptor*>(opaque);
     delete d;
     QIODevice *device = reinterpret_cast<QIODevice*>(stream);
@@ -286,6 +344,7 @@ int ZCALLBACK qiodevice_close_file_func (
     // it IS a QIODevice, but it is NOT compatible with it: close() is private
     QSaveFile *file = qobject_cast<QSaveFile*>(device);
     if (file != NULL) {
+        qInfo() << "qsavefile bug workaround";
         // We have to call the ugly commit() instead:
         return file->commit() ? 0 : -1;
     }
@@ -298,6 +357,7 @@ int ZCALLBACK qiodevice_fakeclose_file_func (
    voidpf opaque,
    voidpf /*stream*/)
 {
+    qInfo() << "qiodevice_fakeclose_file_func";
     QIODevice_descriptor *d = reinterpret_cast<QIODevice_descriptor*>(opaque);
     delete d;
     return 0;
@@ -307,6 +367,7 @@ int ZCALLBACK qiodevice_error_file_func (
    voidpf /*opaque UNUSED*/,
    voidpf /*stream UNUSED*/)
 {
+    qInfo() << "qiodevice_error_file_func";
     // can't check for error due to the QIODevice API limitation
     return 0;
 }
@@ -314,6 +375,7 @@ int ZCALLBACK qiodevice_error_file_func (
 void fill_qiodevice_filefunc (
   zlib_filefunc_def* pzlib_filefunc_def)
 {
+    qInfo() << "fill_qiodevice_filefunc (32-bit)";
     pzlib_filefunc_def->zopen_file = qiodevice_open_file_func;
     pzlib_filefunc_def->zread_file = qiodevice_read_file_func;
     pzlib_filefunc_def->zwrite_file = qiodevice_write_file_func;
@@ -327,6 +389,7 @@ void fill_qiodevice_filefunc (
 void fill_qiodevice64_filefunc (
   zlib_filefunc64_def* pzlib_filefunc_def)
 {
+    qInfo() << "fill_qiodevice64_filefunc (64-bit)";
     // Open functions are the same for Qt.
     pzlib_filefunc_def->zopen64_file = qiodevice_open_file_func;
     pzlib_filefunc_def->zread_file = qiodevice_read_file_func;
@@ -341,6 +404,7 @@ void fill_qiodevice64_filefunc (
 
 void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def* p_filefunc64_32,const zlib_filefunc_def* p_filefunc32)
 {
+    qInfo() << "fill_zlib_filefunc64_32_def_from_filefunc32";
     p_filefunc64_32->zfile_func64.zopen64_file = NULL;
     p_filefunc64_32->zopen32_file = p_filefunc32->zopen_file;
     p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;

--- a/src/lib/data-transfer/quazip/quaadler32.cpp
+++ b/src/lib/data-transfer/quazip/quaadler32.cpp
@@ -5,28 +5,34 @@
 #include "quaadler32.h"
 
 #include "zlib.h"
+#include <QDebug>
 
 QuaAdler32::QuaAdler32()
 {
+    qInfo() << "Constructing QuaAdler32 object and resetting checksum";
 	reset();
 }
 
 quint32 QuaAdler32::calculate(const QByteArray &data)
 {
+    qInfo() << "Calculating static Adler-32 for data of size:" << data.size();
 	return adler32( adler32(0L, Z_NULL, 0), (const Bytef*)data.data(), data.size() );
 }
 
 void QuaAdler32::reset()
 {
+    qInfo() << "Resetting Adler-32 checksum to initial value";
 	checksum = adler32(0L, Z_NULL, 0);
 }
 
 void QuaAdler32::update(const QByteArray &buf)
 {
+    qInfo() << "Updating Adler-32 checksum with buffer of size:" << buf.size();
 	checksum = adler32( checksum, (const Bytef*)buf.data(), buf.size() );
 }
 
 quint32 QuaAdler32::value()
 {
+    qInfo() << "Getting current Adler-32 checksum value";
 	return checksum;
 }

--- a/src/lib/data-transfer/quazip/quacrc32.cpp
+++ b/src/lib/data-transfer/quazip/quacrc32.cpp
@@ -5,28 +5,34 @@
 #include "quacrc32.h"
 
 #include "zlib.h"
+#include <QDebug>
 
 QuaCrc32::QuaCrc32()
 {
+    qInfo() << "Constructing QuaCrc32 object and resetting checksum";
 	reset();
 }
 
 quint32 QuaCrc32::calculate(const QByteArray &data)
 {
+    qInfo() << "Calculating static CRC32 for data of size:" << data.size();
 	return crc32( crc32(0L, Z_NULL, 0), (const Bytef*)data.data(), data.size() );
 }
 
 void QuaCrc32::reset()
 {
+    qInfo() << "Resetting CRC32 checksum to initial value";
 	checksum = crc32(0L, Z_NULL, 0);
 }
 
 void QuaCrc32::update(const QByteArray &buf)
 {
+    qInfo() << "Updating CRC32 checksum with buffer of size:" << buf.size();
 	checksum = crc32( checksum, (const Bytef*)buf.data(), buf.size() );
 }
 
 quint32 QuaCrc32::value()
 {
+    qInfo() << "Getting current CRC32 checksum value";
 	return checksum;
 }

--- a/src/lib/data-transfer/quazip/quagzipfile.cpp
+++ b/src/lib/data-transfer/quazip/quagzipfile.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <QFile>
+#include <QDebug>
 
 #include "quagzipfile.h"
 
@@ -22,11 +23,13 @@ class QuaGzipFilePrivate {
 
 gzFile QuaGzipFilePrivate::open(const QString &name, const char *modeString)
 {
+    qInfo() << "Opening Gzip file by name:" << name << "with mode string:" << modeString;
     return gzopen(QFile::encodeName(name).constData(), modeString);
 }
 
 gzFile QuaGzipFilePrivate::open(int fd, const char *modeString)
 {
+    qInfo() << "Opening Gzip file by file descriptor:" << fd << "with mode string:" << modeString;
     return gzdopen(fd, modeString);
 }
 
@@ -34,17 +37,20 @@ template<typename FileId>
 bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode, 
                               QString &error)
 {
+    qInfo() << "Preparing to open Gzip file with mode:" << mode;
     char modeString[2];
     modeString[0] = modeString[1] = '\0';
     if ((mode & QIODevice::Append) != 0) {
         error = QuaGzipFile::tr("QIODevice::Append is not "
                 "supported for GZIP");
+        qInfo() << error;
         return false;
     }
     if ((mode & QIODevice::ReadOnly) != 0
             && (mode & QIODevice::WriteOnly) != 0) {
         error = QuaGzipFile::tr("Opening gzip for both reading"
             " and writing is not supported");
+        qInfo() << error;
         return false;
     } else if ((mode & QIODevice::ReadOnly) != 0) {
         modeString[0] = 'r';
@@ -53,11 +59,13 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     } else {
         error = QuaGzipFile::tr("You can open a gzip either for reading"
             " or for writing. Which is it?");
+        qInfo() << error;
         return false;
     }
     gzd = open(id, modeString);
     if (gzd == NULL) {
         error = QuaGzipFile::tr("Could not gzopen() file");
+        qInfo() << error;
         return false;
     }
     return true;
@@ -67,22 +75,26 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
 QuaGzipFile::QuaGzipFile():
 d(new QuaGzipFilePrivate())
 {
+    qInfo() << "Constructing QuaGzipFile (default)";
 }
 
 QuaGzipFile::QuaGzipFile(QObject *parent):
 QIODevice(parent),
 d(new QuaGzipFilePrivate())
 {
+    qInfo() << "Constructing QuaGzipFile with parent";
 }
 
 QuaGzipFile::QuaGzipFile(const QString &fileName, QObject *parent):
   QIODevice(parent),
 d(new QuaGzipFilePrivate(fileName))
 {
+    qInfo() << "Constructing QuaGzipFile with fileName:" << fileName;
 }
 
 QuaGzipFile::~QuaGzipFile()
 {
+    qInfo() << "Destructing QuaGzipFile for file:" << d->fileName;
   if (isOpen()) {
     close();
   }
@@ -91,24 +103,29 @@ QuaGzipFile::~QuaGzipFile()
 
 void QuaGzipFile::setFileName(const QString& fileName)
 {
+    qInfo() << "Setting file name to:" << fileName;
     d->fileName = fileName;
 }
 
 QString QuaGzipFile::getFileName() const
 {
+    qInfo() << "Getting file name";
     return d->fileName;
 }
 
 bool QuaGzipFile::isSequential() const
 {
+    qInfo() << "Checking if device is sequential";
   return true;
 }
 
 bool QuaGzipFile::open(QIODevice::OpenMode mode)
 {
+    qInfo() << "Opening file:" << d->fileName << "with mode:" << mode;
     QString error;
     if (!d->open(d->fileName, mode, error)) {
         setErrorString(error);
+        qInfo() << error;
         return false;
     }
     return QIODevice::open(mode);
@@ -116,9 +133,11 @@ bool QuaGzipFile::open(QIODevice::OpenMode mode)
 
 bool QuaGzipFile::open(int fd, QIODevice::OpenMode mode)
 {
+    qInfo() << "Opening file descriptor:" << fd << "with mode:" << mode;
     QString error;
     if (!d->open(fd, mode, error)) {
         setErrorString(error);
+        qInfo() << error;
         return false;
     }
     return QIODevice::open(mode);
@@ -126,27 +145,35 @@ bool QuaGzipFile::open(int fd, QIODevice::OpenMode mode)
 
 bool QuaGzipFile::flush()
 {
+    qInfo() << "Flushing Gzip stream for file:" << d->fileName;
     return gzflush(d->gzd, Z_SYNC_FLUSH) == Z_OK;
 }
 
 void QuaGzipFile::close()
 {
-  QIODevice::close();
-  gzclose(d->gzd);
+    qInfo() << "Closing Gzip file:" << d->fileName;
+    QIODevice::close();
+    gzclose(d->gzd);
 }
 
 qint64 QuaGzipFile::readData(char *data, qint64 maxSize)
 {
+    // qInfo() << "Reading data, max size:" << maxSize;
     return gzread(d->gzd, (voidp)data, (unsigned)maxSize);
 }
 
 qint64 QuaGzipFile::writeData(const char *data, qint64 maxSize)
 {
-    if (maxSize == 0)
+    // qInfo() << "Writing data, size:" << maxSize;
+    if (maxSize == 0) {
+        // qInfo() << "maxSize is 0";
         return 0;
+    }
     int written = gzwrite(d->gzd, (voidp)data, (unsigned)maxSize);
-    if (written == 0)
+    if (written == 0) {
+        // qInfo() << "gzwrite returned 0";
         return -1;
-    else
+    } else {
         return written;
+    }
 }

--- a/src/lib/data-transfer/quazip/quaziodevice.cpp
+++ b/src/lib/data-transfer/quazip/quaziodevice.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "quaziodevice.h"
+#include <QDebug>
 
 #define QUAZIO_INBUFSIZE 4096
 #define QUAZIO_OUTBUFSIZE 4096
@@ -37,6 +38,7 @@ QuaZIODevicePrivate::QuaZIODevicePrivate(QIODevice *io):
   zBufError(false),
   atEnd(false)
 {
+  qInfo() << "Constructing QuaZIODevicePrivate";
   zins.zalloc = (alloc_func) NULL;
   zins.zfree = (free_func) NULL;
   zins.opaque = NULL;
@@ -57,6 +59,7 @@ QuaZIODevicePrivate::QuaZIODevicePrivate(QIODevice *io):
 
 QuaZIODevicePrivate::~QuaZIODevicePrivate()
 {
+  qInfo() << "Destructing QuaZIODevicePrivate";
 #ifdef ZIODEVICE_DEBUG_OUTPUT
   debug.close();
 #endif
@@ -71,15 +74,19 @@ QuaZIODevicePrivate::~QuaZIODevicePrivate()
 
 int QuaZIODevicePrivate::doFlush(QString &error)
 {
+  qInfo() << "Flushing internal buffer to underlying IO device";
   int flushed = 0;
   while (outBufPos < outBufSize) {
     int more = io->write(outBuf + outBufPos, outBufSize - outBufPos);
     if (more == -1) {
       error = io->errorString();
+      qInfo() << "write error:" << error;
       return -1;
     }
-    if (more == 0)
+    if (more == 0) {
+      qInfo() << "write returned 0";
       break;
+    }
     outBufPos += more;
     flushed += more;
   }
@@ -106,11 +113,13 @@ QuaZIODevice::QuaZIODevice(QIODevice *io, QObject *parent):
     QIODevice(parent),
     d(new QuaZIODevicePrivate(io))
 {
+  qInfo() << "Constructing QuaZIODevice";
   connect(io, SIGNAL(readyRead()), SIGNAL(readyRead()));
 }
 
 QuaZIODevice::~QuaZIODevice()
 {
+    qInfo() << "Destructing QuaZIODevice";
     if (isOpen())
         close();
     delete d;
@@ -118,30 +127,36 @@ QuaZIODevice::~QuaZIODevice()
 
 QIODevice *QuaZIODevice::getIoDevice() const
 {
+    qInfo() << "Getting underlying IO device";
     return d->io;
 }
 
 bool QuaZIODevice::open(QIODevice::OpenMode mode)
 {
+    qInfo() << "Opening QuaZIODevice with mode:" << mode;
     if ((mode & QIODevice::Append) != 0) {
         setErrorString(tr("QIODevice::Append is not supported for"
                     " QuaZIODevice"));
+        qInfo() << "Append mode not supported";
         return false;
     }
     if ((mode & QIODevice::ReadWrite) == QIODevice::ReadWrite) {
         setErrorString(tr("QIODevice::ReadWrite is not supported for"
                     " QuaZIODevice"));
+        qInfo() << "ReadWrite mode not supported";
         return false;
     }
     if ((mode & QIODevice::ReadOnly) != 0) {
         if (inflateInit(&d->zins) != Z_OK) {
             setErrorString(d->zins.msg);
+            qInfo() << "inflateInit failed:" << d->zins.msg;
             return false;
         }
     }
     if ((mode & QIODevice::WriteOnly) != 0) {
         if (deflateInit(&d->zouts, Z_DEFAULT_COMPRESSION) != Z_OK) {
             setErrorString(d->zouts.msg);
+            qInfo() << "deflateInit failed:" << d->zouts.msg;
             return false;
         }
     }
@@ -150,15 +165,18 @@ bool QuaZIODevice::open(QIODevice::OpenMode mode)
 
 void QuaZIODevice::close()
 {
+    qInfo() << "Closing QuaZIODevice";
     if ((openMode() & QIODevice::ReadOnly) != 0) {
         if (inflateEnd(&d->zins) != Z_OK) {
             setErrorString(d->zins.msg);
+            qInfo() << "inflateEnd failed:" << d->zins.msg;
         }
     }
     if ((openMode() & QIODevice::WriteOnly) != 0) {
         flush();
         if (deflateEnd(&d->zouts) != Z_OK) {
             setErrorString(d->zouts.msg);
+            qInfo() << "deflateEnd failed:" << d->zouts.msg;
         }
     }
     QIODevice::close();
@@ -166,6 +184,7 @@ void QuaZIODevice::close()
 
 qint64 QuaZIODevice::readData(char *data, qint64 maxSize)
 {
+  qInfo() << "Reading data, max size:" << maxSize;
   int read = 0;
   while (read < maxSize) {
     if (d->inBufPos == d->inBufSize) {
@@ -174,10 +193,13 @@ qint64 QuaZIODevice::readData(char *data, qint64 maxSize)
       if (d->inBufSize == -1) {
         d->inBufSize = 0;
         setErrorString(d->io->errorString());
+        qInfo() << "read error:" << d->io->errorString();
         return -1;
       }
-      if (d->inBufSize == 0)
+      if (d->inBufSize == 0) {
+        qInfo() << "read returned 0";
         break;
+      }
     }
     while (read < maxSize && d->inBufPos < d->inBufSize) {
       d->zins.next_in = (Bytef *) (d->inBuf + d->inBufPos);
@@ -199,6 +221,7 @@ qint64 QuaZIODevice::readData(char *data, qint64 maxSize)
         if (!d->zBufError) {
           qWarning("Z_BUF_ERROR detected with %d/%d in/out, weird",
               d->zins.avail_in, d->zins.avail_out);
+          qInfo() << "Z_BUF_ERROR";
           d->zBufError = true;
         }
         memmove(d->inBuf, d->inBuf + d->inBufPos, d->inBufSize - d->inBufPos);
@@ -207,14 +230,18 @@ qint64 QuaZIODevice::readData(char *data, qint64 maxSize)
         more = d->io->read(d->inBuf + d->inBufSize, QUAZIO_INBUFSIZE - d->inBufSize);
         if (more == -1) {
           setErrorString(d->io->errorString());
+          qInfo() << "read error:" << d->io->errorString();
           return -1;
         }
-        if (more == 0)
+        if (more == 0) {
+          qInfo() << "read returned 0";
           return read;
+        }
         d->inBufSize += more;
         break;
       default:
         setErrorString(QString::fromLocal8Bit(d->zins.msg));
+        qInfo() << "inflate error:" << d->zins.msg;
         return -1;
       }
     }
@@ -227,16 +254,20 @@ qint64 QuaZIODevice::readData(char *data, qint64 maxSize)
 
 qint64 QuaZIODevice::writeData(const char *data, qint64 maxSize)
 {
+  qInfo() << "Writing data, size:" << maxSize;
   int written = 0;
   QString error;
   if (d->doFlush(error) == -1) {
     setErrorString(error);
+    qInfo() << "flush error:" << error;
     return -1;
   }
   while (written < maxSize) {
       // there is some data waiting in the output buffer
-    if (d->outBufPos < d->outBufSize)
+    if (d->outBufPos < d->outBufSize) {
+      qInfo() << "output buffer not empty";
       return written;
+    }
     d->zouts.next_in = (Bytef *) (data + written);
     d->zouts.avail_in = (uInt) (maxSize - written); // hope it's less than 2GB
     d->zouts.next_out = (Bytef *) d->outBuf;
@@ -248,10 +279,12 @@ qint64 QuaZIODevice::writeData(const char *data, qint64 maxSize)
       break;
     default:
       setErrorString(QString::fromLocal8Bit(d->zouts.msg));
+      qInfo() << "deflate error:" << d->zouts.msg;
       return -1;
     }
     if (d->doFlush(error) == -1) {
       setErrorString(error);
+      qInfo() << "flush error:" << error;
       return -1;
     }
   }
@@ -263,14 +296,18 @@ qint64 QuaZIODevice::writeData(const char *data, qint64 maxSize)
 
 bool QuaZIODevice::flush()
 {
+    qInfo() << "Flushing QuaZIODevice";
     QString error;
     if (d->doFlush(error) < 0) {
         setErrorString(error);
+        qInfo() << "flush error:" << error;
         return false;
     }
     // can't flush buffer, some data is still waiting
-    if (d->outBufPos < d->outBufSize)
+    if (d->outBufPos < d->outBufSize) {
+        qInfo() << "output buffer not empty";
         return true;
+    }
     Bytef c = 0;
     d->zouts.next_in = &c; // fake input buffer
     d->zouts.avail_in = 0; // of zero size
@@ -282,15 +319,20 @@ bool QuaZIODevice::flush()
           d->outBufSize = (char *) d->zouts.next_out - d->outBuf;
           if (d->doFlush(error) < 0) {
               setErrorString(error);
+              qInfo() << "flush error:" << error;
               return false;
           }
-          if (d->outBufPos < d->outBufSize)
+          if (d->outBufPos < d->outBufSize) {
+              qInfo() << "output buffer not empty";
               return true;
+          }
           break;
         case Z_BUF_ERROR: // nothing to write?
+          qInfo() << "Z_BUF_ERROR";
           return true;
         default:
           setErrorString(QString::fromLocal8Bit(d->zouts.msg));
+          qInfo() << "deflate error:" << d->zouts.msg;
           return false;
         }
     } while (d->zouts.avail_out == 0);
@@ -299,11 +341,13 @@ bool QuaZIODevice::flush()
 
 bool QuaZIODevice::isSequential() const
 {
+    qInfo() << "Checking if device is sequential";
     return true;
 }
 
 bool QuaZIODevice::atEnd() const
 {
+    qInfo() << "Checking if at end of stream";
     // Here we MUST check QIODevice::bytesAvailable() because WE
     // might have reached the end, but QIODevice didn't--
     // it could have simply pre-buffered all remaining data.
@@ -312,6 +356,7 @@ bool QuaZIODevice::atEnd() const
 
 qint64 QuaZIODevice::bytesAvailable() const
 {
+    qInfo() << "Checking bytes available";
     // If we haven't recevied Z_STREAM_END, it means that
     // we have at least one more input byte available.
     // Plus whatever QIODevice has buffered.

--- a/src/lib/data-transfer/quazip/quazipfileinfo.cpp
+++ b/src/lib/data-transfer/quazip/quazipfileinfo.cpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "quazipfileinfo.h"
+#include <QDebug>
 
 static QFile::Permissions permissionsFromExternalAttr(quint32 externalAttr) {
+    qInfo() << "Converting external attributes to file permissions";
     quint32 uPerm = (externalAttr & 0xFFFF0000u) >> 16;
     QFile::Permissions perm = 0;
     if ((uPerm & 0400) != 0)
@@ -31,16 +33,19 @@ static QFile::Permissions permissionsFromExternalAttr(quint32 externalAttr) {
 
 QFile::Permissions QuaZipFileInfo::getPermissions() const
 {
+    qInfo() << "Getting QuaZipFileInfo permissions";
     return permissionsFromExternalAttr(externalAttr);
 }
 
 QFile::Permissions QuaZipFileInfo64::getPermissions() const
 {
+    qInfo() << "Getting QuaZipFileInfo64 permissions";
     return permissionsFromExternalAttr(externalAttr);
 }
 
 bool QuaZipFileInfo64::toQuaZipFileInfo(QuaZipFileInfo &info) const
 {
+    qInfo() << "Converting QuaZipFileInfo64 to QuaZipFileInfo";
     bool noOverflow = true;
     info.name = name;
     info.versionCreated = versionCreated;
@@ -51,12 +56,14 @@ bool QuaZipFileInfo64::toQuaZipFileInfo(QuaZipFileInfo &info) const
     info.crc = crc;
     if (compressedSize > 0xFFFFFFFFu) {
         info.compressedSize = 0xFFFFFFFFu;
+        qInfo() << "compressedSize overflow";
         noOverflow = false;
     } else {
         info.compressedSize = compressedSize;
     }
     if (uncompressedSize > 0xFFFFFFFFu) {
         info.uncompressedSize = 0xFFFFFFFFu;
+        qInfo() << "uncompressedSize overflow";
         noOverflow = false;
     } else {
         info.uncompressedSize = uncompressedSize;
@@ -72,6 +79,7 @@ bool QuaZipFileInfo64::toQuaZipFileInfo(QuaZipFileInfo &info) const
 static QDateTime getNTFSTime(const QByteArray &extra, int position,
                              int *fineTicks)
 {
+    qInfo() << "Getting NTFS time";
     QDateTime dateTime;
     for (int i = 0; i <= extra.size() - 4; ) {
         unsigned type = static_cast<unsigned>(static_cast<unsigned char>(
@@ -142,15 +150,18 @@ static QDateTime getNTFSTime(const QByteArray &extra, int position,
 
 QDateTime QuaZipFileInfo64::getNTFSmTime(int *fineTicks) const
 {
+    qInfo() << "Getting NTFS modification time";
     return getNTFSTime(extra, 0, fineTicks);
 }
 
 QDateTime QuaZipFileInfo64::getNTFSaTime(int *fineTicks) const
 {
+    qInfo() << "Getting NTFS access time";
     return getNTFSTime(extra, 8, fineTicks);
 }
 
 QDateTime QuaZipFileInfo64::getNTFScTime(int *fineTicks) const
 {
+    qInfo() << "Getting NTFS creation time";
     return getNTFSTime(extra, 16, fineTicks);
 }


### PR DESCRIPTION
Add more logs for datatransfer.

Log: more logs for datatransfer.

## Summary by Sourcery

Add extensive logging across the data-transfer module to improve observability and aid debugging.

Enhancements:
- Instrument QuaZip core (open, close, read/write, constructors) and gzip adapters with qInfo logs for every major step and error.
- Add debug logs in compression utilities (CompressUtil), zlib I/O adapter (qioapi), checksum calculators (CRC32, Adler32) and QuaZipNewInfo metadata handling.
- Enhance GUI components under core/gui/data-transfer with DLOG messages to trace widget initialization, user events, UI state changes, and data flows.
- Log file size calculations, backup packaging (ZipWork), and extraction (UnzipWorker) processes, including success/failure and performance details.