### PR TITLE
chore: New 1.1.12 tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-cooperation (1.1.12) unstable; urgency=medium
+
+  * v1.1.12 version update.
+  * chore: update translation.
+  * chore: more logs.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 03 Jul 2025 16:02:26 +0800
+
 dde-cooperation (1.1.11) unstable; urgency=medium
 
   * update version to 1.1.11.


### PR DESCRIPTION
Update changelog for version 1.1.12 .

Log: New v1.1.12

## Summary by Sourcery

Chores:
- Bump package version to 1.1.12 in debian/changelog