### PR TITLE
chore: Update Qt version compatibility in signal connections

### DIFF
--- a/src/base/reportlog/datas/cooperationreportdata.cpp
+++ b/src/base/reportlog/datas/cooperationreportdata.cpp
@@ -7,6 +7,7 @@
 #include <DSysInfo>
 
 #include <QDateTime>
+#include <QDebug>
 
 using namespace deepin_cross;
 DCORE_USE_NAMESPACE

--- a/src/compat/base/reportlog/datas/cooperationreportdata.cpp
+++ b/src/compat/base/reportlog/datas/cooperationreportdata.cpp
@@ -7,6 +7,7 @@
 #include <DSysInfo>
 
 #include <QDateTime>
+#include <QDebug>
 
 using namespace deepin_cross;
 DCORE_USE_NAMESPACE

--- a/src/infrastructure/slotipc/src/interfaceconnection.cpp
+++ b/src/infrastructure/slotipc/src/interfaceconnection.cpp
@@ -20,7 +20,7 @@ SlotIPCInterfaceConnection::SlotIPCInterfaceConnection(QLocalSocket* socket, QOb
     m_lastCallSuccessful(false)
 {
   connect(socket, SIGNAL(disconnected()), SIGNAL(socketDisconnected()));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(socket, SIGNAL(errorOccurred(QLocalSocket::LocalSocketError)), SLOT(errorOccured(QLocalSocket::LocalSocketError)));
 #else
   connect(socket, SIGNAL(error(QLocalSocket::LocalSocketError)), SLOT(errorOccured(QLocalSocket::LocalSocketError)));

--- a/src/infrastructure/slotipc/src/serviceconnection.cpp
+++ b/src/infrastructure/slotipc/src/serviceconnection.cpp
@@ -23,7 +23,7 @@ SlotIPCServiceConnection::SlotIPCServiceConnection(QLocalSocket* socket, SlotIPC
   connect(socket, SIGNAL(disconnected()), socket, SLOT(deleteLater()));
   connect(socket, SIGNAL(disconnected()), SLOT(deleteLater()));
   connect(this, SIGNAL(destroyed(QObject*)), parent, SLOT(_q_connectionDestroyed(QObject*)));
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(socket, SIGNAL(errorOccurred(QLocalSocket::LocalSocketError)), SLOT(errorOccured(QLocalSocket::LocalSocketError)));
 #else
   connect(socket, SIGNAL(error(QLocalSocket::LocalSocketError)), SLOT(errorOccured(QLocalSocket::LocalSocketError)));

--- a/src/lib/cooperation/dfmplugin/reportlog/datas/cooperationreportdata.cpp
+++ b/src/lib/cooperation/dfmplugin/reportlog/datas/cooperationreportdata.cpp
@@ -7,6 +7,7 @@
 #include <DSysInfo>
 
 #include <QDateTime>
+#include <QDebug>
 
 using namespace deepin_cross;
 DCORE_USE_NAMESPACE

--- a/src/singleton/singleapplication.cpp
+++ b/src/singleton/singleapplication.cpp
@@ -323,8 +323,12 @@ bool SingleApplication::doSendMessage(const QString &socketPath, const QByteArra
         qWarning() << "Socket error:" << localSocket->error() << localSocket->errorString();
     };
 
-    // Connect error signals
+    // Connect error signals - Qt5/Qt6 compatibility
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
     connect(localSocket, &QLocalSocket::errorOccurred, errorHandler);
+#else
+    connect(localSocket, QOverload<QLocalSocket::LocalSocketError>::of(&QLocalSocket::error), errorHandler);
+#endif
     connect(localSocket, &QLocalSocket::disconnected, localSocket, &QLocalSocket::deleteLater);
 
     localSocket->connectToServer(socketPath);


### PR DESCRIPTION
- Adjusted signal connection compatibility for QLocalSocket error handling to support Qt version 5.15.0 and above.

Log: Update Qt version compatibility in signal connections.

## Summary by Sourcery

Align QLocalSocket error signal connections with Qt 5.15+ by using the new errorOccurred signal across modules and falling back to the legacy error signal for earlier versions.

Enhancements:
- Replace Qt6-only checks with a Qt>=5.15.0 guard for connecting QLocalSocket::errorOccurred in singleapplication, interfaceconnection, and serviceconnection modules
- Maintain backward compatibility by falling back to the older QLocalSocket::error signal on Qt versions below 5.15.0