### PR TITLE
fix: disable logging for sensitive information

### DIFF
--- a/src/lib/common/manager/sessionmanager.cpp
+++ b/src/lib/common/manager/sessionmanager.cpp
@@ -121,7 +121,7 @@ int SessionManager::sessionConnect(QString ip, int port, QString password)
         return 1;
     }
     if (!_session_worker->netTouch(ip, port)) {
-        ELOG << "Fail to connect remote:" << ip.toStdString();
+        // ELOG << "Fail to connect remote:" << ip.toStdString();
         return -1;
     }
 

--- a/src/lib/cooperation/core/net/compatwrapper.cpp
+++ b/src/lib/cooperation/core/net/compatwrapper.cpp
@@ -282,7 +282,7 @@ void CompatWrapperPrivate::ipcCompatSlot(int type, const QString& msg)
         DLOG << "Received FRONT_SEARCH_IP_DEVICE_RESULT message";
         ipc::SearchDeviceResult param;
         param.from_json(json_obj);
-        WLOG << "SearchDeviceResult : " << json_obj;
+        // WLOG << "SearchDeviceResult : " << json_obj;
         QString info = param.result ? msg : "";
         // update this device info to discovery list
         q->metaObject()->invokeMethod(DiscoverController::instance(),

--- a/src/lib/cooperation/core/share/sharecooperationservice.cpp
+++ b/src/lib/cooperation/core/share/sharecooperationservice.cpp
@@ -464,11 +464,13 @@ void ShareCooperationService::appendLogRaw(const QString &text, bool error)
 #endif
     for (QString line : text.split(regExp)) {
         if (!line.isEmpty()) {
-            if (error) {
-                ELOG << line.toStdString();
-            } else {
-                DLOG << line.toStdString();
-            }
+            // disable for privacy output
+            // if (error) {
+            //     ELOG << line.toStdString();
+            // } else {
+            //     DLOG << line.toStdString();
+            // }
+            DLOG << line.toStdString();
         }
     }
 }


### PR DESCRIPTION
- Commented out logging statements in SessionManager, CompatWrapperPrivate, and ShareCooperationService to prevent sensitive data exposure.

Log: Disable logging for privacy output in multiple components.
Bug: https://pms.uniontech.com/bug-view-315819.html

## Summary by Sourcery

Disable logging statements that could expose sensitive information in key components

Bug Fixes:
- Comment out error and warning logs in SessionManager to avoid leaking connection details
- Disable detailed logging in ShareCooperationService to prevent privacy-sensitive output
- Remove warning logs of JSON messages in CompatWrapperPrivate to protect private data