### PR TITLE
fix: Update notification handling to prevent showing in notification …

### DIFF
--- a/src/lib/cooperation/core/net/helper/transferhelper.cpp
+++ b/src/lib/cooperation/core/net/helper/transferhelper.cpp
@@ -337,7 +337,8 @@ void TransferHelper::transferResult(bool result, const QString &msg)
             d->notifyMessage(msg, actions, -1, hints);
         } else {
             DLOG << "Transfer failed, showing message";
-            d->notifyMessage(msg, {}, 3 * 1000);
+            QVariantMap hitMap { { "x-deepin-ShowInNotifyCenter", false } };
+            d->notifyMessage(msg, {}, 3 * 1000, hitMap);
         }
         return;
     }
@@ -434,8 +435,9 @@ void TransferHelper::notifyTransferRequest(const QString &nick, const QString &i
     QStringList actions { NotifyRejectAction, tr("Reject"),
                           NotifyAcceptAction, tr("Accept"),
                           NotifyCloseAction, tr("Close") };
+    QVariantMap hitMap { { "x-deepin-ShowInNotifyCenter", false } };
 
-    d->notifyMessage(msg.arg(CommonUitls::elidedText(nick, Qt::ElideMiddle, 25)), actions, 10 * 1000);
+    d->notifyMessage(msg.arg(CommonUitls::elidedText(nick, Qt::ElideMiddle, 25)), actions, 10 * 1000, hitMap);
 #else
     DLOG << "Showing transfer confirmation dialog";
     d->transDialog()->showConfirmDialog(nick);
@@ -446,7 +448,8 @@ void TransferHelper::handleCancelTransferApply()
 {
     static QString body(tr("The other party has cancelled the transfer request !"));
 #ifdef __linux__
-    d->notifyMessage(body, {}, 3 * 1000);
+    QVariantMap hitMap { { "x-deepin-ShowInNotifyCenter", false } };
+    d->notifyMessage(body, {}, 3 * 1000, hitMap);
 #else
     DLOG << "Non-Linux platform, showing result dialog";
     d->transDialog()->showResultDialog(false, body);

--- a/src/lib/cooperation/core/net/linux/noticeutil.cpp
+++ b/src/lib/cooperation/core/net/linux/noticeutil.cpp
@@ -56,8 +56,9 @@ void NoticeUtil::onActionTriggered(uint replacesId, const QString &action)
 
 void NoticeUtil::notifyMessage(const QString &title, const QString &body, const QStringList &actions, QVariantMap hitMap, int expireTimeout)
 {
-
-    uint notifyId = 0;
+    // If hitMap is not empty, use previous recvNotifyId for progress updates
+    uint notifyId = hitMap.isEmpty() ? 0 : recvNotifyId;
+    
     QDBusReply<uint> reply = notifyIfc->call(QString("Notify"), QString("dde-cooperation"), notifyId,
                                              QString("dde-cooperation"), title, body,
                                              actions, hitMap, expireTimeout);


### PR DESCRIPTION
…center

- Added a QVariantMap parameter to notifyMessage calls to control visibility in the notification center.
- Updated transferResult, notifyTransferRequest, and handleCancelTransferApply methods to include the new parameter.

Log: Enhance notification handling by preventing certain messages from appearing in the notification center.
Bug: https://pms.uniontech.com/bug-view-317261.html

## Summary by Sourcery

Prevent certain transfer notifications from appearing in the notification center by adding a visibility hint to notifyMessage and updating its handling

Bug Fixes:
- Prevent transfer failure, request, and cancellation messages from appearing in the notification center

Enhancements:
- Add a QVariantMap parameter to notifyMessage for passing visibility hints
- Include x-deepin-ShowInNotifyCenter: false hint in transferResult, notifyTransferRequest, and handleCancelTransferApply
- Modify NoticeUtil.notifyMessage to reuse previous notification ID when a visibility hint is provided