### PR TITLE
fix: update translations of ja

### DIFF
--- a/translations/dfmplugin-deliver/cooperation-transfer_ja.ts
+++ b/translations/dfmplugin-deliver/cooperation-transfer_ja.ts
@@ -4,13 +4,13 @@
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/cooperationplugin.cpp" line="60"/>
         <source>File transfer settings</source>
-        <translation type="unfinished"/>
+        <translation>ファイル転送設定</translation>
     </message>
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/cooperationplugin.cpp" line="62"/>
         <source>Settings</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>設定</translation>
     </message>
 </context>
 <context>
@@ -18,7 +18,7 @@
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/menu/cooperationmenuscene.cpp" line="32"/>
         <source>File transfer</source>
-        <translation type="unfinished"/>
+        <translation>ファイル転送</translation>
     </message>
 </context>
 <context>
@@ -26,7 +26,7 @@
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/cooperationplugin.cpp" line="55"/>
         <source>File transfer</source>
-        <translation type="unfinished"/>
+        <translation>ファイル転送</translation>
     </message>
 </context>
 <context>
@@ -34,32 +34,32 @@
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/dialogs/filetransfersettingsdialog.cpp" line="150"/>
         <source>File transfer settings</source>
-        <translation type="unfinished"/>
+        <translation>ファイル転送設定</translation>
     </message>
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/dialogs/filetransfersettingsdialog.cpp" line="164"/>
         <source>Everyone in the same LAN</source>
-        <translation type="unfinished"/>
+        <translation>同じLANの全員</translation>
     </message>
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/dialogs/filetransfersettingsdialog.cpp" line="165"/>
         <source>Only those who are collaborating are allowed</source>
-        <translation type="unfinished"/>
+        <translation>コラボレーション中の者のみ許可</translation>
     </message>
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/dialogs/filetransfersettingsdialog.cpp" line="166"/>
         <source>Not allow</source>
-        <translation type="unfinished"/>
+        <translation>許可しない</translation>
     </message>
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/dialogs/filetransfersettingsdialog.cpp" line="170"/>
         <source>Allows the following users to send files to me</source>
-        <translation type="unfinished"/>
+        <translation>以下のユーザーが私にファイルを送信することを許可</translation>
     </message>
     <message>
         <location filename="../src/dde-file-manager/dfmplugin-cooperation/dialogs/filetransfersettingsdialog.cpp" line="171"/>
         <source>File save location</source>
-        <translation type="unfinished"/>
+        <translation>ファイル保存場所</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
log: update translations.

bug: https://pms.uniontech.com/bug-view-324285.html

## Summary by Sourcery

Documentation:
- Fill in Japanese translations for file transfer settings, menu entries, and dialog options in the cooperation-transfer_ja.ts file.