### PR TITLE
fix: Disable search by self IP

### DIFF
--- a/src/lib/cooperation/core/gui/widgets/workspacewidget.cpp
+++ b/src/lib/cooperation/core/gui/widgets/workspacewidget.cpp
@@ -148,6 +148,13 @@ void WorkspaceWidgetPrivate::onSearchDevice()
         return;
     }
 
+    // 过滤本机IP，防止搜索自己的设备
+    QString localIp = QString::fromStdString(deepin_cross::CommonUitls::getFirstIp());
+    if (ip == localIp) {
+        DLOG << "Cannot search for local IP:" << ip.toStdString();
+        return;
+    }
+
     q->switchWidget(WorkspaceWidget::kLookignForDeviceWidget);
     emit q->search(ip);
 }


### PR DESCRIPTION
Disable search by self  IP which may cause more problems.

Log: Disable search by self IP.
Bug: https://pms.uniontech.com/bug-view-333893.html

## Summary by Sourcery

Bug Fixes:
- Ignore the host’s own IP during device searches to avoid self-discovery issues.