### PR TITLE
fix: Add delay before application exit to ensure config is saved

### DIFF
--- a/src/lib/cooperation/core/gui/mainwindow.cpp
+++ b/src/lib/cooperation/core/gui/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include <QMenu>
 #include <QVBoxLayout>
 #include <QStackedLayout>
+#include <QTimer>
 
 using namespace cooperation_core;
 
@@ -331,19 +332,24 @@ void MainWindow::showCloseDialog()
     int code = dlg.exec();
     if (code == QDialog::Accepted) {
         DLOG << "Dialog accepted";
+        int delay = 0;
         bool isExit = op2->checkState() == Qt::Checked;
         if (op3->checkState() == Qt::Checked) {
             DLOG << "Saving close option";
             CooperationUtil::saveOption(isExit);
+            delay = 1000; // Wait 1000ms to ensure config is written to disk before exit, because the config is async 1s to write to disk
         }
 
         if (isExit) {
-            DLOG << "Exiting application";
-            QApplication::quit();
+            DLOG << "Exiting application with delay:" << delay;
+            QTimer::singleShot(delay, []() {
+                QApplication::quit();
+            });
         } else {
             DLOG << "Minimizing application";
             minimizedAPP();
         }
+        this->hide();
     } else {
         DLOG << "Dialog rejected";
     }


### PR DESCRIPTION
Implement a delay of 1000ms before quitting the application to allow asynchronous configuration saving to complete. This change enhances the reliability of the application exit process.

Log: Add delay before application exit to ensure config is saved.
Bug: https://pms.uniontech.com/bug-view-333889.html

## Summary by Sourcery

Delay application exit by 1000ms when saving configuration to ensure the async write completes before quitting.

Bug Fixes:
- Ensure configuration is saved to disk by waiting 1 second before calling QApplication::quit()

Enhancements:
- Use QTimer::singleShot to schedule the application quit
- Hide the main window immediately after scheduling the delayed exit