### PR TITLE
fix: Local IP address display incomplete

### DIFF
--- a/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
@@ -118,26 +118,28 @@ void ConnectWidget::initConnectLayout()
                            "border-radius: 16; "
                            "border: 1px solid rgba(0, 129, 255, 0.2);"
                            "}");
-    ipFrame->setFixedSize(204, 32);
+	ipFrame->setFixedHeight(32);
+	ipFrame->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
 
     ipLabel->setText(ipaddress);
     ipLabel1->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     StyleHelper::setAutoFont(ipLabel, 17, QFont::Bold);
     StyleHelper::setAutoFont(ipLabel1, 12, QFont::Normal);
 
-    QHBoxLayout *ipHLayout = new QHBoxLayout(ipFrame);
-    ipHLayout->addWidget(ipLabel1);
-    ipHLayout->addWidget(ipLabel);
-    ipHLayout->setSpacing(8);
-    ipHLayout->addSpacing(26);
-    ipHLayout->setContentsMargins(0, 0, 0, 0);
+	// keep both the localized prefix and IP value inside the rounded frame
+	QHBoxLayout *ipInnerLayout = new QHBoxLayout(ipFrame);
+	ipInnerLayout->addWidget(ipLabel1);
+	ipInnerLayout->addSpacing(8);
+	ipInnerLayout->addWidget(ipLabel);
+	ipInnerLayout->setSpacing(8);
+	ipInnerLayout->setContentsMargins(12, 0, 12, 0);
 
     iconLabel->setAlignment(Qt::AlignCenter);
     nameLabel->setAlignment(Qt::AlignCenter);
 
     ipVLayout->addWidget(iconLabel);
     ipVLayout->addWidget(nameLabel);
-    ipVLayout->addWidget(ipFrame);
+	ipVLayout->addWidget(ipFrame);
     ipVLayout->setAlignment(Qt::AlignCenter);
 
     //passwordLayout


### PR DESCRIPTION
log: Removed fixed width and switched to fixed height with QSizePolicy::Minimum applied, allowing the frame width to adapt to content.

Set the internal layout to “prefix + spacing + IP” and applied appropriate padding.

bug: https://pms.uniontech.com/bug-view-330371.html

## Summary by Sourcery

Fix incomplete local IP address display by replacing fixed width with a minimum-size width policy and adjusting the frame’s internal layout for proper prefix, spacing, and padding.

Bug Fixes:
- Remove fixed-width constraint on the IP display frame and set a fixed height with QSizePolicy::Minimum for adaptive width
- Rebuild the IP frame’s inner layout to include the localized prefix, controlled spacing, and consistent padding