### PR TITLE
 chore: Update version to 1.1.20

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-cooperation (1.1.20) unstable; urgency=medium
+
+  * chore: Update version to 1.1.20.
+  * fix: Fix some UI issues.
+  * fix: Add delay before application exit to ensure config is saved
+  * fix: Disable search by self IP
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 18 Sep 2025 19:02:33 +0800
+
 dde-cooperation (1.1.19) unstable; urgency=medium
 
   * chore: Update version to 1.1.19.


### PR DESCRIPTION
Update version to 1.1.20

log: Update version to 1.1.20

## Summary by Sourcery

Chores:
- Bump Debian package version to 1.1.20