### PR TITLE
fix: Fix transfer dialog still show issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ CMake*.json
 .roo_temp/
 .roo_temp_$$/
 .cursor/
-memory-bank/
+.spec-workflow/
 .cursorrules
 .cursorindexingignore
 .specstory/

--- a/src/lib/cooperation/core/cooperationcoreplugin.cpp
+++ b/src/lib/cooperation/core/cooperationcoreplugin.cpp
@@ -200,9 +200,8 @@ bool CooperaionCorePlugin::start()
 void CooperaionCorePlugin::stop()
 {
     DLOG << "Stopping cooperation core plugin";
-#ifdef ENABLE_COMPAT
     NetworkUtil::instance()->stop();
-    DLOG << "Network util stopped";
+#ifdef ENABLE_COMPAT
     TransferWrapper::instance()->close();
 #endif
     DLOG << "Cleanup complete";

--- a/src/lib/cooperation/core/net/helper/transferhelper.h
+++ b/src/lib/cooperation/core/net/helper/transferhelper.h
@@ -69,6 +69,9 @@ public Q_SLOTS:
     // exception: network connection(ping out) or other io
     void onTransferExcepted(int type, const QString &remote);
 
+    // notification management
+    void closeAllNotifications();
+
 private:
     explicit TransferHelper(QObject *parent = nullptr);
     ~TransferHelper();

--- a/src/lib/cooperation/core/net/networkutil.h
+++ b/src/lib/cooperation/core/net/networkutil.h
@@ -50,10 +50,11 @@ public:
 
     bool isCurrentlyCooperating();
 
+    void stop();
 #ifdef ENABLE_COMPAT
     //compat share
     void compatSendStartShare(const QString &screenName);
-    void stop();
+    void compatAppExit();
     void updateCooperationStatus(int status);
 #endif
 


### PR DESCRIPTION
Close all notifications and disconnect remote connection, do not update progress if out transfering.

Log: Fix transfer dialog still show issue. Bug:
https://pms.uniontech.com/bug-view-311375.html

## Summary by Sourcery

Fix lingering transfer dialog and stale progress updates by enhancing the stop procedure to close notifications and disconnect remote connections, and guard progress updates when transfers are no longer active.

Bug Fixes:
- Close transfer dialog and notifications on stop to prevent them from lingering after transfer ends
- Skip progress updates when transfer status is no longer active to avoid stale UI updates

Enhancements:
- Add TransferHelper::closeAllNotifications to close both notification bubbles and dialogs
- Extend NetworkUtil::stop to invoke closeAllNotifications, disconnect any remote connection, and clear the current target

Chores:
- Reorder and clean up compatSendStartShare and stop method definitions
- Refine plugin stop sequence to conditionally close compatibility wrapper under ENABLE_COMPAT