### PR TITLE
fix: Fix not show device for NotAllow mode

### DIFF
--- a/src/lib/cooperation/transfer/helper/transferhelper.cpp
+++ b/src/lib/cooperation/transfer/helper/transferhelper.cpp
@@ -154,6 +154,9 @@ bool TransferHelper::buttonVisible(const QString &id, const DeviceInfoPointer in
             return info->connectStatus() != DeviceInfo::Offline;
         case DeviceInfo::TransMode::OnlyConnected:
             return info->connectStatus() == DeviceInfo::Connected;
+        case DeviceInfo::TransMode::NotAllow:
+            DLOG << "Transfer mode is NotAllow, hiding transfer button";
+            return false;
         default:
             return false;
         }
@@ -322,6 +325,13 @@ bool TransferHelper::transable(const DeviceInfoPointer devInfo)
     if (DeviceInfo::TransMode::OnlyConnected == devInfo->transMode() &&
         DeviceInfo::ConnectStatus::Connected == devInfo->connectStatus()) {
         DLOG << "Transfer mode is OnlyConnected and device is Connected, returning true";
+        return true;
+    }
+
+    // For NotAllow mode, return true to show device in list
+    // Button visibility will be controlled by buttonVisible() function
+    if (DeviceInfo::TransMode::NotAllow == devInfo->transMode()) {
+        DLOG << "Transfer mode is NotAllow, showing device but disabling transfer";
         return true;
     }
 


### PR DESCRIPTION
Show device and hide button for NotAllow mode.

Log: Fix not show device for NotAllow mode. Bug:
https://pms.uniontech.com/bug-view-334627.html

## Summary by Sourcery

Handle NotAllow transfer mode by displaying devices in the list while hiding the transfer button and logging mode transitions

Bug Fixes:
- Show devices in NotAllow mode by returning true in transable()
- Hide transfer button for NotAllow mode by returning false in buttonVisible()

Enhancements:
- Add debug logs for NotAllow mode in both transable() and buttonVisible()