### PR TITLE
fix: Fix not show offline device if not same subnet.

### DIFF
--- a/src/lib/cooperation/core/discover/discovercontroller.cpp
+++ b/src/lib/cooperation/core/discover/discovercontroller.cpp
@@ -177,13 +177,25 @@ void DiscoverController::initConnect()
 
 bool DiscoverController::isVaildDevice(const DeviceInfoPointer info)
 {
-    if (!info || info->ipAddress().isEmpty() || !info->ipAddress().startsWith(d->ipfilter)) {
-        DLOG << "Device is not valid or does not match IP filter";
+    if (!info || info->ipAddress().isEmpty()) {
+        DLOG << "Device is not valid or IP address is empty";
         return false;
-    } else {
-        DLOG << "Device is valid";
+    }
+    
+    // Skip IP filter check for history devices (including offline ones)
+    if (_historyDevices.contains(info->ipAddress())) {
+        DLOG << "Device is in history, skipping IP filter check";
         return true;
     }
+    
+    // Apply IP filter only for non-history devices
+    if (!info->ipAddress().startsWith(d->ipfilter)) {
+        DLOG << "Device does not match IP filter";
+        return false;
+    }
+    
+    DLOG << "Device is valid";
+    return true;
 }
 
 DeviceInfoPointer DiscoverController::parseDeviceJson(const QString &info)


### PR DESCRIPTION
Skip IP filter check for history devices in DiscoverController.

Log: Fix not show offline device if not same subnet. Bug: https://pms.uniontech.com/bug-view-334203.html

## Summary by Sourcery

Bug Fixes:
- Skip IP filter check for history devices so offline devices are displayed even if they are outside the current subnet.