### PR TITLE
fix: Fix network connect tips

### DIFF
--- a/src/lib/cooperation/core/gui/mainwindow.cpp
+++ b/src/lib/cooperation/core/gui/mainwindow.cpp
@@ -165,6 +165,18 @@ void MainWindow::setFirstTipVisible()
 void MainWindow::onLookingForDevices()
 {
     DLOG << "Looking for devices";
+
+    // Check network status before refreshing device list
+    QString localIP = CooperationUtil::localIPAddress();
+    bool isNetworkConnected = !localIP.isEmpty();
+
+    if (!isNetworkConnected) {
+        DLOG << "Network is not connected, showing network disconnected page";
+        d->workspaceWidget->clear();
+        d->workspaceWidget->switchWidget(WorkspaceWidget::kNoNetworkWidget);
+        return;
+    }
+
     _userAction = true;
     emit refreshDevices();
     d->workspaceWidget->clear();


### PR DESCRIPTION
Check network connectivity before device refresh.

Log: Fix network connect tips. 
Bug: https://pms.uniontech.com/bug-view-335277.html

## Summary by Sourcery

Bug Fixes:
- Add network connection check in onLookingForDevices to prevent device refresh when offline and show the no-network UI