### PR TITLE
chore: update version to 1.2.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-cooperation (1.2.2) unstable; urgency=medium
+
+  * fix(log): remove duplicate qCritical logs
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 12 Mar 2026 20:24:43 +0800
+
 dde-cooperation (1.2.1) unstable; urgency=medium
 
   * chore: Update version to 1.2.1.


### PR DESCRIPTION
- bump version to 1.2.2

Log : bump version to 1.2.2

## Summary by Sourcery

Chores:
- Bump package version references in Debian changelog to 1.2.2.