### PR TITLE
refactor(gui): integrate debug dialog access via hidden click mechanism

### DIFF
--- a/src/lib/data-transfer/core/utils/settinghepler.cpp
+++ b/src/lib/data-transfer/core/utils/settinghepler.cpp
@@ -1,4 +1,8 @@
-﻿#include "settinghepler.h"
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "settinghepler.h"
 
 #include "common/log.h"
 
@@ -71,7 +75,7 @@ bool SettingHelper::handleDataConfiguration(const QString &path)
 
     QDir pdir(path);
     QString filepath = pdir.absolutePath() + "/";
-    QJsonObject jsonObj = ParseJson(filepath + "transfer.json");
+    QJsonObject jsonObj = ParseJson(QDir(filepath).filePath("transfer.json"));
     if (jsonObj.isEmpty()) {
         addTaskcounter(-1);
         WLOG << "transfer.json is invaild";
@@ -100,8 +104,10 @@ bool SettingHelper::handleDataConfiguration(const QString &path)
         }
     }
     addTaskcounter(-1);
-    //remove dir
-    pdir.removeRecursively();
+    //remove transfer.json
+    const QString jsonFile = QDir(filepath).filePath("transfer.json");
+    if (!QFile::remove(jsonFile))
+        WLOG << "Failed to remove transfer.json: " << jsonFile.toStdString();
     return true;
 }
 
@@ -309,8 +315,11 @@ bool SettingHelper::setFile(QJsonObject jsonObj, QString filepath)
         const QJsonArray &userFileArray = userFileValue.toArray();
         for (const auto &value : userFileArray) {
             QString filename = value.toString();
+
+            // 只保留文件名部分，兼容相对路径和绝对路径格式
+            QString file = filepath + QFileInfo(filename).fileName();
+
             QString targetFile = QDir::homePath() + "/" + filename;
-            QString file = filepath + filename.mid(filename.indexOf('/') + 1);
             QFileInfo info = QFileInfo(targetFile);
             auto dir = info.dir();
             if (!dir.exists())


### PR DESCRIPTION
- Add 10-click sequence on Basic Settings label to trigger debug dialog
- Implement click counter with 3-second timeout reset functionality
- Add similar click-based debug access to data transfer start widget
- Install event filters for mouse button release detection
- Connect timer signals for automatic click count reset

## Summary by Sourcery

Add a hidden debug dialog accessible from key GUI labels and wire it into shared utilities and plugins.

New Features:
- Introduce a reusable debug dialog for adjusting log level, exporting logs, and detecting network ports.
- Enable hidden 10-click access to the debug dialog from the Basic Settings label in the settings dialog.
- Enable hidden 10-click access to the debug dialog from the data transfer start widget title.

Enhancements:
- Extend common utilities with a helper to return the current log directory for use by debugging tools.

Build:
- Include the new debug dialog sources in cooperation core, transfer, and data-transfer core plugin builds.