### PR TITLE
fix(transfer): do not remove transfer confirmation on job completion

### DIFF
--- a/src/plugins/daemon/core/service/jobmanager.cpp
+++ b/src/plugins/daemon/core/service/jobmanager.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -321,10 +321,7 @@ void JobManager::handleJobTransStatus(QString appname, int jobid, int status, QS
     req.add_member("api", "Frontend.cbTransStatus");
     SendIpcService::instance()->handleSendToClient(appname, req.str().c_str());
 
-    // 安全验证：作业完成、取消或失败时，清理确认状态
-    if (status == JOB_TRANS_FINISHED || status == JOB_TRANS_CANCELED || status == JOB_TRANS_FAILED) {
-        removeConfirmedTransfer(appname);
-    }
+
 }
 
 void JobManager::handleRemoveJob(const int jobid)


### PR DESCRIPTION
- Remove the transfer confirmation cleanup on job finished/canceled/failed
- Keep the confirmation state alive for the entire session to allow subsequent transfers without re-authentication
- This fixes the network error when transferring files again after returning from a completed transfer

Log: fix(transfer): 传输完成后点击返回再次传输提示网络错误
Bug: https://pms.uniontech.com/bug-view-355819.html

## Summary by Sourcery

Keep transfer confirmation state across job completion events to avoid unnecessary re-authentication and fix post-transfer errors.

Bug Fixes:
- Prevent network error when initiating a new transfer after returning from a completed, canceled, or failed transfer by no longer clearing the confirmation state on job completion.

Enhancements:
- Update SPDX copyright header years for the job manager service source file.