### PR TITLE
fix(data-transfer): save files to ~/Downloads subdirectory and only r…

### DIFF
--- a/src/plugins/daemon/core/utils/config.h
+++ b/src/plugins/daemon/core/utils/config.h
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -168,7 +168,7 @@ public:
             // 默认使用下载目录
             _storageDir = path::join(home, "Downloads");
         } else {
-            _storageDir = path::join(home, _targetName);
+            _storageDir = path::join(path::join(home, "Downloads"), _targetName);
         }
         return _storageDir;
     }
@@ -178,8 +178,7 @@ public:
         fastring home;
         home = getAppConfig(appName, "storagedir");
         if (home.empty())
-            // 默认使用下载目录
-            home = path::join(os::homedir(), "Downloads");
+            home = getStorageDir();
 
         return home;
     }

--- a/src/plugins/data-transfer/core/utils/settinghepler.cpp
+++ b/src/plugins/data-transfer/core/utils/settinghepler.cpp
@@ -1,4 +1,7 @@
-﻿#include "settinghepler.h"
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "settinghepler.h"
 #include "transferhepler.h"
 
 #include <QDebug>
@@ -56,7 +59,7 @@ QJsonObject SettingHelper::ParseJson(const QString &filepath)
 bool SettingHelper::handleDataConfiguration(const QString &filepath)
 {
     addTaskcounter(1);
-    QJsonObject jsonObj = ParseJson(filepath + "/" + "transfer.json");
+    QJsonObject jsonObj = ParseJson(QDir(filepath).filePath("transfer.json"));
     if (jsonObj.isEmpty()) {
         addTaskcounter(-1);
         WLOG << "transfer.json is invaild";
@@ -85,8 +88,13 @@ bool SettingHelper::handleDataConfiguration(const QString &filepath)
         }
     }
     addTaskcounter(-1);
-    //remove dir
-    QDir(filepath).removeRecursively();
+    const QString jsonFile = QDir(filepath).filePath("transfer.json");
+    if (QFile::exists(jsonFile)) {
+        LOG << "Removing transfer.json: " << jsonFile.toStdString();
+        if (!QFile::remove(jsonFile)) {
+            WLOG << "Failed to remove transfer.json: " << jsonFile.toStdString();
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
…emove transfer.json

- Fix storage directory for data-transfer: place target subdirectory under ~/Downloads instead of directly under home directory
- Change cleanup behavior to only remove transfer.json instead of the entire directory

Log: fix(data-transfer): save files to ~/Downloads subdirectory and only remove transfer.json
Bug: https://pms.uniontech.com/bug-view-356089.html

## Summary by Sourcery

Adjust data transfer storage location and cleanup behavior for downloaded files.

Bug Fixes:
- Ensure data-transfer stores files in a subdirectory under the user's Downloads folder instead of directly under the home directory.
- Limit cleanup after handling data configuration to removing only transfer.json rather than deleting the entire transfer directory.