### PR TITLE
fix(data-transfer): improve file path handling in setting helper

### DIFF
--- a/src/lib/data-transfer/core/utils/settinghepler.cpp
+++ b/src/lib/data-transfer/core/utils/settinghepler.cpp
@@ -1,4 +1,8 @@
-﻿#include "settinghepler.h"
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "settinghepler.h"
 
 #include "common/log.h"
 
@@ -71,7 +75,7 @@ bool SettingHelper::handleDataConfiguration(const QString &path)
 
     QDir pdir(path);
     QString filepath = pdir.absolutePath() + "/";
-    QJsonObject jsonObj = ParseJson(filepath + "transfer.json");
+    QJsonObject jsonObj = ParseJson(pdir.filePath("transfer.json"));
     if (jsonObj.isEmpty()) {
         addTaskcounter(-1);
         WLOG << "transfer.json is invaild";
@@ -100,8 +104,10 @@ bool SettingHelper::handleDataConfiguration(const QString &path)
         }
     }
     addTaskcounter(-1);
-    //remove dir
-    pdir.removeRecursively();
+    //remove transfer.json
+    const QString jsonFile = pdir.filePath("transfer.json");
+    if (!QFile::remove(jsonFile))
+        WLOG << "Failed to remove transfer.json: " << jsonFile.toStdString();
     return true;
 }
 
@@ -309,8 +315,11 @@ bool SettingHelper::setFile(QJsonObject jsonObj, QString filepath)
         const QJsonArray &userFileArray = userFileValue.toArray();
         for (const auto &value : userFileArray) {
             QString filename = value.toString();
+
+            // 只保留文件名部分，兼容相对路径和绝对路径格式
+            QString file = filepath + QFileInfo(filename).fileName();
+
             QString targetFile = QDir::homePath() + "/" + filename;
-            QString file = filepath + filename.mid(filename.indexOf('/') + 1);
             QFileInfo info = QFileInfo(targetFile);
             auto dir = info.dir();
             if (!dir.exists())


### PR DESCRIPTION
- Extract only the filename part from the full path to support both relative and absolute path formats
- Use QFileInfo to properly handle path separators across different platforms
- Replace complex string manipulation with more robust file name extraction logic

## Summary by Sourcery

Improve data transfer setting helper path handling and cleanup behavior.

Bug Fixes:
- Handle JSON configuration path construction using QDir::filePath to avoid manual path concatenation issues with separators and formats.
- Remove only the transfer.json file instead of recursively deleting the entire directory after processing.
- Correct file name extraction in setFile to support both relative and absolute input paths using QFileInfo.

Enhancements:
- Add SPDX copyright and license header to the setting helper implementation file.