### PR TITLE
fix(network): filter virtual network interfaces correctly on Windows

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-cooperation (1.2.3) unstable; urgency=medium
+
+  * chore: Update version to 1.2.3
+  * fix(network): filter virtual network interfaces correctly on Windows
+  * fix: add PNG/JPEG to BMP DIB conversion for X11 clipboard
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 23 Apr 2026 16:42:52 +0800
+
 dde-cooperation (1.2.2) unstable; urgency=medium
 
   * fix(log): remove duplicate qCritical logs

--- a/src/common/commonutils.cpp
+++ b/src/common/commonutils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,6 +24,27 @@ using namespace deepin_cross;
 #define WEB_MIN_PORT 13628
 #define WEB_MAX_PORT 23628
 
+static bool isVirtualInterface(const QNetworkInterface &netInterface)
+{
+    QString name = netInterface.name().toLower();
+    if (name.startsWith("virbr") || name.startsWith("vmnet")
+        || name.startsWith("docker") || name.startsWith("veth")
+        || name.startsWith("br-")) {
+        qInfo() << "Filtering virtual interface (by name):" << netInterface.name();
+        return true;
+    }
+
+    QString humanName = netInterface.humanReadableName().toLower();
+    if (humanName.contains("vmware") || humanName.contains("virtualbox")
+        || humanName.contains("hyper-v") || humanName.contains("virtual ethernet")
+        || humanName.contains("vethernet") || humanName.contains("bluetooth")) {
+        qInfo() << "Filtering virtual interface (by humanReadableName):" << netInterface.humanReadableName();
+        return true;
+    }
+
+    return false;
+}
+
 std::string CommonUitls::getFirstIp()
 {
     qInfo() << "Getting first available IP address";
@@ -38,10 +59,7 @@ std::string CommonUitls::getFirstIp()
             continue;
         }
 
-        if (netInterface.name().startsWith("virbr") || netInterface.name().startsWith("vmnet")
-            || netInterface.name().startsWith("docker")) {
-            // 跳过桥接，虚拟机和docker的网络接口
-            qInfo() << "netInterface name:" << netInterface.name();
+        if (isVirtualInterface(netInterface)) {
             continue;
         }
 
@@ -52,7 +70,7 @@ std::string CommonUitls::getFirstIp()
             if (entry.ip().protocol() == QAbstractSocket::IPv4Protocol && entry.ip() != QHostAddress::LocalHost) {
                 //IP地址
                 ip = QString(entry.ip().toString());
-                qInfo() << "Found available IP: " << ip;
+                qInfo() << "Found available IP: " << ip << "on interface:" << netInterface.name();
                 return ip.toStdString();
             }
         }

--- a/src/compat/common/commonutils.cpp
+++ b/src/compat/common/commonutils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,6 +23,27 @@ static constexpr char kApp1[] { "dde-cooperation" };
 static constexpr char kApp2[] { "deepin-data-transfer" };
 static constexpr char kDaemon[] { "cooperation-daemon" };
 
+static bool isVirtualInterface(const QNetworkInterface &netInterface)
+{
+    QString name = netInterface.name().toLower();
+    if (name.startsWith("virbr") || name.startsWith("vmnet")
+        || name.startsWith("docker") || name.startsWith("veth")
+        || name.startsWith("br-")) {
+        qInfo() << "Filtering virtual interface (by name):" << netInterface.name();
+        return true;
+    }
+
+    QString humanName = netInterface.humanReadableName().toLower();
+    if (humanName.contains("vmware") || humanName.contains("virtualbox")
+        || humanName.contains("hyper-v") || humanName.contains("virtual ethernet")
+        || humanName.contains("vethernet") || humanName.contains("bluetooth")) {
+        qInfo() << "Filtering virtual interface (by humanReadableName):" << netInterface.humanReadableName();
+        return true;
+    }
+
+    return false;
+}
+
 std::string CommonUitls::getFirstIp()
 {
     QString ip;
@@ -35,10 +56,7 @@ std::string CommonUitls::getFirstIp()
             continue;
         }
 
-        if (netInterface.name().startsWith("virbr") || netInterface.name().startsWith("vmnet")
-            || netInterface.name().startsWith("docker")) {
-            // 跳过桥接，虚拟机和docker的网络接口
-            qInfo() << "netInterface name:" << netInterface.name();
+        if (isVirtualInterface(netInterface)) {
             continue;
         }
 


### PR DESCRIPTION
Fix data migration failure when multiple network adapters exist, including virtual adapters like VMware Network Adapter VMnet1. On Windows, virtual adapter names in QNetworkInterface::name() are GUIDs, not "vmnet*", so the previous filter failed to exclude them, causing the app to select the wrong IP address (e.g., 192.168.199.1 instead of the real WLAN IP 192.168.43.204).

Changes:
- Add isVirtualInterface() helper to check both name() and humanReadableName()
- Linux: filter virbr*, vmnet*, docker*, veth*, br- prefixes
- Windows: filter VMware, VirtualBox, Hyper-V, Virtual Ethernet, vEthernet, Bluetooth

This ensures the sender advertises the correct IP address and the web server binds to a reachable network interface, preventing 0B file transfers.

## Summary by Sourcery

Filter out virtual and non-routable network interfaces more reliably when selecting the first available IP address.

Bug Fixes:
- Prevent selection of IP addresses from virtual or bridged adapters (e.g., VMware, VirtualBox, Hyper-V, Docker) when determining the primary IPv4 address.
- Ensure the application binds its web server to a reachable, physical network interface on both Linux and Windows.

Enhancements:
- Introduce a reusable helper to detect virtual network interfaces using both technical and human-readable interface names, with improved logging for filtered adapters.