### PR TITLE
fix(gui): correct dialog window flags setting

### DIFF
--- a/src/lib/cooperation/core/gui/widgets/cooperationstatewidget.cpp
+++ b/src/lib/cooperation/core/gui/widgets/cooperationstatewidget.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023-2024 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -459,7 +459,7 @@ void BottomLabel::initUI()
     contentLayout->setAlignment(Qt::AlignCenter);
 
     dialog->setLayout(contentLayout);
-    dialog->setWindowFlags(Qt::ToolTip);
+    dialog->setWindowFlags(Qt::Tool);
 
     CooperationGuiHelper::setAutoFont(tipWidgt, 14, QFont::Normal);
     CooperationGuiHelper::setAutoFont(tipWidgt, 12, QFont::Normal);


### PR DESCRIPTION
Change dialog window flags from Qt::ToolTip to Qt::Tool to fix display and interaction issues.

修复对话框窗口标志设置错误，将 Qt::ToolTip 改为 Qt::Tool
以解决显示和交互问题。

Log: 修复对话框窗口标志设置
PMS: BUG-355923
Influence: 修复后对话框能够正常显示和交互，提升用户体验。