### PR TITLE
fix: delay discovery service init to prevent focus stealing

### DIFF
--- a/src/lib/cooperation/core/cooperationcoreplugin.cpp
+++ b/src/lib/cooperation/core/cooperationcoreplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,6 +24,7 @@
 #include <QCommandLineParser>
 #include <QCommandLineOption>
 #include <QStandardPaths>
+#include <QTimer>
 #ifdef __linux__
 #    include "base/reportlog/reportlogmanager.h"
 #    include <DFeatureDisplayDialog>
@@ -164,9 +165,6 @@ bool CooperaionCorePlugin::start()
         connect(HistoryManager::instance(), &HistoryManager::connectHistoryUpdated, DiscoverController::instance(), &DiscoverController::onConnectHistoryUpdated);
         DLOG << "Connected history update signals";
 
-        DiscoverController::instance()->init();   // init zeroconf and regist
-        DLOG << "Discover controller initialized";
-
         // start network status listen after all ready
         CooperationUtil::instance()->initNetworkListener();
         DLOG << "Network listener initialized";
@@ -197,6 +195,15 @@ bool CooperaionCorePlugin::start()
     } else {
         DLOG << "Showing main window";
         dMain->show();
+    }
+
+    if (!onlyTransfer) {
+        // Delay discovery init to ensure main window is visible first,
+        // preventing focus stealing from the discovery/auth dialog
+        QTimer::singleShot(500, this, []() {
+            DiscoverController::instance()->init();
+            DLOG << "Discover controller initialized (delayed)";
+        });
     }
 
     return true;


### PR DESCRIPTION
## Summary

- Fix PMS Bug #355969: password input box not editable by default when opening cooperation
- Delay `DiscoverController::init()` to after main window `show()` via `QTimer::singleShot(500ms)`
- Prevents main window from stealing focus from discovery/auth dialogs

## Root Cause

`CooperaionCorePlugin::start()` called `DiscoverController::init()` before `dMain->show()`. When the discovery service dialog was shown (blocking `exec()`), after it closed the main window appeared and stole focus from subsequent input dialogs.

## Test Plan

- [x] Open cooperation when Avahi service is NOT running
- [x] Verify main window appears first, then discovery service dialog
- [x] Verify password/input fields are focusable and editable
- [x] Verify discovery still works correctly after confirming the dialog