### PR TITLE
fix(log): remove write to read-only system directory in initLog

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -31,3 +31,9 @@ Files: android/*
 Copyright:
  2018 Huang JinQun <jinqun0730@gmail.com>
 License: Apache-2.0
+
+# config files without inline SPDX headers
+Files: src/common/config.conf
+Copyright:
+ 2023 - 2026 UnionTech Software Technology Co., Ltd.
+License: GPL-3.0-or-later

--- a/debian/dde-cooperation.install
+++ b/debian/dde-cooperation.install
@@ -10,6 +10,8 @@ usr/lib/*/libco.so*
 usr/lib/*/libzrpc.so*
 usr/lib/*/dde-cooperation/plugins/daemon/libdaemon-core.so
 usr/share/dde-cooperation/translations/*.qm
+usr/share/dde-cooperation/config.conf
+usr/share/dde-cooperation-daemon/config.conf
 usr/share/icons/hicolor/scalable/apps/dde-cooperation.svg
 usr/share/dsg/configs/org.deepin.dde.cooperation/*.json
 usr/share/applications/dde-cooperation.desktop

--- a/debian/deepin-data-transfer.install
+++ b/debian/deepin-data-transfer.install
@@ -1,6 +1,7 @@
 usr/bin/deepin-data-transfer
 usr/lib/*/libdata-transfer-core.so*
 usr/share/deepin-data-transfer/translations/*.qm
+usr/share/deepin-data-transfer/config.conf
 usr/share/icons/hicolor/scalable/apps/deepin-data-transfer.svg
 usr/share/applications/deepin-data-transfer.desktop
 usr/share/deepin-log-viewer/deepin-log.conf.d/deepin-data-transfer.json

--- a/src/apps/data-transfer/CMakeLists.txt
+++ b/src/apps/data-transfer/CMakeLists.txt
@@ -147,5 +147,8 @@ else()
 
     # 日志收集配置
     install(FILES res/linux/deepin-data-transfer.json DESTINATION share/deepin-log-viewer/deepin-log.conf.d)
+
+    # 日志级别配置（只读，由deb包安装）
+    install(FILES ${CMAKE_SOURCE_DIR}/src/common/config.conf DESTINATION share/${PROJ_NAME})
 endif()
 

--- a/src/apps/dde-cooperation/CMakeLists.txt
+++ b/src/apps/dde-cooperation/CMakeLists.txt
@@ -140,4 +140,7 @@ else()
 
     # 日志收集配置
     install(FILES res/linux/dde-cooperation.json DESTINATION share/deepin-log-viewer/deepin-log.conf.d)
+
+    # 日志级别配置（只读，由deb包安装）
+    install(FILES ${CMAKE_SOURCE_DIR}/src/common/config.conf DESTINATION share/${PROJ_NAME})
 endif()

--- a/src/common/commonutils.cpp
+++ b/src/common/commonutils.cpp
@@ -142,12 +142,15 @@ void CommonUitls::initLog()
     QString logConfPath = logDir();
 #endif
     QString configFile = logConfPath + "config.conf";   //日志级别配置
-    QFile file(configFile);
     QSettings settings(configFile, QSettings::IniFormat);
+#ifndef linux
+    // On Windows, create config file if not exists (logDir is user-writable)
+    QFile file(configFile);
     if (!file.exists()) {
         settings.setValue("g_minLogLevel", 2);
         settings.sync();
     }
+#endif
 
 #ifndef QT_DEBUG
     int level = settings.value("g_minLogLevel", 2).toInt();

--- a/src/common/config.conf
+++ b/src/common/config.conf
@@ -1,0 +1,2 @@
+[General]
+g_minLogLevel=2

--- a/src/compat/common/commonutils.cpp
+++ b/src/compat/common/commonutils.cpp
@@ -172,12 +172,15 @@ void CommonUitls::initLog()
     QString logConfPath = logDir();
 #endif
     QString configFile = logConfPath + "config.conf";   //日志级别配置
-    QFile file(configFile);
     QSettings settings(configFile, QSettings::IniFormat);
+#ifndef linux
+    // On Windows, create config file if not exists (logDir is user-writable)
+    QFile file(configFile);
     if (!file.exists()) {
         settings.setValue("g_minLogLevel", 2);
         settings.sync();
     }
+#endif
 
 #ifndef QT_DEBUG
     int level = settings.value("g_minLogLevel", 2).toInt();

--- a/src/compat/plugins/daemon/core/CMakeLists.txt
+++ b/src/compat/plugins/daemon/core/CMakeLists.txt
@@ -63,3 +63,6 @@ install(TARGETS
     ${DEEPIN_DAEMON_PLUGIN_DIR}
 )
 
+# 日志级别配置（只读，由deb包安装）
+install(FILES ${CMAKE_SOURCE_DIR}/src/common/config.conf DESTINATION share/dde-cooperation-daemon)
+


### PR DESCRIPTION
## Summary

- Fix PMS Bug #347813: cooperation app triggers Panshi immutable system write rejection notification
- Remove runtime write to `/usr/share/<appName>/config.conf` on Linux, use deb-installed read-only config instead
- Add shared `src/common/config.conf` with default log level, installed via CMake to each app's share directory
- Preserve Windows auto-creation logic (logDir is user-writable there)

## Root Cause

Both `commonutils.cpp` implementations hardcoded `/usr/share/<appName>/config.conf` on Linux and attempted to write when the file didn't exist (`setValue + sync`). The file was never installed by any CMake rule or deb package, so it was always missing on a fresh install, triggering the write attempt on every startup. On immutable/read-only filesystems (磐石系统), this was blocked with a security notification.

## Test Plan

- [x] Build and install deb package, verify config.conf exists in `/usr/share/dde-cooperation/`, `/usr/share/dde-cooperation-daemon/`, `/usr/share/deepin-data-transfer/`
- [x] Open cooperation, verify no Panshi write rejection notification
- [x] Verify log level is correctly set to default (2) from installed config
- [x] Modify installed config.conf to change log level, verify runtime update after 2 seconds
- [x] Verify Windows build still creates config.conf automatically in logDir