### PR TITLE
fix(storage): initialize default save path to Downloads instead of home

### DIFF
--- a/src/compat/plugins/daemon/core/utils/config.h
+++ b/src/compat/plugins/daemon/core/utils/config.h
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -164,10 +164,11 @@ public:
     const fastring getStorageDir()
     {
         fastring home = os::homedir();
+        fastring download = path::join(home, "Downloads");
         if (_targetName.empty()) {
-            _storageDir = home;
+            _storageDir = download;
         } else {
-            _storageDir = path::join(home, _targetName);
+            _storageDir = path::join(download, _targetName);
         }
         return _storageDir;
     }

--- a/src/lib/cooperation/core/net/networkutil.cpp
+++ b/src/lib/cooperation/core/net/networkutil.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,6 +25,7 @@
 #include <QJsonDocument>
 #include <QDebug>
 #include <QDir>
+#include <QStandardPaths>
 #include <QScreen>
 
 using namespace cooperation_core;
@@ -35,6 +36,7 @@ NetworkUtilPrivate::NetworkUtilPrivate(NetworkUtil *qq)
     LOG << "This is only transfer?" << onlyTransfer;
 
     sessionManager = new SessionManager(this);
+    sessionManager->setStorageRoot(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation));
     if (onlyTransfer) {
         DLOG << "Running in transfer-only mode, skipping full initialization";
         return;


### PR DESCRIPTION
## Summary

- Initialize `SessionManager._save_root` to `DownloadLocation` in `NetworkUtilPrivate` constructor, eliminating dependency on `storageConfig` signal timing
- Fix `DaemonConfig::getStorageDir()` fallback from `homedir()` to `path::join(home, "Downloads")` for compat daemon

## Root Cause

PMS Bug #296181 — 新安装镜像上通过文管投送文件后，文件保存在主目录而非下载目录，必现。

**5-Why 分析**:
1. `_save_root`(SessionManager) 和 `storagedir`(DaemonConfig) 未被正确设置
2. `NetworkUtil::updateStorageConfig()` 从未被调用（依赖 `storageConfig` 信号）
3. 信号在 `deviceInfo()` 中通过 `std::call_once` 触发，但可能在 `connect` 之前执行
4. `DaemonConfig::getStorageDir()` fallback 是 `homedir()` 而非 `Downloads`
5. **根因**: 存储路径依赖信号时序初始化，无保底机制

**为什么之前修复两次仍被激活**: 打开设置对话框会自动写入默认路径并触发信号链，"修复"了问题。开发者本地无法复现是因为已有历史配置。

## Test Plan

- [ ] 新安装镜像，不打开设置对话框，投送文件 → 文件保存在 `~/Downloads/设备名(IP)/`
- [ ] 打开设置对话框，路径显示为 `~/Downloads`
- [ ] 修改保存路径后，投送文件 → 文件保存在新路径
- [ ] 通过 compat daemon 接收文件 → 文件保存在 `~/Downloads/`