### PR TITLE
chore: update version to 1.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,22 +16,15 @@ CMake*.json
 vcpkg.json
 
 # AI configuration files
-.roomodes
-.roo/
-.ruru/
-.roo_temp/
-.roo_temp_$$/
 .cursor/
-.spec-workflow/
 .cursorrules
-.cursorindexingignore
-.specstory/
-.taskmaster/
 .kilocode/
-.marscode/
-.qoder/
-.serena/
+
+# AI project spec and knowledge
 .claude/
+.opencode/
+.trellis/
+AGENTS.md
 
 # Modules
 modules/*

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-cooperation (1.2.4) unstable; urgency=medium
+
+  * fix(log): remove write to read-only system directory in initLog
+  * fix(discovery): delay init to prevent focus stealing
+  * fix(gui): correct dialog window flags setting
+
+ -- re2zero <yangwu@uniontech.com>  Wed, 29 Apr 2026 15:36:09 +0800
+
 dde-cooperation (1.2.3) unstable; urgency=medium
 
   * chore: Update version to 1.2.3


### PR DESCRIPTION
- Update .gitignore for AI tool cleanup
- bump version to 1.2.4

Log : bump version to 1.2.4

## Summary by Sourcery

Bump the project version to 1.2.4 and update repository metadata accordingly.

Enhancements:
- Adjust .gitignore entries to exclude additional AI tool artifacts from version control.

Build:
- Update Debian packaging changelog to reflect the 1.2.4 release version.

Chores:
- Increment the overall project version to 1.2.4.