### PR TITLE
chore: update version to 1.2.5

### DIFF
--- a/3rdparty/barrier/src/lib/platform/MSWindowsDesks.cpp
+++ b/3rdparty/barrier/src/lib/platform/MSWindowsDesks.cpp
@@ -463,15 +463,27 @@ MSWindowsDesks::secondaryDeskProc(
 void
 MSWindowsDesks::deskMouseMove(SInt32 x, SInt32 y) const
 {
-    // when using absolute positioning with mouse_event(),
-    // the normalized device coordinates range over only
-    // the primary screen.
-    SInt32 w = GetSystemMetrics(SM_CXSCREEN);
-    SInt32 h = GetSystemMetrics(SM_CYSCREEN);
-    mouse_event(MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE,
-                            (DWORD)((65535.0f * x) / (w - 1) + 0.5f),
-                            (DWORD)((65535.0f * y) / (h - 1) + 0.5f),
-                            0, 0);
+    // clamp coordinates to virtual screen bounds to prevent
+    // overflow in mouse_event normalization and out-of-range
+    // cursor positions on high-resolution or multi-monitor setups.
+    if (x < m_x) { x = m_x; }
+    else if (x > m_x + m_w - 1) { x = m_x + m_w - 1; }
+    if (y < m_y) { y = m_y; }
+    else if (y > m_y + m_h - 1) { y = m_y + m_h - 1; }
+
+    // use SetCursorPos which accepts virtual screen pixel coordinates
+    // directly, avoiding the 0-65535 normalization that mouse_event
+    // requires and the DPI context mismatch after SetThreadDesktop.
+    if (!SetCursorPos(x, y)) {
+        // fallback to mouse_event for cases where SetCursorPos
+        // is blocked (e.g. Vista/7 secure desktop).
+        SInt32 w = GetSystemMetrics(SM_CXSCREEN);
+        SInt32 h = GetSystemMetrics(SM_CYSCREEN);
+        mouse_event(MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE,
+                                (DWORD)((65535.0f * x) / (w - 1) + 0.5f),
+                                (DWORD)((65535.0f * y) / (h - 1) + 0.5f),
+                                0, 0);
+    }
 }
 
 void

--- a/3rdparty/barrier/src/lib/server/Server.cpp
+++ b/3rdparty/barrier/src/lib/server/Server.cpp
@@ -738,6 +738,18 @@ Server::mapToNeighbor(BaseClientProxy* src,
 	assert(lastGoodScreen != NULL);
 	dst = lastGoodScreen;
 
+	// clamp coordinates to destination screen bounds. when screens
+	// have different resolutions, mapToNeighbor can produce values
+	// outside the valid range (e.g. x == dw from the kLeft path).
+	{
+		SInt32 dx, dy, dw, dh;
+		dst->getShape(dx, dy, dw, dh);
+		if (x < dx) { x = dx; }
+		else if (x >= dx + dw) { x = dx + dw - 1; }
+		if (y < dy) { y = dy; }
+		else if (y >= dy + dh) { y = dy + dh - 1; }
+	}
+
 	// if entering primary screen then be sure to move in far enough
 	// to avoid the jump zone.  if entering a side that doesn't have
 	// a neighbor (i.e. an asymmetrical side) then we don't need to

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-cooperation (1.2.5) unstable; urgency=medium
+
+  * fix(barrier): prevent mouse freeze when crossing different-resolution screens
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 04 Jun 2026 20:40:34 +0800
+
 dde-cooperation (1.2.4) unstable; urgency=medium
 
   * fix(log): remove write to read-only system directory in initLog


### PR DESCRIPTION
## Summary
- bump version to 1.2.5
- fix(barrier): prevent mouse freeze when crossing different-resolution screens

Log : bump version to 1.2.5