### PR TITLE
chore(tests): enable unit tests build options for basekit and netutil modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,9 @@
 # it causes barrier build failed on MSVC, so only enable it for src
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+# Enable testing globally (per-module options control which tests are built)
+enable_testing()
+
 # some base common libraries
 add_subdirectory(infrastructure)
 

--- a/src/infrastructure/CMakeLists.txt
+++ b/src/infrastructure/CMakeLists.txt
@@ -2,6 +2,12 @@ if(ENABLE_SLOTIPC)
     include("slotipc.cmake")
 endif()
 
+# Unit tests configuration
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+    enable_testing()
+endif()
+
 # the ssl configuration module, must before Compiler features
 add_subdirectory(sslconf)
 

--- a/src/infrastructure/basekit/CMakeLists.txt
+++ b/src/infrastructure/basekit/CMakeLists.txt
@@ -53,8 +53,11 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" PUBLIC ${vld})
 target_link_libraries(${PROJECT_NAME} ${LINKLIBS} fmt)
 
-# # Enable testing
-# enable_testing()
-
-# # Add tests
-# add_subdirectory(tests)
+# Enable testing
+option(BUILD_BASEKIT_TESTS "Build basekit tests" OFF)
+if(BUILD_BASEKIT_TESTS)
+    if(NOT BUILD_TESTS)
+        enable_testing()
+    endif()
+    add_subdirectory(tests)
+endif()

--- a/src/infrastructure/logging/CMakeLists.txt
+++ b/src/infrastructure/logging/CMakeLists.txt
@@ -49,8 +49,8 @@ endif()
 # 添加测试支持
 option(BUILD_LOGGING_TESTS "Build logging tests" OFF)
 if(BUILD_LOGGING_TESTS)
-    # 启用测试
-    enable_testing()
-    # 添加tests子目录
+    if(NOT BUILD_TESTS)
+        enable_testing()
+    endif()
     add_subdirectory(tests)
 endif()

--- a/src/infrastructure/netutil/CMakeLists.txt
+++ b/src/infrastructure/netutil/CMakeLists.txt
@@ -68,8 +68,8 @@ endif()
 # 添加测试支持
 option(BUILD_NETUTIL_TESTS "Build netutil tests" OFF)
 if(BUILD_NETUTIL_TESTS)
-    # 启用测试
-    enable_testing()
-    # 添加tests子目录
+    if(NOT BUILD_TESTS)
+        enable_testing()
+    endif()
     add_subdirectory(tests)
 endif()

--- a/src/infrastructure/netutil/tests/CMakeLists.txt
+++ b/src/infrastructure/netutil/tests/CMakeLists.txt
@@ -32,5 +32,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE netutil Catch2::Catch2WithMain)
 
 # 启用测试
 include(CTest)
+find_package(Catch2)
 include(Catch)
 catch_discover_tests(${PROJECT_NAME}) 


### PR DESCRIPTION
Enable BUILD_BASEKIT_TESTS CMake option and fix Catch2 v3 include path for netutil tests to support optional unit test builds.

Log: 启用 basekit 和 netutil 模块的单元测试构建选项
Influence: 用户可通过 -DBUILD_BASEKIT_TESTS=ON 等选项选择性构建单元测试。

## Summary by Sourcery

Enable optional unit test builds for the basekit module and fix Catch2 integration for netutil tests.

Tests:
- Add a CMake option to conditionally build basekit unit tests and wire it to the tests subdirectory.
- Update netutil tests CMake configuration to use the correct Catch2 v3 CTest integration script.