### PR TITLE
chore(tests): enable unit tests build options for basekit and netutil…

### DIFF
--- a/src/infrastructure/basekit/CMakeLists.txt
+++ b/src/infrastructure/basekit/CMakeLists.txt
@@ -53,8 +53,9 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" PUBLIC ${vld})
 target_link_libraries(${PROJECT_NAME} ${LINKLIBS} fmt)
 
-# # Enable testing
-# enable_testing()
-
-# # Add tests
-# add_subdirectory(tests)
+# Enable testing
+option(BUILD_BASEKIT_TESTS "Build basekit tests" OFF)
+if(BUILD_BASEKIT_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/src/infrastructure/netutil/tests/CMakeLists.txt
+++ b/src/infrastructure/netutil/tests/CMakeLists.txt
@@ -32,5 +32,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE netutil Catch2::Catch2WithMain)
 
 # 启用测试
 include(CTest)
-include(Catch)
+include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 catch_discover_tests(${PROJECT_NAME}) 


### PR DESCRIPTION
… modules

Enable BUILD_BASEKIT_TESTS CMake option and fix Catch2 v3 include path for netutil tests to support optional unit test builds.

Log: 启用 basekit 和 netutil 模块的单元测试构建选项
Influence: 用户可通过 -DBUILD_BASEKIT_TESTS=ON 等选项选择性构建单元测试。