### PR TITLE
chore(i18n): update lupdate source path from plugins to lib and refre…

### DIFF
--- a/src/data-transfer-translate.sh
+++ b/src/data-transfer-translate.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-lupdate ./plugins/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer.ts
-lupdate ./plugins/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_zh_CN.ts
-lupdate ./plugins/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_zh_HK.ts
-lupdate ./plugins/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_zh_TW.ts
-lupdate ./plugins/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_bo.ts
-lupdate ./plugins/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_ug.ts
+lupdate ./lib/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer.ts
+lupdate ./lib/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_zh_CN.ts
+lupdate ./lib/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_zh_HK.ts
+lupdate ./lib/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_zh_TW.ts
+lupdate ./lib/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_bo.ts
+lupdate ./lib/data-transfer ./apps/data-transfer  -ts -no-obsolete ../translations/deepin-data-transfer/deepin-data-transfer_ug.ts

--- a/translations/deepin-data-transfer/deepin-data-transfer.ts
+++ b/translations/deepin-data-transfer/deepin-data-transfer.ts
@@ -4,47 +4,47 @@
 <context>
     <name>AppSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="42"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="50"/>
         <source>Check transfer application will automatically install the corresponding UOS version of the application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="64"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="62"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Recommendation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="113"/>
         <source>Transferable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="124"/>
         <source>Not Suitable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
         <source>Select apps to transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
         <source>Please select the applications to back up</source>
         <translation type="unfinished"></translation>
     </message>
@@ -52,12 +52,12 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="86"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="41"/>
         <source>UOS data transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="91"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="45"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to UOS, helping you seamlessly replace your system.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -65,32 +65,32 @@
 <context>
     <name>ChooseWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
         <source>Export to local directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="46"/>
         <source>Select a transfer way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="61"/>
         <source>Unable to connect to the network， please check your network connection or select export to local directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="74"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
         <source>From Windows PC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
         <source>Import from backup files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,54 +98,54 @@
 <context>
     <name>ConfigSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="47"/>
         <source>Check transfer configuration will automatically apply to UOS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="59"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="57"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
         <source>Browser bookmarks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Recommendation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="98"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="139"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="109"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="154"/>
         <source>Transferable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Personal Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="153"/>
         <source>Customized Wallpaper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
         <source>Select the configuration to transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
         <source>Please select the configurations to back up</source>
         <translation type="unfinished"></translation>
     </message>
@@ -153,52 +153,57 @@
 <context>
     <name>ConnectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="44"/>
         <source>Ready to connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="49"/>
         <source>Please open data transfer on Windows, and imput the IP and connect code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="56"/>
         <source>Download Windows client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="68"/>
         <source>Connect code is expired, please refresh for new code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="84"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="104"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="114"/>
         <source>computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="107"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="135"/>
         <source>Local IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="163"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="147"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="210"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>The code will be expired in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>please input connect code as soon as possible</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,62 +211,62 @@
 <context>
     <name>CreateBackupFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="87"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="98"/>
         <source>Create data backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="106"/>
         <source>File information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="126"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="144"/>
         <source>size:0B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="152"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="163"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="162"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="173"/>
         <source>(Select Backup Disk)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="187"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="198"/>
         <source>Insufficient space in the selected disk, please clean the space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="206"/>
         <source>Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="193"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="204"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="339"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="369"/>
         <source>Size:%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="382"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="420"/>
         <source>local disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="388"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="426"/>
         <source>%1/%2 available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -269,22 +274,22 @@
 <context>
     <name>CustomMessageBox</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="72"/>
         <source>Reselect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="81"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="87"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>The presence of outstanding transfer tasks between you and the target device has been detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>Do you want to continue with the last transfer?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -292,42 +297,42 @@
 <context>
     <name>ErrorWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="63"/>
         <source>Transfer will be completed in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="78"/>
         <source>Try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="75"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="31"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="30"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
         <source>Transfer interrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
         <source>The network disconnected, transfer failed, please connect the network and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
         <source>Insufficient space in UOS, please clear at least %1 GB and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="38"/>
         <source>Insufficient space in UOS, Please reserve enough space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -335,37 +340,37 @@
 <context>
     <name>FileSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="60"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="69"/>
         <source>When transfer completed, the data will be placed in the user&apos;s home directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="82"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="80"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
         <source>Select the file to transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
         <source>Please select the files to back up</source>
         <translation type="unfinished"></translation>
     </message>
@@ -373,25 +378,44 @@
 <context>
     <name>NetworkDisconnectionWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="38"/>
         <source>The network has been disconnected. Please check your network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="44"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="45"/>
         <source>Try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkUtil</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="472"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="496"/>
+        <source>Transfering</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetworkUtilPrivate</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="145"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="165"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="188"/>
+        <source>Transfering</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProcessWindow</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="297"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="352"/>
         <source>Installing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,87 +423,149 @@
 <context>
     <name>PromptWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="35"/>
         <source>Before tranfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="40"/>
         <source>Data transfer requires some time, to avoid interrupting the migration due to low battery, please keep connect to the  power.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="42"/>
         <source>Other applications may slowdown the transfer speed. For smoother experience, please close other applications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="44"/>
         <source>For the security of your transfer, please use a trusted network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="68"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="70"/>
         <source>Confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="116"/>
+        <source>Port number must be between %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="120"/>
+        <source>Port is already in use, please change</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaGzipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="44"/>
+        <source>QIODevice::Append is not supported for GZIP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="51"/>
+        <source>Opening gzip for both reading and writing is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="60"/>
+        <source>You can open a gzip either for reading or for writing. Which is it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="67"/>
+        <source>Could not gzopen() file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZIODevice</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="138"/>
+        <source>QIODevice::Append is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="144"/>
+        <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quazipfile.cpp" line="246"/>
+        <source>ZIP/UNZIP API error %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ReadyWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="113"/>
         <source>Ready to connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="117"/>
         <source>IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="125"/>
         <source>Please input the IP of UOS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="79"/>
-        <source>Please open data transfer on UOS, and get the IP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="85"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="148"/>
         <source>Connect code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="159"/>
         <source>Please input the connect code on UOS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="118"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="184"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="33"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="112"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="167"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="178"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="250"/>
         <source>connect...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="49"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="186"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="258"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="242"/>
+        <source>Port is unreachable, please change the port on both devices and retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="354"/>
         <source>Failed to connect, please check your input</source>
         <translation type="unfinished"></translation>
     </message>
@@ -487,28 +573,28 @@
 <context>
     <name>ResultDisplayWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="128"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="154"/>
         <source>Transfer completed partially</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="32"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="125"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="150"/>
         <source>Transfer completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="45"/>
         <source>Partial information migration failed, please go to UOS for manual transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="57"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="59"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -516,19 +602,19 @@
 <context>
     <name>SelectItem</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="216"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="263"/>
         <source>Selected:0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="239"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="241"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="289"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="292"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="295"/>
         <source>Selected:%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="304"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="361"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -536,42 +622,42 @@
 <context>
     <name>SelectMainWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="116"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="121"/>
         <source>App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="97"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="123"/>
         <source>Config</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="138"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="72"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
         <source>Select data to transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="76"/>
         <source>Please select the content to back up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="74"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="77"/>
         <source>Start transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="78"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
@@ -579,117 +665,130 @@
 <context>
     <name>SettingHelper</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Wrong or missing profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
         <source>My Wallpaper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="234"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <source>File not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <source>Failed to move wallpaper file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="293"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
+        <source>Failed to set wallpaper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Browser Bookmarks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
         <source>BrowserBookMark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="176"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="226"/>
         <source>is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="200"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="250"/>
         <source>Installing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
         <source>Format error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Setup failed, configuration can be imported manually</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="157"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="188"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="201"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="297"/>
         <source>Installation failed, please go to the app store to install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="249"/>
-        <source>Transfer Complete</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SidebarWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="21"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
         <source>Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
         <source>Downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="27"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="28"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="80"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="94"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="399"/>
         <source>Select:%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="225"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="267"/>
         <source>local disk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -697,82 +796,73 @@
 <context>
     <name>StartWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
         <source>UOS data transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="43"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to
 UOS, helping you seamlessly replace your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="50"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>TransferHandle</name>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/transferworker.cpp" line="326"/>
-        <source>Transfering</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TransferringWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="42"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="193"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="230"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="221"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="264"/>
         <source>Transferring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="57"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="229"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="65"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="218"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="263"/>
         <source>Calculationing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="63"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="132"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="147"/>
         <source>Show processes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="119"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="133"/>
         <source>Hide processes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="154"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="170"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="223"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="171"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="243"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="281"/>
         <source>Transfering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="199"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="227"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="202"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="231"/>
         <source>Transfer will be completed in --</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="272"/>
         <source>Decompressing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -780,8 +870,8 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>UnzipWorker</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="126"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="137"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="140"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="151"/>
         <source>Decompressing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -789,34 +879,34 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>UploadFileFrame</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="197"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="256"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="212"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="274"/>
         <source>Drag file here </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="202"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="257"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="217"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="275"/>
         <source>Import file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="276"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="296"/>
         <source>Only .zip is supported, please</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="277"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="297"/>
         <source>reselect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>select zip file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>ZIP file (*.zip)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -824,48 +914,43 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>UploadFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
         <source>Select data transfer file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
         <source>File error, cannot transfer, please reselect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="108"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="113"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="121"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="76"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="80"/>
         <source>Retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="130"/>
         <source>The file is corrupted and cannot be migrated. Please replace it with a backup file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="133"/>
-        <source>Insufficient space on UOS. Please reserve at least %1G of space and try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UserSelectFileSize</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/userselectfilesize.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/userselectfilesize.cpp" line="28"/>
         <source>Calculating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -873,33 +958,33 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>WaitTransferWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="36"/>
         <source>Waiting for transfer...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="37"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="41"/>
         <source>Please select the data to transfer on Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="47"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="98"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="113"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="99"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="114"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="116"/>
         <source>This operation will clear the transmission progress, Do you want to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="117"/>
         <source>This operation is not recoverable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -907,32 +992,32 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>ZipFileProcessResultWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="37"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="54"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="91"/>
         <source>Back up succeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="97"/>
         <source>Congratulations, Your Information has been Successfully Backed Up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="102"/>
         <source>Go to View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="131"/>
         <source>Back up failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -940,23 +1025,23 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>ZipFileProcessWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="44"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="51"/>
         <source>Packing  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="53"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="114"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="67"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="97"/>
         <source>Creating Backup File...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -964,12 +1049,12 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>ZipWork</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="283"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="328"/>
         <source>%1 File compression failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="213"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="252"/>
         <source>Back up file done</source>
         <translation type="unfinished"></translation>
     </message>
@@ -977,7 +1062,7 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>data_transfer_core::MainWindowPrivate</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="37"/>
         <source>UOS data transfer</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-data-transfer/deepin-data-transfer_bo.ts
+++ b/translations/deepin-data-transfer/deepin-data-transfer_bo.ts
@@ -1,48 +1,50 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>AppSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="42"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="50"/>
         <source>Check transfer application will automatically install the corresponding UOS version of the application.</source>
         <translation>མཉམ་འགྲོས་ཉེར་སྤྱོད་བདམས་ན། དེ་དང་འདྲ་བའི་UOSཔར་གཞིའི་ཉེར་སྤྱོད་རང་འགུལ་ངང་སྒྲིག་སྦྱོར་བྱེད་སྲིད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="64"/>
         <source>Confirm</source>
         <translation>གཏན་ཁེལ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="62"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Application</source>
         <translation>ཉེར་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Recommendation</source>
         <translation>སྤོ་བའི་བསམ་འཆར།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="113"/>
         <source>Transferable</source>
         <translation>རེད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="124"/>
         <source>Not Suitable</source>
         <translation>མ་རེད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
         <source>Select apps to transfer</source>
         <translation>མཉམ་འགྲོས་དགོས་པའི་ཉེར་སྤྱོད་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
         <source>Please select the applications to back up</source>
         <translation>གྲབས་ཉར་དགོས་པའི་ཉེར་སྤྱོད་འདེམས་རྒྱུ།</translation>
     </message>
@@ -50,12 +52,12 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="86"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="41"/>
         <source>UOS data transfer</source>
         <translation>UOSསྤོ་བའི་ཡོ་བྱད།</translation>
     </message>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="91"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="45"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to UOS, helping you seamlessly replace your system.</source>
         <translation>UOSསྤོ་བའི་ཡོ་བྱད། སྤྱོད་ཐེངས་གཅིག་ལ་ཁྱེད་ཀྱི་ཡིག་ཆ་དང་མི་སྒེར་གྱི་གཞི་གྲངས། ཉེར་སྤྱོད་གཞི་གྲངས་ཚང་མ་UOSལ་སྤོ་ཐུབ་པས། འཕྲལ་མར་རྒྱུད་ཁོངས་བརྗེ་རོགས་བྱེད།</translation>
     </message>
@@ -63,32 +65,32 @@
 <context>
     <name>ChooseWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
         <source>Export to local directory</source>
         <translation>རང་ས་ལ་གྲབས་ཉར་ཕྱིར་འདྲེན་པ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="46"/>
         <source>Select a transfer way</source>
         <translation>ཆ་འཕྲིན་སྤོ་སྟངས་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="61"/>
         <source>Unable to connect to the network， please check your network connection or select export to local directory.</source>
         <translation>ཞབས་ཞུ་ཆས་འབྲེལ་ཐབས་མེད། དྲ་རྒྱའི་འབྲེལ་ལམ་ལ་བརྟག་དཔྱད་བྱེད་པའམ་ཡང་ན་གྲབས་ཉར་ཡིག་ཆར་སྤྱད་ནས་སྤོ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="74"/>
         <source>Next</source>
         <translation>རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
         <source>From Windows PC</source>
         <translation>Windows PCནས་</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
         <source>Import from backup files</source>
         <translation>གྲབས་ཉར་ཡིག་ཆ་ནས་འདྲེན་རྒྱུ།</translation>
     </message>
@@ -96,54 +98,54 @@
 <context>
     <name>ConfigSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="47"/>
         <source>Check transfer configuration will automatically apply to UOS.</source>
         <translation>མིག་སྔའི་མ་ལག་གི་སྒེར་གྱི་བཀོད་སྒྲིག་ལ་བཤེར་ཟིན་པས། སྤོ་དགོས་པའི་བཀོད་སྒྲིག་ཚན་པ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="59"/>
         <source>Confirm</source>
         <translation>གཏན་ཁེལ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="57"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
         <source>Browser bookmarks</source>
         <translation>ལྟ་ཆས་ཀྱི་ཤོག་འཛར།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Recommendation</source>
         <translation>སྤོ་བའི་བསམ་འཆར།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="98"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="139"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="109"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="154"/>
         <source>Transferable</source>
         <translation>རེད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Personal Settings</source>
         <translation>སྒེར་གྱི་བཀོད་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="153"/>
         <source>Customized Wallpaper</source>
         <translation>རང་སྒྲུབ་ཅོག་ངོས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
         <source>Select the configuration to transfer</source>
         <translation>མཉམ་འགྲོས་ཀྱི་བཀོད་སྒྲིག་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
         <source>Please select the configurations to back up</source>
         <translation>གྲབས་ཉར་དགོས་པའི་བཀོད་སྒྲིག་འདེམས་རྒྱུ།</translation>
     </message>
@@ -151,52 +153,57 @@
 <context>
     <name>ConnectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="44"/>
         <source>Ready to connect</source>
         <translation>འབྲེལ་རྩིས་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="49"/>
         <source>Please open data transfer on Windows, and imput the IP and connect code</source>
         <translation>Windowsསྣེ་ནས་སྤོ་བའི་ཡོ་བྱད་ཁ་ཕྱེ་རྗེས། འཕྲུལ་ཆས་འདིའི་IPདང་འབྲེལ་མཐུད་གསང་ཨང་འཇུག་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="56"/>
         <source>Download Windows client</source>
         <translation>Windowsསྤྱོད་སྣེ་ཕབ་ལེན།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="68"/>
         <source>Connect code is expired, please refresh for new code</source>
         <translation>འབྲེལ་མཐུད་གསང་ཨང་དུས་ཡུན་བརྒལ་ཟིན་པས། གསར་སྒྱུར་བྱས་ནས་གསང་ཨང་གསར་པ་ལེན་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="84"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="104"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="114"/>
         <source>computer</source>
         <translation>གློག་ཀླད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="107"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="135"/>
         <source>Local IP</source>
         <translation>རང་འཕྲུལ་འཁོར་IP</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="163"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="147"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="210"/>
         <source>Refresh</source>
         <translation>གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>The code will be expired in</source>
         <translation>གསང་ཨང་སྤྱོད་གོ་ཆོད་པའི་དུས་ཚོད་</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>please input connect code as soon as possible</source>
         <translation>འབྲེལ་མཐུད་གསང་ཨང་གང་མགྱོགས་འཇུག་རོགས།</translation>
     </message>
@@ -204,62 +211,62 @@
 <context>
     <name>CreateBackupFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="87"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="98"/>
         <source>Create data backup</source>
         <translation>གྲབས་ཉར་ཡིག་ཆ་གསར་པ་བཟོ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="106"/>
         <source>File information</source>
         <translation>ཡིག་ཆའི་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="126"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="144"/>
         <source>size:0B</source>
         <translation>ཆེ་ཆུང་།0B</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="152"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="163"/>
         <source>Location</source>
         <translation>ཉར་ཚགས་བྱེད་ཡུལ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="162"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="173"/>
         <source>(Select Backup Disk)</source>
         <translation>（གྲབས་ཉར་སྡུད་སྡེར་འདེམས་རྒྱུ་）</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="187"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="198"/>
         <source>Insufficient space in the selected disk, please clean the space</source>
         <translation>མིག་སྔའི་སྡུད་སྡེར་ཤོང་ཚད་མི་འདང་བས། སྡུད་སྡེར་གཙང་སེལ་གནང་རོགས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="206"/>
         <source>Backup</source>
         <translation>གྲབས་ཉར་འགོ་ཚུགས་པ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="193"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="204"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="339"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="369"/>
         <source>Size:%1</source>
         <translation>ཆེ་ཆུང་། %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="382"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="420"/>
         <source>local disk</source>
         <translation>རང་སའི་སྡུད་སྡེར།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="388"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="426"/>
         <source>%1/%2 available</source>
         <translation>%1/%2སྤྱད་ཆོག</translation>
     </message>
@@ -267,22 +274,22 @@
 <context>
     <name>CustomMessageBox</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="72"/>
         <source>Reselect</source>
         <translation>ཡང་བསྐྱར་འདེམས་པ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="81"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="87"/>
         <source>Continue</source>
         <translation>མུ་མཐུད་བསྐུར་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>The presence of outstanding transfer tasks between you and the target device has been detected.</source>
         <translation>ཁྱེད་དང་དམིགས་ཡུལ་སྒྲིག་ཆས་དབར་ཚར་མེད་པའི་བརྒྱུད་བསྐུར་ལས་འགན་ཡོད་པ་བཤེར་འཇལ་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>Do you want to continue with the last transfer?</source>
         <translation>ཁྱེད་ཀྱིས་མུ་མཐུད་སྔ་མའི་བརྒྱུད་བསྐུར་ལས་འགན་ལེགས་གྲུབ་བྱེད་དམ།</translation>
     </message>
@@ -290,42 +297,42 @@
 <context>
     <name>ErrorWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="63"/>
         <source>Transfer will be completed in</source>
         <translation>སྔོན་རྩིས་ལྟར་ན་ད་དུང་  སྤོ་དགོས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="78"/>
         <source>Try again</source>
         <translation>ཡང་བསྐྱར་ཚོད་ལྟ་བགྱིས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="75"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="31"/>
         <source>Network Error</source>
         <translation>དྲ་རྒྱ་ནོར་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="30"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
         <source>Transfer interrupted</source>
         <translation>སྤོ་མཚམས་ཆད་པ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
         <source>The network disconnected, transfer failed, please connect the network and try again</source>
         <translation>དྲ་བ་ཆད་པའི་རྐྱེན་གྱིས་སྤོ་ཐུབ་མ་སོང་། དྲ་རྒྱར་ཞིབ་བཤེར་རམ་ཡང་བསྐྱར་ཚོད་ལྟ་གནང་རོགས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
         <source>Insufficient space in UOS, please clear at least %1 GB and try again</source>
         <translation>UOSཤོང་ཚད་འདང་ངེས་མེད་པས། གཙང་སེལ་%1GBབྱས་རྗེས་ཡང་བསྐྱར་ཚོད་ལྟ་བགྱིས་དང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="38"/>
         <source>Insufficient space in UOS, Please reserve enough space</source>
         <translation>UOSཤོང་ཚད་འདང་ངེས་མེད་པས། འདང་ངེས་ཤོང་ཚད་བཞག་དགོས།</translation>
     </message>
@@ -333,37 +340,37 @@
 <context>
     <name>FileSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="60"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="69"/>
         <source>When transfer completed, the data will be placed in the user&apos;s home directory</source>
         <translation>བརྒྱུད་བསྐུར་ལེགས་གྲུབ་ཐུབ་པའི་གཞི་གྲངས་རྣམས་སྤྱོད་མཁན་གྱི་དཀར་ཆག་homeའོག་ཏུ་ཉར་སྲིད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="82"/>
         <source>Confirm</source>
         <translation>གཏན་ཁེལ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="80"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
         <source>Select the file to transfer</source>
         <translation>སྤོ་དགོས་པའི་ཡིག་ཆ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
         <source>Please select the files to back up</source>
         <translation>གྲབས་ཉར་དགོས་པའི་ཡིག་ཆ་འདེམས་རྒྱུ། </translation>
     </message>
@@ -371,25 +378,44 @@
 <context>
     <name>NetworkDisconnectionWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="38"/>
         <source>The network has been disconnected. Please check your network</source>
         <translation>དྲ་རྒྱ་བཅད་ཟིན་པས། ཁྱེད་ཀྱི་དྲ་རྒྱ་བཤེར་རོགས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="44"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="45"/>
         <source>Try again</source>
         <translation>ཡང་བསྐྱར་ཚོད་ལྟ་བགྱིས།</translation>
     </message>
 </context>
 <context>
+    <name>NetworkUtil</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="472"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="496"/>
+        <source>Transfering</source>
+        <translation type="unfinished">བསྐུར་བཞིན་པ། </translation>
+    </message>
+</context>
+<context>
+    <name>NetworkUtilPrivate</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="145"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="165"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="188"/>
+        <source>Transfering</source>
+        <translation type="unfinished">བསྐུར་བཞིན་པ། </translation>
+    </message>
+</context>
+<context>
     <name>ProcessWindow</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="297"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="352"/>
         <source>Installing</source>
         <translation>སྒྲིག་སྦྱོར་བཞིན་པ། </translation>
     </message>
@@ -397,87 +423,149 @@
 <context>
     <name>PromptWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="35"/>
         <source>Before tranfer</source>
         <translation>འགོ་མ་ཚུགས་གོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="40"/>
         <source>Data transfer requires some time, to avoid interrupting the migration due to low battery, please keep connect to the  power.</source>
         <translation>སྤོ་བར་དུས་ཚོད་ངེས་ཅན་དགོས་པས། གློག་ཆད་ནས་སྤོ་མཚམས་མི་ཆད་པའི་ཆེད་དུ་གློག་ཁུངས་སྦྲེལ་རོགས་གནང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="42"/>
         <source>Other applications may slowdown the transfer speed. For smoother experience, please close other applications.</source>
         <translation>ཉེར་སྤྱོད་གཞན་དག་གིས་སྤོ་བའི་མགྱོགས་ཚད་ལ་ཤུགས་རྐྱེན་མི་ཐེབས་པའི་ཆེད་དུ་ཉེར་སྤྱོད་གཞན་དག་སྒོ་རྒྱག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="44"/>
         <source>For the security of your transfer, please use a trusted network.</source>
         <translation>ཁྱེད་ཀྱི་བརྒྱུད་བསྐུར་ཆ་འཕྲིན་གྱི་བདེ་འཇགས་ཆེད་ཡིད་ཆེས་རུང་བའི་དྲ་རྒྱ་སྤྱོད་རོགས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="68"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="70"/>
         <source>Confirm</source>
         <translation>གཏན་ཁེལ།</translation>
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="116"/>
+        <source>Port number must be between %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="120"/>
+        <source>Port is already in use, please change</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaGzipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="44"/>
+        <source>QIODevice::Append is not supported for GZIP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="51"/>
+        <source>Opening gzip for both reading and writing is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="60"/>
+        <source>You can open a gzip either for reading or for writing. Which is it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="67"/>
+        <source>Could not gzopen() file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZIODevice</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="138"/>
+        <source>QIODevice::Append is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="144"/>
+        <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quazipfile.cpp" line="246"/>
+        <source>ZIP/UNZIP API error %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ReadyWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="113"/>
         <source>Ready to connect</source>
         <translation>འབྲེལ་རྩིས་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="117"/>
         <source>IP</source>
         <translation>IPས་གནས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="125"/>
         <source>Please input the IP of UOS</source>
         <translation>UOSསྣེའི་IPས་གནས་འཇུག་རོགས་གནང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="79"/>
-        <source>Please open data transfer on UOS, and get the IP</source>
-        <translation>UOSསྣེའི་གཞི་གྲངས་སྤོ་བའི་ཡོ་བྱད་ཁ་ཕྱེ་བ་དང་སྦྲགས། IPས་གནས་ལྟ་རོགས་གནང་།</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="85"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="148"/>
         <source>Connect code</source>
         <translation>འབྲེལ་མཐུད་གསང་ཨང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="159"/>
         <source>Please input the connect code on UOS</source>
         <translation>UOSསྣེར་འཆར་བའི་འབྲེལ་མཐུད་གསང་ཨང་འཇུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="118"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="184"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="33"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="112"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="167"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="178"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="250"/>
         <source>connect...</source>
         <translation>སྦྲེལ་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="49"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="186"/>
         <source>Connect</source>
         <translation>སྦྲེལ་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="258"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="242"/>
+        <source>Port is unreachable, please change the port on both devices and retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="354"/>
         <source>Failed to connect, please check your input</source>
         <translation>སྦྲེལ་མ་ཐུབ་པས། ནང་འཇུག་ཞིབ་བཤེར་བྱ་རོགས།</translation>
     </message>
@@ -485,28 +573,28 @@
 <context>
     <name>ResultDisplayWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="128"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="154"/>
         <source>Transfer completed partially</source>
         <translation>ཆ་ཤས་སྤོ་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="32"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="125"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="150"/>
         <source>Transfer completed</source>
         <translation>སྤོ་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="45"/>
         <source>Partial information migration failed, please go to UOS for manual transfer</source>
         <translation>ཆ་འཕྲིན་ཆ་ཤས་སྤོ་ཐུབ་མ་སོང་བས། UOSལག་འགུལ་ཐོག་ནས་སྤོ་རོགས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="57"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="59"/>
         <source>Exit</source>
         <translation>ཕྱིར་འཐེན། </translation>
     </message>
@@ -514,19 +602,19 @@
 <context>
     <name>SelectItem</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="216"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="263"/>
         <source>Selected:0</source>
         <translation>འདེམས་པ། 0</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="239"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="241"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="289"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="292"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="295"/>
         <source>Selected:%1</source>
         <translation>འདེམས་ཟིན་པ། %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="304"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="361"/>
         <source>Edit</source>
         <translation>རྩོམ་སྒྲིག</translation>
     </message>
@@ -534,42 +622,42 @@
 <context>
     <name>SelectMainWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="116"/>
         <source>File</source>
         <translation>ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="121"/>
         <source>App</source>
         <translation>ཉེར་སྤྱོད། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="97"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="123"/>
         <source>Config</source>
         <translation>བཀོད་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="138"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="72"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
         <source>Select data to transfer</source>
         <translation>སྤོ་དགོས་པའི་གཞི་གྲངས་འདེམས་རྒྱུ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="76"/>
         <source>Please select the content to back up</source>
         <translation>གྲབས་ཉར་དགོས་པའི་ནང་དོན་འདེམས་རྒྱུ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="74"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="77"/>
         <source>Start transfer</source>
         <translation>སྤོ་འགོ་ཚུགས་པ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="78"/>
         <source>Next</source>
         <translation>རྗེས་མ། </translation>
     </message>
@@ -577,117 +665,130 @@
 <context>
     <name>SettingHelper</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Profiles</source>
         <translation>བཀོད་སྒྲིག་ཡིག་ཆ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Wrong or missing profile</source>
         <translation>བཀོད་སྒྲིག་ཡིག་ཆ་ནོར་བའམ་བོར་འདུག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
         <source>My Wallpaper</source>
         <translation>ངའི་རྒྱབ་ཤོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="234"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <source>File not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <source>Failed to move wallpaper file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="293"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer completed</source>
         <translation>སྤོ་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
+        <source>Failed to set wallpaper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Browser Bookmarks</source>
         <translation>ལྟ་ཆས་ཀྱི་ཤོག་འཛར།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
         <source>BrowserBookMark</source>
         <translation>ལྟ་ཆས་ཀྱི་ཤོག་འཛར། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="176"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="226"/>
         <source>is installed</source>
         <translation>སྒྲིག་སྦྱོར་ཟིན། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="200"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="250"/>
         <source>Installing</source>
         <translation>སྒྲིག་སྦྱོར་བཞིན་པ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer failed</source>
         <translation>སྤོ་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
         <source>Format error</source>
         <translation>རྣམ་གཞག་ནོར་བ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Setup failed, configuration can be imported manually</source>
         <translation>བཀོད་སྒྲིག་མ་ཐུབ་པས། ལག་འགུལ་གྱིས་ནང་འདྲེན་བྱ་རྒྱུ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="157"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="188"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="201"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="297"/>
         <source>Installation failed, please go to the app store to install</source>
         <translation>སྒྲིག་སྦྱོར་མ་ཐུབ་པས། ཉེར་སྤྱོད་ཚོང་ཁང་དུ་བསྐྱོད་ནས་སྒྲིག་སྦྱོར་བྱ་རྒྱུ། </translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="249"/>
-        <source>Transfer Complete</source>
-        <translation>སྤོ་ཐུབ་སོང་།</translation>
     </message>
 </context>
 <context>
     <name>SidebarWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="21"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
         <source>Videos</source>
         <translation>བཪྙན་ཟློས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
         <source>Pictures</source>
         <translation>པར་རིས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
         <source>Documents</source>
         <translation>ཡིག་ཚགས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
         <source>Downloads</source>
         <translation>ཕབ་ལེན། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="27"/>
         <source>Music</source>
         <translation>གླུ་གཞས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="28"/>
         <source>Desktop</source>
         <translation>ཅོག་ངོས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="80"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="94"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="399"/>
         <source>Select:%1</source>
         <translation>འདེམས་ཟིན་པ། %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="225"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="267"/>
         <source>local disk</source>
         <translation>རང་སའི་སྡུད་སྡེར།</translation>
     </message>
@@ -695,82 +796,73 @@
 <context>
     <name>StartWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
         <source>UOS data transfer</source>
         <translation>UOSསྤོ་བའི་ཡོ་བྱད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="43"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to
 UOS, helping you seamlessly replace your system.</source>
         <translation>UOSསྤོ་བའི་ཡོ་བྱད། སྤྱོད་ཐེངས་གཅིག་ལ་ཁྱེད་ཀྱི་ཡིག་ཆ་དང་མི་སྒེར་གྱི་གཞི་གྲངས། ཉེར་སྤྱོད་གཞི་གྲངས་ཚང་མ་UOSལ་སྤོ་ཐུབ་པས། འཕྲལ་མར་རྒྱུད་ཁོངས་བརྗེ་རོགས་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="50"/>
         <source>Next</source>
         <translation>རྗེས་མ། </translation>
     </message>
 </context>
 <context>
-    <name>TransferHandle</name>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/transferworker.cpp" line="326"/>
-        <source>Transfering</source>
-        <translation>བསྐུར་བཞིན་པ། </translation>
-    </message>
-</context>
-<context>
     <name>TransferringWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="42"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="193"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="230"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="221"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="264"/>
         <source>Transferring...</source>
         <translation>བསྐུར་བཞིན་པ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="57"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="229"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="65"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="218"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="263"/>
         <source>Calculationing...</source>
         <translation>རྩིས་བཞིན་པ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="63"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="132"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="147"/>
         <source>Show processes</source>
         <translation>བྱ་རིམ་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="119"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="133"/>
         <source>Hide processes</source>
         <translation>བྱ་རིམ་ཡིབ་པ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="154"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="170"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="223"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>སྔོན་རྩིས་ལྟར་ན་སྤོས་ཚར་བར་ད་དུང་སྐར་མ་%1 དགོས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="171"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="243"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="281"/>
         <source>Transfering</source>
         <translation>བསྐུར་བཞིན་པ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="199"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="227"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>སྔོན་རྩིས་ལྟར་ན་སྤོས་ཚར་བར་ད་དུང་སྐར་ཆ་%1 དགོས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="202"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="231"/>
         <source>Transfer will be completed in --</source>
         <translation>སྔོན་རྩིས་ལྟར་ན་སྤོས་ཚར་བར་ད་དུང་དུས་ཚོད་  དགོས།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="272"/>
         <source>Decompressing</source>
         <translation>སྡུད་གྲོལ་བཞིན་པ། </translation>
     </message>
@@ -778,8 +870,8 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>UnzipWorker</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="126"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="137"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="140"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="151"/>
         <source>Decompressing</source>
         <translation>སྡུད་གྲོལ་བཞིན་པ། </translation>
     </message>
@@ -787,34 +879,34 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>UploadFileFrame</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="197"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="256"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="212"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="274"/>
         <source>Drag file here </source>
         <translation>ཡིག་ཆ་འདི་རུ་འཐེན་དགོས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="202"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="257"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="217"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="275"/>
         <source>Import file</source>
         <translation>ཡིག་ཆ་ནང་འདྲེན། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="276"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="296"/>
         <source>Only .zip is supported, please</source>
         <translation>རྣམ་གཞག་zipགཅིག་པུར་རྒྱབ་སྐྱོར་ཐུབ། ཡང་བསྐྱར་འདེམས་རོགས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="277"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="297"/>
         <source>reselect</source>
         <translation>ཡང་བསྐྱར་འདེམས་པ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>select zip file</source>
         <translation>zipཡིག་ཆ་འདེམས་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>ZIP file (*.zip)</source>
         <translation>ZIPཡིག་ཆ་(*.zip)</translation>
     </message>
@@ -822,48 +914,43 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>UploadFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
         <source>Select data transfer file</source>
         <translation>གཞི་གྲངས་འདེམས་ནས་ཡིག་ཆ་སྤོ་བ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
         <source>File error, cannot transfer, please reselect</source>
         <translation>ཡིག་ཆ་ནོར་བས་སྤོ་ཐབས་མེད། ཡང་བསྐྱར་འདེམས་རོགས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="108"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="113"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="121"/>
         <source>Next</source>
         <translation>རྗེས་མ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="76"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="80"/>
         <source>Retry</source>
         <translation>ཡང་བསྐྱར་ཚོད་ལྟ་བགྱིས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="130"/>
         <source>The file is corrupted and cannot be migrated. Please replace it with a backup file.</source>
         <translation>ཡིག་ཆ་ནོར་བས་སྤོ་ཐབས་མེད། གྲབས་ཉར་ཡིག་ཆ་བརྗེ་རོགས། </translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="133"/>
-        <source>Insufficient space on UOS. Please reserve at least %1G of space and try again.</source>
-        <translation>UOSཤོང་ཚད་འདང་ངེས་མེད་པས། ཉུང་མཐར་ཡང་ཤོང་ཚད་ %1G བཞག་ནས་ཚོད་ལྟ་བགྱིས། </translation>
     </message>
 </context>
 <context>
     <name>UserSelectFileSize</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/userselectfilesize.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/userselectfilesize.cpp" line="28"/>
         <source>Calculating</source>
         <translation>རྩིས་བཞིན་པ། </translation>
     </message>
@@ -871,33 +958,33 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>WaitTransferWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="36"/>
         <source>Waiting for transfer...</source>
         <translation>བསྐུར་རྒྱུ་སྒུག་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="37"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="41"/>
         <source>Please select the data to transfer on Windows</source>
         <translation>Windowsསྣེ་ནས་བསྐུར་དགོས་པའི་ནང་དོན་འདེམས་རྒྱུ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="47"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="98"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="113"/>
         <source>Cancel</source>
         <translation>འདོར་བ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="99"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="114"/>
         <source>Close</source>
         <translation>སྒོ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="116"/>
         <source>This operation will clear the transmission progress, Do you want to continue.</source>
         <translation>བཀོལ་སྤྱོད་འདིས་བརྒྱུད་བསྐུར་བྱེད་རིམ་གཙང་སེལ་བྱེད་པས། མུ་མཐུད་བྱེད་དགོས་སམ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="117"/>
         <source>This operation is not recoverable</source>
         <translation>བཀོལ་སྤྱོད་འདི་སླར་གསོ་བྱེད་ཐབས་མེད། </translation>
     </message>
@@ -905,32 +992,32 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>ZipFileProcessResultWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="37"/>
         <source>Exit</source>
         <translation>ཕྱིར་འཐེན། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="54"/>
         <source>Back</source>
         <translation>ཕྱིར་ལོག</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="91"/>
         <source>Back up succeed</source>
         <translation>གྲབས་ཉར་ཚར་སོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="97"/>
         <source>Congratulations, Your Information has been Successfully Backed Up.</source>
         <translation>བཀྲ་ཤིས་ཞུ། ཆ་འཕྲིན་གྲབས་ཉར་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="102"/>
         <source>Go to View</source>
         <translation>ལྟ་བཤེར་བྱེད་པ། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="131"/>
         <source>Back up failed</source>
         <translation>གྲབས་ཉར་མི་ཐུབ། </translation>
     </message>
@@ -938,23 +1025,23 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>ZipFileProcessWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="44"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="51"/>
         <source>Packing  %1</source>
         <translation>ཐུབ་ཁ་རྒྱག་བཞིན་པ། %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="53"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="114"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>ལེགས་པར་གྲུབ་པར་ད་དུང་སྐར་མ་%1དགོས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="67"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>ལེགས་པར་གྲུབ་པར་ད་དུང་སྐར་ཆ་%1དགོས། </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="97"/>
         <source>Creating Backup File...</source>
         <translation>གྲབས་ཉར་ཡིག་ཆ་གསར་བཟོ་བྱེད་བཞིན་པ། </translation>
     </message>
@@ -962,12 +1049,12 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>ZipWork</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="283"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="328"/>
         <source>%1 File compression failed</source>
         <translation>%1 ཡིག་ཆ་སྡུད་སྒྲིལ་བྱེད་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="213"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="252"/>
         <source>Back up file done</source>
         <translation>ཡིག་ཆ་གྲབས་ཉར་བྱས་ཟིན། </translation>
     </message>
@@ -975,7 +1062,7 @@ UOS, helping you seamlessly replace your system.</source>
 <context>
     <name>data_transfer_core::MainWindowPrivate</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="37"/>
         <source>UOS data transfer</source>
         <translation>UOSསྤོ་བའི་ཡོ་བྱད།</translation>
     </message>

--- a/translations/deepin-data-transfer/deepin-data-transfer_ug.ts
+++ b/translations/deepin-data-transfer/deepin-data-transfer_ug.ts
@@ -1,48 +1,50 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>AppSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="42"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="50"/>
         <source>Check transfer application will automatically install the corresponding UOS version of the application.</source>
         <translation>ئەپلەرنى ماس قەدەملەشنى تاللىسىڭىز، ماس كېلىدىغان UOS نەشرى ئاپتوماتىك قاچىلىنىدۇ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="64"/>
         <source>Confirm</source>
         <translation>جەزملەش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="62"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Application</source>
         <translation>ئەپ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Recommendation</source>
         <translation>يۆتكەش تەشەببۇسى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="113"/>
         <source>Transferable</source>
         <translation>ھەئە</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="124"/>
         <source>Not Suitable</source>
         <translation>ياق</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
         <source>Select apps to transfer</source>
         <translation>ماس قەدەملەيدىغان ئەپنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
         <source>Please select the applications to back up</source>
         <translation>زاپاسلايدىغان ئەپنى تاللاڭ</translation>
     </message>
@@ -50,12 +52,12 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="86"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="41"/>
         <source>UOS data transfer</source>
         <translation>UOS يۆتكەش قورالى</translation>
     </message>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="91"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="45"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to UOS, helping you seamlessly replace your system.</source>
         <translation>UOS يۆتكەش قورالى بىر كۇنۇپكا بىلەن ھۆججەت، شەخسىي سانلىق مەلۇمات ۋە ئەپلەرنىڭ سانلىق مەلۇماتلىرىنى UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇشىڭىزغا ياردەم بېرىدۇ</translation>
     </message>
@@ -63,32 +65,32 @@
 <context>
     <name>ChooseWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
         <source>Export to local directory</source>
         <translation>يەرلىكتىن چىقىرىپ زاپاسلاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="46"/>
         <source>Select a transfer way</source>
         <translation>ئۇچۇرنى يۆتكەش ئۇسۇلىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="61"/>
         <source>Unable to connect to the network， please check your network connection or select export to local directory.</source>
         <translation>مۇلازىمېتىرغا ئۇلىغىلى بولمىدى! تور ئۇلىنىشىنى تەكشۈرۈپ بېقىڭ ياكى زاپاس ھۆججەت ئارقىلىق يۆتكەڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="74"/>
         <source>Next</source>
         <translation>كېيىنكى قەدەم</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
         <source>From Windows PC</source>
         <translation>Windows PC دىن</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
         <source>Import from backup files</source>
         <translation>زاپاس ھۆججەتتىن ئەكىرىش</translation>
     </message>
@@ -96,54 +98,54 @@
 <context>
     <name>ConfigSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="47"/>
         <source>Check transfer configuration will automatically apply to UOS.</source>
         <translation>نۆۋەتتىكى سىستېمىنىڭ شەخسىي سەپلىمىسىنى تەكشۈرۈپ بولدى، يۆتكەشكە تېگىشلىك سەپلىمە تۈرىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="59"/>
         <source>Confirm</source>
         <translation>جەزملەش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="57"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
         <source>Browser bookmarks</source>
         <translation>توركۆرگۈچ خەتكۈچى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Recommendation</source>
         <translation>يۆتكەش تەشەببۇسى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="98"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="139"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="109"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="154"/>
         <source>Transferable</source>
         <translation>ھەئە</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Personal Settings</source>
         <translation>شەخسىي سەپلىمە</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="153"/>
         <source>Customized Wallpaper</source>
         <translation>ئېكران بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
         <source>Select the configuration to transfer</source>
         <translation>ماس قەدەملەيدىغان سەپلىمىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
         <source>Please select the configurations to back up</source>
         <translation>زاپاسلايدىغان سەپلىمىنى تاللاڭ</translation>
     </message>
@@ -151,52 +153,57 @@
 <context>
     <name>ConnectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="44"/>
         <source>Ready to connect</source>
         <translation>ئۇلانماقچى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="49"/>
         <source>Please open data transfer on Windows, and imput the IP and connect code</source>
         <translation>Windows تېرمىنالىدا يۆتكەش قورالىنى ئېچىپ، مەزكۇر ئاپپاراتنىڭ IPسى ۋە ئۇلىنىش پارولىنى كىرگۈزۈڭ </translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="56"/>
         <source>Download Windows client</source>
         <translation>Windows تېرمىنالىنى چۈشۈرۈش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="68"/>
         <source>Connect code is expired, please refresh for new code</source>
         <translation>ئۇلىنىش پارولىنى ۋاقتى ئۆتكەن، يېڭىلاپ يېڭى پارولغا ئېرىشىڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="84"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="104"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="114"/>
         <source>computer</source>
         <translation>كومپيۇتېر</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="107"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="135"/>
         <source>Local IP</source>
         <translation>IP ئادرېس</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="163"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="147"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="210"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>The code will be expired in</source>
         <translation>پارولنىڭ ئۈنۈملۈك ۋاقتى يەنە</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>please input connect code as soon as possible</source>
         <translation>تېزدىن ئۇلىنىش پارولى كىرگۈزۈڭ</translation>
     </message>
@@ -204,62 +211,62 @@
 <context>
     <name>CreateBackupFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="87"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="98"/>
         <source>Create data backup</source>
         <translation>زاپاس ھۆججەت قۇرۇش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="106"/>
         <source>File information</source>
         <translation>ھۆججەت ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="126"/>
         <source>Name</source>
         <translation>نامى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="144"/>
         <source>size:0B</source>
         <translation>سىغىمى: 0B</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="152"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="163"/>
         <source>Location</source>
         <translation>ساقلايدىغان ئورۇن</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="162"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="173"/>
         <source>(Select Backup Disk)</source>
         <translation>(زاپاسلايدىغان دىسكىنى تاللاڭ)</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="187"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="198"/>
         <source>Insufficient space in the selected disk, please clean the space</source>
         <translation>بۇ دىسكىنىڭ بوشلۇقى يەتمەيدۇ، دىسكا بوشلۇقىنى تازىلاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="206"/>
         <source>Backup</source>
         <translation>زاپاسلاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="193"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="204"/>
         <source>Cancel</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="339"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="369"/>
         <source>Size:%1</source>
         <translation>سىغىمى: %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="382"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="420"/>
         <source>local disk</source>
         <translation>يەرلىك دىسكا</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="388"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="426"/>
         <source>%1/%2 available</source>
         <translation>%1/%2 نى ئىشلەتكىلى بولىدۇ</translation>
     </message>
@@ -267,22 +274,22 @@
 <context>
     <name>CustomMessageBox</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="72"/>
         <source>Reselect</source>
         <translation>قايتا تاللاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="81"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="87"/>
         <source>Continue</source>
         <translation>داۋاملىق يوللاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>The presence of outstanding transfer tasks between you and the target device has been detected.</source>
         <translation>سىز بىلەن نىشان ئۈسكۈنە ئوتتۇرىسىدا تاماملانمىغان يوللاش ۋەزىپىسى بارلىقى بايقالدى.</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>Do you want to continue with the last transfer?</source>
         <translation>ئالدىنقى يوللاش ۋەزىپىسىنى داۋاملاشتۇرامسىز؟</translation>
     </message>
@@ -290,42 +297,42 @@
 <context>
     <name>ErrorWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="63"/>
         <source>Transfer will be completed in</source>
         <translation>يۆتكەپ بولۇشقا يەنە</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="78"/>
         <source>Try again</source>
         <translation>قايتا سىناش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="75"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="31"/>
         <source>Network Error</source>
         <translation>تور خاتالىقى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="30"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
         <source>Transfer interrupted</source>
         <translation>يۆتكەش ئۈزۈلۈپ قالدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
         <source>The network disconnected, transfer failed, please connect the network and try again</source>
         <translation>تور ئۇلىنىشى ئۈزۈلۈپ قالغاچقا، يۆتكەش مەغلۇپ بولدى، تور ئۇلىنىشىنى تەكشۈرۈڭ ياكى قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
         <source>Insufficient space in UOS, please clear at least %1 GB and try again</source>
         <translation>UOS نىڭ قالدۇق بوشلۇقى يېتىشمەيدۇ، كەم دېگەندە %1GB بوشلۇق بىكارلاپ قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="38"/>
         <source>Insufficient space in UOS, Please reserve enough space</source>
         <translation>UOS نىڭ قالدۇق بوشلۇقى يېتىشمەيدۇ، يېتەرلىك بوشلۇق قالدۇرۇڭ</translation>
     </message>
@@ -333,37 +340,37 @@
 <context>
     <name>FileSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Name</source>
         <translation>نامى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Size</source>
         <translation>سىغىمى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="60"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="69"/>
         <source>When transfer completed, the data will be placed in the user&apos;s home directory</source>
         <translation>يۆتكەپ بولۇنغان سانلىق مەلۇمات ئىشلەتكۈچىنىڭ home مۇندەرىجىسى ئاستىدا ساقلىنىدۇ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="82"/>
         <source>Confirm</source>
         <translation>جەزملەش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="80"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
         <source>Select the file to transfer</source>
         <translation>يۆتكەيدىغان ھۆججەتنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
         <source>Please select the files to back up</source>
         <translation>زاپاسلايدىغان ھۆججەتنى تاللاڭ</translation>
     </message>
@@ -371,25 +378,44 @@
 <context>
     <name>NetworkDisconnectionWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="38"/>
         <source>The network has been disconnected. Please check your network</source>
         <translation>تور ئۈزۈلۈپ قالدى، تورىڭىزنى تەكشۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="44"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="45"/>
         <source>Try again</source>
         <translation>قايتا سىناش</translation>
     </message>
 </context>
 <context>
+    <name>NetworkUtil</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="472"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="496"/>
+        <source>Transfering</source>
+        <translation type="unfinished">يوللىنىۋاتىدۇ</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkUtilPrivate</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="145"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="165"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="188"/>
+        <source>Transfering</source>
+        <translation type="unfinished">يوللىنىۋاتىدۇ</translation>
+    </message>
+</context>
+<context>
     <name>ProcessWindow</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="297"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="352"/>
         <source>Installing</source>
         <translation>قاچىلاۋاتىدۇ</translation>
     </message>
@@ -397,87 +423,149 @@
 <context>
     <name>PromptWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="35"/>
         <source>Before tranfer</source>
         <translation>باشلاشتىن بۇرۇن</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="40"/>
         <source>Data transfer requires some time, to avoid interrupting the migration due to low battery, please keep connect to the  power.</source>
         <translation>يۆتكەشكە بەلگىلىك ۋاقىت كېتىدۇ، توك ئۈزۈلۈپ قېلىپ يۆتكەش ئۈزۈلۈپ قېلىشتىن ساقلىنىش ئۈچۈن، توك مەنبەسىگە چېتىڭ.</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="42"/>
         <source>Other applications may slowdown the transfer speed. For smoother experience, please close other applications.</source>
         <translation>باشقا ئەپلەر يۆتكەش سۈرئىتىگە كاشىلا قىلىشى مۇمكىن، تېخىمۇ راۋان كۆچۈش ئۈچۈن باشقا ئەپلەرنى ئېتىۋېتىڭ.</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="44"/>
         <source>For the security of your transfer, please use a trusted network.</source>
         <translation>يوللانغان ئۇچۇرىڭىزنىڭ بىخەتەرلىكى ئۈچۈن، ئىشەنچىلىك تور ئىشلىتىڭ.</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="68"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="70"/>
         <source>Confirm</source>
         <translation>جەزملەش</translation>
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="116"/>
+        <source>Port number must be between %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="120"/>
+        <source>Port is already in use, please change</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaGzipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="44"/>
+        <source>QIODevice::Append is not supported for GZIP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="51"/>
+        <source>Opening gzip for both reading and writing is not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="60"/>
+        <source>You can open a gzip either for reading or for writing. Which is it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="67"/>
+        <source>Could not gzopen() file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZIODevice</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="138"/>
+        <source>QIODevice::Append is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="144"/>
+        <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QuaZipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quazipfile.cpp" line="246"/>
+        <source>ZIP/UNZIP API error %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ReadyWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="113"/>
         <source>Ready to connect</source>
         <translation>ئۇلانماقچى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="117"/>
         <source>IP</source>
         <translation>IP ئادرېس</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="125"/>
         <source>Please input the IP of UOS</source>
         <translation>UOS تېرمىنالىنىڭ IP ئادرېسىنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="79"/>
-        <source>Please open data transfer on UOS, and get the IP</source>
-        <translation>UOS تېرمىنالىدىكى يۆتكەش قورالىنى ئاچسىڭىز IP ئادرېسنى كۆرەلەيسىز</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="85"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="148"/>
         <source>Connect code</source>
         <translation>ئۇلىنىش پارولى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="159"/>
         <source>Please input the connect code on UOS</source>
         <translation>UOS تېرمىنالىدا كۆرۈنگەن ئۇلىنىش پارولىنى كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="118"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="184"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="33"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="112"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="167"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="178"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="250"/>
         <source>connect...</source>
         <translation>ئۇلىنىۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="49"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="186"/>
         <source>Connect</source>
         <translation>ئۇلاندى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="258"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="242"/>
+        <source>Port is unreachable, please change the port on both devices and retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="354"/>
         <source>Failed to connect, please check your input</source>
         <translation>ئۇلانمىدى، تەكشۈرۈپ كىرگۈزۈڭ</translation>
     </message>
@@ -485,28 +573,28 @@
 <context>
     <name>ResultDisplayWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="128"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="154"/>
         <source>Transfer completed partially</source>
         <translation>قىسمەن يۆتكەش ئاياغلاشتى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="32"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="125"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="150"/>
         <source>Transfer completed</source>
         <translation>يۆتكەلدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="45"/>
         <source>Partial information migration failed, please go to UOS for manual transfer</source>
         <translation>قىسمەن ئۇچۇرلار يۆتكەلمىدى، UOS قا كىرىپ قولدا يۆتكەڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="57"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="59"/>
         <source>Exit</source>
         <translation>چېكىنىش</translation>
     </message>
@@ -514,19 +602,19 @@
 <context>
     <name>SelectItem</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="216"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="263"/>
         <source>Selected:0</source>
         <translation>تاللاش: 0</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="239"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="241"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="289"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="292"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="295"/>
         <source>Selected:%1</source>
         <translation>تاللانغىنى: %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="304"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="361"/>
         <source>Edit</source>
         <translation>تەھرىرلەش</translation>
     </message>
@@ -534,42 +622,42 @@
 <context>
     <name>SelectMainWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="116"/>
         <source>File</source>
         <translation>ھۆججەت</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="121"/>
         <source>App</source>
         <translation>ئەپ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="97"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="123"/>
         <source>Config</source>
         <translation>سەپلىمە</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="138"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="72"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
         <source>Select data to transfer</source>
         <translation>يۆتكەيدىغان سانلىق مەلۇماتنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="76"/>
         <source>Please select the content to back up</source>
         <translation>زاپاسلايدىغان سانلىق مەلۇماتنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="74"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="77"/>
         <source>Start transfer</source>
         <translation>يۆتكەشنى باشلاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="78"/>
         <source>Next</source>
         <translation>كېيىنكى قەدەم</translation>
     </message>
@@ -577,117 +665,130 @@
 <context>
     <name>SettingHelper</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Profiles</source>
         <translation>سەپلىمە ھۆججىتى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Wrong or missing profile</source>
         <translation>سەپلىمە ھۆججىتىدە خاتالىق كۆرۈلدى ياكى يوقاپ كەتتى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
         <source>My Wallpaper</source>
         <translation>تەگلىكىم</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="234"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <source>File not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <source>Failed to move wallpaper file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="293"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer completed</source>
         <translation>يۆتكەلدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
+        <source>Failed to set wallpaper</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Browser Bookmarks</source>
         <translation>توركۆرگۈچ خەتكۈچى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
         <source>BrowserBookMark</source>
         <translation>توركۆرگۈچ خەتكۈچى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="176"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="226"/>
         <source>is installed</source>
         <translation>قاچىلاندى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="200"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="250"/>
         <source>Installing</source>
         <translation>قاچىلاۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer failed</source>
         <translation>يۆتكەلمىدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
         <source>Format error</source>
         <translation>فورمات خاتالىقى كۆرۈلدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Setup failed, configuration can be imported manually</source>
         <translation>سەپلەنمىدى، قولدا كىرگۈزۈڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="157"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="188"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="201"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="297"/>
         <source>Installation failed, please go to the app store to install</source>
         <translation>قاچىلانمىدى، ئەپ بازىرىغا كىرىڭ قاچىلاڭ</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="249"/>
-        <source>Transfer Complete</source>
-        <translation>يۆتكەلدى</translation>
     </message>
 </context>
 <context>
     <name>SidebarWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="21"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
         <source>Videos</source>
         <translation>سىن</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
         <source>Pictures</source>
         <translation>رەسىم</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
         <source>Documents</source>
         <translation>ھۆججەت</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
         <source>Downloads</source>
         <translation>چۈشۈرۈلمىلەر</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="27"/>
         <source>Music</source>
         <translation>مۇزىكا</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="28"/>
         <source>Desktop</source>
         <translation>ئۈستەليۈزى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="80"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="94"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="399"/>
         <source>Select:%1</source>
         <translation>تاللانغىنى: %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="225"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="267"/>
         <source>local disk</source>
         <translation>يەرلىك دىسكا</translation>
     </message>
@@ -695,83 +796,74 @@
 <context>
     <name>StartWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
         <source>UOS data transfer</source>
         <translation>UOS يۆتكەش قورالى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="43"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to
 UOS, helping you seamlessly replace your system.</source>
         <translation>UOS يۆتكەش قورالى بىر كۇنۇپكا بىلەن ھۆججەت، شەخسىي سانلىق مەلۇمات ۋە ئەپلەرنىڭ سانلىق مەلۇماتلىرىنى
 UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇشىڭىزغا ياردەم بېرىدۇ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="50"/>
         <source>Next</source>
         <translation>كېيىنكى قەدەم</translation>
     </message>
 </context>
 <context>
-    <name>TransferHandle</name>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/transferworker.cpp" line="326"/>
-        <source>Transfering</source>
-        <translation>يوللىنىۋاتىدۇ</translation>
-    </message>
-</context>
-<context>
     <name>TransferringWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="42"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="193"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="230"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="221"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="264"/>
         <source>Transferring...</source>
         <translation>يوللىنىۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="57"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="229"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="65"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="218"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="263"/>
         <source>Calculationing...</source>
         <translation>ھېسابلاۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="63"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="132"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="147"/>
         <source>Show processes</source>
         <translation>كۆرسىتىلىدىغان پىروگرامما</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="119"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="133"/>
         <source>Hide processes</source>
         <translation>يوشۇرۇن پىروگرامما</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="154"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="170"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="223"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>يۆتكەپ بولۇشقا يەنە %1 مىنۇت قالدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="171"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="243"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="281"/>
         <source>Transfering</source>
         <translation>يوللىنىۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="199"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="227"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>يۆتكەپ بولۇشقا يەنە %1 سېكۇنت قالدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="202"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="231"/>
         <source>Transfer will be completed in --</source>
         <translation>يۆتكەپ بولۇشقا يەنە ...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="272"/>
         <source>Decompressing</source>
         <translation>يېشىۋاتىدۇ</translation>
     </message>
@@ -779,8 +871,8 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>UnzipWorker</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="126"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="137"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="140"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="151"/>
         <source>Decompressing</source>
         <translation>يېشىۋاتىدۇ</translation>
     </message>
@@ -788,34 +880,34 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>UploadFileFrame</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="197"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="256"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="212"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="274"/>
         <source>Drag file here </source>
         <translation>ھۆججەتنى بۇ يەرگە سۆرەپ كىرىڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="202"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="257"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="217"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="275"/>
         <source>Import file</source>
         <translation>ھۆججەت ئەكىرىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="276"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="296"/>
         <source>Only .zip is supported, please</source>
         <translation>zip فورماتىنىلا قوللايدۇ، قايتا تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="277"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="297"/>
         <source>reselect</source>
         <translation>قايتا تاللاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>select zip file</source>
         <translation>zip ھۆججىتى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>ZIP file (*.zip)</source>
         <translation>ZIP ھۆججىتى (*.zip)</translation>
     </message>
@@ -823,48 +915,43 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>UploadFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
         <source>Select data transfer file</source>
         <translation>يۆتكەيدىغان ھۆججەتنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
         <source>File error, cannot transfer, please reselect</source>
         <translation>ھۆججەت خاتالىقى كۆرۈلدى، يۆتكىگىلى بولمايدۇ، قايتا تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="108"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="113"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="121"/>
         <source>Next</source>
         <translation>كېيىنكى قەدەم</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="76"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="80"/>
         <source>Retry</source>
         <translation>قايتا سىناش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="130"/>
         <source>The file is corrupted and cannot be migrated. Please replace it with a backup file.</source>
         <translation>ھۆججەت خاتالىقى كۆرۈلدى، يۆتكىگىلى بولمايدۇ، زاپاس ھۆججەتنى ئالماشتۇرۇڭ</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="133"/>
-        <source>Insufficient space on UOS. Please reserve at least %1G of space and try again.</source>
-        <translation>UOS نىڭ قالدۇق بوشلۇقى يېتىشمەيدۇ، كەم دېگەندە %1GB بوشلۇق قالدۇرۇپ قايتا سىناڭ</translation>
     </message>
 </context>
 <context>
     <name>UserSelectFileSize</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/userselectfilesize.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/userselectfilesize.cpp" line="28"/>
         <source>Calculating</source>
         <translation>ھېسابلاۋاتىدۇ</translation>
     </message>
@@ -872,33 +959,33 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>WaitTransferWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="36"/>
         <source>Waiting for transfer...</source>
         <translation>يوللاش ئالدىدا تۇرماقتا</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="37"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="41"/>
         <source>Please select the data to transfer on Windows</source>
         <translation>Windows تېرمىنالىدىكى يوللىماقچى بولغان مەزمۇننى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="47"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="98"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="113"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="99"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="114"/>
         <source>Close</source>
         <translation>تاقاش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="116"/>
         <source>This operation will clear the transmission progress, Do you want to continue.</source>
         <translation>بۇ مەشغۇلات يوللاش جەريانىنى تازىلىۋېتىدۇ، داۋاملاشتۇرامسىز؟</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="117"/>
         <source>This operation is not recoverable</source>
         <translation>بۇ مەشغۇلاتنى ئەسلىگە قايتۇرغىلى بولمايدۇ</translation>
     </message>
@@ -906,32 +993,32 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>ZipFileProcessResultWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="37"/>
         <source>Exit</source>
         <translation>چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="54"/>
         <source>Back</source>
         <translation>قايتىش</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="91"/>
         <source>Back up succeed</source>
         <translation>زاپاسلاندى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="97"/>
         <source>Congratulations, Your Information has been Successfully Backed Up.</source>
         <translation>مۇبارەك بولسۇن، ئۇچۇرلار زاپاسلاندى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="102"/>
         <source>Go to View</source>
         <translation>كۆرۈپ باقاي</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="131"/>
         <source>Back up failed</source>
         <translation>زاپاسلانمىدى</translation>
     </message>
@@ -939,23 +1026,23 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>ZipFileProcessWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="44"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="51"/>
         <source>Packing  %1</source>
         <translation>بولاقلاۋاتىدۇ: %1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="53"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="114"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>تاماملىنىشقا يەنە %1 مىنۇت قالدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="67"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>تاماملىنىشقا يەنە %1 سېكۇنت قالدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="97"/>
         <source>Creating Backup File...</source>
         <translation>زاپاس ھۆججەت قۇرۇۋاتىدۇ...</translation>
     </message>
@@ -963,12 +1050,12 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>ZipWork</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="283"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="328"/>
         <source>%1 File compression failed</source>
         <translation>%1 ھۆججەتنى يېشەلمىدى</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="213"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="252"/>
         <source>Back up file done</source>
         <translation>ھۆججەت زاپاسلاش تاماملاندى</translation>
     </message>
@@ -976,7 +1063,7 @@ UOS قا يۆتكەپ، سىستېمىنى يوچۇقسىز ئالماشتۇرۇ
 <context>
     <name>data_transfer_core::MainWindowPrivate</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="37"/>
         <source>UOS data transfer</source>
         <translation>UOS يۆتكەش قورالى</translation>
     </message>

--- a/translations/deepin-data-transfer/deepin-data-transfer_zh_CN.ts
+++ b/translations/deepin-data-transfer/deepin-data-transfer_zh_CN.ts
@@ -1,48 +1,50 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AppSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="42"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="50"/>
         <source>Check transfer application will automatically install the corresponding UOS version of the application.</source>
         <translation>若勾选同步应用，将为您自动安装对应UOS版本应用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="64"/>
         <source>Confirm</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="62"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Application</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Recommendation</source>
         <translation>迁移建议</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="113"/>
         <source>Transferable</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="124"/>
         <source>Not Suitable</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
         <source>Select apps to transfer</source>
         <translation>选择要同步的应用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
         <source>Please select the applications to back up</source>
         <translation>选择要备份的应用</translation>
     </message>
@@ -50,12 +52,12 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="86"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="41"/>
         <source>UOS data transfer</source>
         <translation>UOS迁移工具</translation>
     </message>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="91"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="45"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to UOS, helping you seamlessly replace your system.</source>
         <translation>UOS迁移工具，一键将您的文件、个人数据和应用数据迁移到UOS，助您无缝更换系统</translation>
     </message>
@@ -63,32 +65,32 @@
 <context>
     <name>ChooseWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
         <source>Export to local directory</source>
         <translation>本地导出备份</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="46"/>
         <source>Select a transfer way</source>
         <translation>选择信息迁移方式</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="61"/>
         <source>Unable to connect to the network， please check your network connection or select export to local directory.</source>
         <translation>无法连接服务器！请检测网络连接或者使用备份文件迁移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="74"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
         <source>From Windows PC</source>
         <translation>从Windows PC</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
         <source>Import from backup files</source>
         <translation>从备份文件导入</translation>
     </message>
@@ -96,54 +98,54 @@
 <context>
     <name>ConfigSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="47"/>
         <source>Check transfer configuration will automatically apply to UOS.</source>
         <translation>已扫描当前系统的个人配置，请选择需要迁移的配置项</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="59"/>
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="57"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
         <source>Browser bookmarks</source>
         <translation>浏览器书签</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Recommendation</source>
         <translation>迁移建议</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="98"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="139"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="109"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="154"/>
         <source>Transferable</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Personal Settings</source>
         <translation>个人配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="153"/>
         <source>Customized Wallpaper</source>
         <translation>自定义桌面</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
         <source>Select the configuration to transfer</source>
         <translation>选择要同步的配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
         <source>Please select the configurations to back up</source>
         <translation>请选择要备份的配置</translation>
     </message>
@@ -151,52 +153,57 @@
 <context>
     <name>ConnectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="44"/>
         <source>Ready to connect</source>
         <translation>准备连接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="49"/>
         <source>Please open data transfer on Windows, and imput the IP and connect code</source>
         <translation>请在Windows端打开迁移工具，输入本机IP和连接密码</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="56"/>
         <source>Download Windows client</source>
         <translation>下载Windows客户端</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="68"/>
         <source>Connect code is expired, please refresh for new code</source>
         <translation>连接密码已过期，请刷新获取新密码</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="84"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="104"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="114"/>
         <source>computer</source>
         <translation>电脑</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="107"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="135"/>
         <source>Local IP</source>
         <translation>本机IP</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="163"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="147"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="210"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>The code will be expired in</source>
         <translation>密码有效时间还剩</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>please input connect code as soon as possible</source>
         <translation>请尽快输入连接密码</translation>
     </message>
@@ -204,62 +211,62 @@
 <context>
     <name>CreateBackupFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="87"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="98"/>
         <source>Create data backup</source>
         <translation>创建备份文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="106"/>
         <source>File information</source>
         <translation>文件信息</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="126"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="144"/>
         <source>size:0B</source>
         <translation>大小：0B</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="152"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="163"/>
         <source>Location</source>
         <translation>保存位置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="162"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="173"/>
         <source>(Select Backup Disk)</source>
         <translation>（选择备份磁盘）</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="187"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="198"/>
         <source>Insufficient space in the selected disk, please clean the space</source>
         <translation>当前磁盘空间不足，请清除理磁盘空间</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="206"/>
         <source>Backup</source>
         <translation>开始备份</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="193"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="204"/>
         <source>Cancel</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="339"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="369"/>
         <source>Size:%1</source>
         <translation>大小：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="382"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="420"/>
         <source>local disk</source>
         <translation>本地磁盘</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="388"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="426"/>
         <source>%1/%2 available</source>
         <translation>%1/%2可用</translation>
     </message>
@@ -267,22 +274,22 @@
 <context>
     <name>CustomMessageBox</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="72"/>
         <source>Reselect</source>
         <translation>重新选择</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="81"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="87"/>
         <source>Continue</source>
         <translation>继续传输</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>The presence of outstanding transfer tasks between you and the target device has been detected.</source>
         <translation>已检测到您和目标设备之间存在未完成的传输任务。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>Do you want to continue with the last transfer?</source>
         <translation>您想继续上次的传输任务吗？</translation>
     </message>
@@ -290,42 +297,42 @@
 <context>
     <name>ErrorWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="63"/>
         <source>Transfer will be completed in</source>
         <translation>预计迁移还剩</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="78"/>
         <source>Try again</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="75"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="31"/>
         <source>Network Error</source>
         <translation>网络错误</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="30"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
         <source>Transfer interrupted</source>
         <translation>迁移中断</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
         <source>The network disconnected, transfer failed, please connect the network and try again</source>
         <translation>网络连接断开，迁移失败，请检查网络连接或者重试</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
         <source>Insufficient space in UOS, please clear at least %1 GB and try again</source>
         <translation>UOS剩余空间不足，请至少清理%1GB然后重试</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="38"/>
         <source>Insufficient space in UOS, Please reserve enough space</source>
         <translation>UOS剩余空间不足够,请预留足够空间</translation>
     </message>
@@ -333,37 +340,37 @@
 <context>
     <name>FileSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="60"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="69"/>
         <source>When transfer completed, the data will be placed in the user&apos;s home directory</source>
         <translation>传输完成的数据，将被存放在用户的home目录下</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="82"/>
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="80"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
         <source>Select the file to transfer</source>
         <translation>请选择要迁移的文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
         <source>Please select the files to back up</source>
         <translation>请选择要备份的文件</translation>
     </message>
@@ -371,25 +378,44 @@
 <context>
     <name>NetworkDisconnectionWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="38"/>
         <source>The network has been disconnected. Please check your network</source>
         <translation>网络已断开，请检查您的网络</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="44"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="45"/>
         <source>Try again</source>
         <translation>重试</translation>
     </message>
 </context>
 <context>
+    <name>NetworkUtil</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="472"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="496"/>
+        <source>Transfering</source>
+        <translation>传输中</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkUtilPrivate</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="145"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="165"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="188"/>
+        <source>Transfering</source>
+        <translation>传输中</translation>
+    </message>
+</context>
+<context>
     <name>ProcessWindow</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="297"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="352"/>
         <source>Installing</source>
         <translation>正在安装</translation>
     </message>
@@ -397,87 +423,149 @@
 <context>
     <name>PromptWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="35"/>
         <source>Before tranfer</source>
         <translation>开始之前</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="40"/>
         <source>Data transfer requires some time, to avoid interrupting the migration due to low battery, please keep connect to the  power.</source>
         <translation>迁移需要一定的时间，避免断电中断迁移，请插上电源。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="42"/>
         <source>Other applications may slowdown the transfer speed. For smoother experience, please close other applications.</source>
         <translation>其他应用可能会干扰迁移速度，为了迁移更流畅，请关闭其他应用。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="44"/>
         <source>For the security of your transfer, please use a trusted network.</source>
         <translation>为了您的传输信息安全，请使用可信网络。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="68"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="70"/>
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="116"/>
+        <source>Port number must be between %1 and %2</source>
+        <translation>端口号必须在 %1 和 %2 之间</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="120"/>
+        <source>Port is already in use, please change</source>
+        <translation>端口已被占用，请修改</translation>
+    </message>
+</context>
+<context>
+    <name>QuaGzipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="44"/>
+        <source>QIODevice::Append is not supported for GZIP</source>
+        <translation>GZIP 不支持 QIODevice::Append 模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="51"/>
+        <source>Opening gzip for both reading and writing is not supported</source>
+        <translation>不支持同时以读写方式打开 gzip</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="60"/>
+        <source>You can open a gzip either for reading or for writing. Which is it?</source>
+        <translation>gzip 只能以读或写方式打开，请指定其一</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="67"/>
+        <source>Could not gzopen() file</source>
+        <translation>无法打开 gzip 文件</translation>
+    </message>
+</context>
+<context>
+    <name>QuaZIODevice</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="138"/>
+        <source>QIODevice::Append is not supported for QuaZIODevice</source>
+        <translation>QuaZIODevice 不支持 QIODevice::Append 模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="144"/>
+        <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
+        <translation>QuaZIODevice 不支持 QIODevice::ReadWrite 模式</translation>
+    </message>
+</context>
+<context>
+    <name>QuaZipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quazipfile.cpp" line="246"/>
+        <source>ZIP/UNZIP API error %1</source>
+        <translation>ZIP/UNZIP API 错误 %1</translation>
+    </message>
+</context>
+<context>
     <name>ReadyWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="113"/>
         <source>Ready to connect</source>
         <translation>准备连接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="117"/>
         <source>IP</source>
         <translation>IP地址</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="125"/>
         <source>Please input the IP of UOS</source>
         <translation>请输入UOS端的IP地址</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="79"/>
-        <source>Please open data transfer on UOS, and get the IP</source>
-        <translation>请打开UOS端的数据迁移工具，并可查看IP地址</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="85"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="148"/>
         <source>Connect code</source>
         <translation>连接密码</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="159"/>
         <source>Please input the connect code on UOS</source>
         <translation>请输入UOS端显示的连接密码</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="118"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="184"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="33"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="112"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="167"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="178"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="250"/>
         <source>connect...</source>
         <translation>连接中...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="49"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="186"/>
         <source>Connect</source>
         <translation>连接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="258"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="242"/>
+        <source>Port is unreachable, please change the port on both devices and retry</source>
+        <translation>端口无法通信，请修改两端端口号后重试</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="354"/>
         <source>Failed to connect, please check your input</source>
         <translation>连接失败，请检查输入</translation>
     </message>
@@ -485,28 +573,28 @@
 <context>
     <name>ResultDisplayWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="128"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="154"/>
         <source>Transfer completed partially</source>
         <translation>部分迁移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="32"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="125"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="150"/>
         <source>Transfer completed</source>
         <translation>迁移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="45"/>
         <source>Partial information migration failed, please go to UOS for manual transfer</source>
         <translation>部分信息迁移失败，请前往UOS手动迁移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="57"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="59"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -514,19 +602,19 @@
 <context>
     <name>SelectItem</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="216"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="263"/>
         <source>Selected:0</source>
         <translation>选择：0</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="239"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="241"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="289"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="292"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="295"/>
         <source>Selected:%1</source>
         <translation>已选：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="304"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="361"/>
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
@@ -534,42 +622,42 @@
 <context>
     <name>SelectMainWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="116"/>
         <source>File</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="121"/>
         <source>App</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="97"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="123"/>
         <source>Config</source>
         <translation>配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="138"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="72"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
         <source>Select data to transfer</source>
         <translation>选择要迁移的数据</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="76"/>
         <source>Please select the content to back up</source>
         <translation>请选择要备份的内容</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="74"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="77"/>
         <source>Start transfer</source>
         <translation>开始迁移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="78"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
@@ -577,117 +665,130 @@
 <context>
     <name>SettingHelper</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Profiles</source>
         <translation>配置文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Wrong or missing profile</source>
         <translation>配置文件错误或丢失</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
         <source>My Wallpaper</source>
         <translation>我的壁纸</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="234"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <source>File not found</source>
+        <translation>未找到文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <source>Failed to move wallpaper file</source>
+        <translation>移动壁纸文件失败</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="293"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer completed</source>
         <translation>迁移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
+        <source>Failed to set wallpaper</source>
+        <translation>设置壁纸失败</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Browser Bookmarks</source>
         <translation>浏览器书签</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
         <source>BrowserBookMark</source>
         <translation>浏览器书签</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="176"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="226"/>
         <source>is installed</source>
         <translation>已安装</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="200"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="250"/>
         <source>Installing</source>
         <translation>正在安装</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer failed</source>
         <translation>迁移失败</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
         <source>Format error</source>
         <translation>格式错误</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Setup failed, configuration can be imported manually</source>
         <translation>配置失败，请手动导入</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="157"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="188"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="201"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="297"/>
         <source>Installation failed, please go to the app store to install</source>
         <translation>安装失败，请前往应用商店安装</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="249"/>
-        <source>Transfer Complete</source>
-        <translation>迁移完成</translation>
     </message>
 </context>
 <context>
     <name>SidebarWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="21"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
         <source>Videos</source>
         <translation>视频</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
         <source>Pictures</source>
         <translation>图片</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
         <source>Documents</source>
         <translation>文档</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
         <source>Downloads</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="27"/>
         <source>Music</source>
         <translation>音乐</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="28"/>
         <source>Desktop</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="80"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="94"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="399"/>
         <source>Select:%1</source>
         <translation>已选：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="225"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="267"/>
         <source>local disk</source>
         <translation>本地磁盘</translation>
     </message>
@@ -695,83 +796,74 @@
 <context>
     <name>StartWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
         <source>UOS data transfer</source>
         <translation>UOS迁移工具</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="43"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to
 UOS, helping you seamlessly replace your system.</source>
         <translation>UOS迁移工具，一键将您的文件、个人数据和应用数据迁移到
 UOS，助您无缝更换系统</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="50"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
 </context>
 <context>
-    <name>TransferHandle</name>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/transferworker.cpp" line="326"/>
-        <source>Transfering</source>
-        <translation>传输中</translation>
-    </message>
-</context>
-<context>
     <name>TransferringWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="42"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="193"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="230"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="221"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="264"/>
         <source>Transferring...</source>
         <translation>正在传输...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="57"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="229"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="65"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="218"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="263"/>
         <source>Calculationing...</source>
         <translation>计算中...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="63"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="132"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="147"/>
         <source>Show processes</source>
         <translation>显示进程</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="119"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="133"/>
         <source>Hide processes</source>
         <translation>隐藏进程</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="154"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="170"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="223"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>预计迁移时间还剩 %1 分钟</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="171"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="243"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="281"/>
         <source>Transfering</source>
         <translation>传输中</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="199"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="227"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>预计迁移时间还剩 %1 秒</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="202"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="231"/>
         <source>Transfer will be completed in --</source>
         <translation>预计迁移时间还剩--</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="272"/>
         <source>Decompressing</source>
         <translation>解压中</translation>
     </message>
@@ -779,8 +871,8 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>UnzipWorker</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="126"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="137"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="140"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="151"/>
         <source>Decompressing</source>
         <translation>解压中</translation>
     </message>
@@ -788,34 +880,34 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>UploadFileFrame</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="197"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="256"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="212"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="274"/>
         <source>Drag file here </source>
         <translation>拖拽文件至此</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="202"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="257"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="217"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="275"/>
         <source>Import file</source>
         <translation>导入文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="276"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="296"/>
         <source>Only .zip is supported, please</source>
         <translation>仅支持zip格式，请重新选择</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="277"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="297"/>
         <source>reselect</source>
         <translation>重新选择</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>select zip file</source>
         <translation>选择zip文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>ZIP file (*.zip)</source>
         <translation>ZIP文件(*.zip)</translation>
     </message>
@@ -823,48 +915,43 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>UploadFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
         <source>Select data transfer file</source>
         <translation>选择数据迁移文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
         <source>File error, cannot transfer, please reselect</source>
         <translation>文件错误，无法迁移，请重新选择</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="108"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="113"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="121"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="76"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="80"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="130"/>
         <source>The file is corrupted and cannot be migrated. Please replace it with a backup file.</source>
         <translation>文件错误，无法迁移，请更换备份文件</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="133"/>
-        <source>Insufficient space on UOS. Please reserve at least %1G of space and try again.</source>
-        <translation>UOS空间不足，请至少预留 %1G 空间后重试</translation>
     </message>
 </context>
 <context>
     <name>UserSelectFileSize</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/userselectfilesize.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/userselectfilesize.cpp" line="28"/>
         <source>Calculating</source>
         <translation>计算中</translation>
     </message>
@@ -872,33 +959,33 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>WaitTransferWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="36"/>
         <source>Waiting for transfer...</source>
         <translation>等待传输</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="37"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="41"/>
         <source>Please select the data to transfer on Windows</source>
         <translation>请在Windows端选择要传输的内容</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="47"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="98"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="113"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="99"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="114"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="116"/>
         <source>This operation will clear the transmission progress, Do you want to continue.</source>
         <translation>此操作将清除传输进度，是否要继续。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="117"/>
         <source>This operation is not recoverable</source>
         <translation>此操作不可恢复</translation>
     </message>
@@ -906,32 +993,32 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>ZipFileProcessResultWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="37"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="54"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="91"/>
         <source>Back up succeed</source>
         <translation>备份完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="97"/>
         <source>Congratulations, Your Information has been Successfully Backed Up.</source>
         <translation>恭喜你，信息备份成功</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="102"/>
         <source>Go to View</source>
         <translation>前往查看</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="131"/>
         <source>Back up failed</source>
         <translation>备份失败</translation>
     </message>
@@ -939,23 +1026,23 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>ZipFileProcessWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="44"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="51"/>
         <source>Packing  %1</source>
         <translation>正在打包：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="53"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="114"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>预计完成时间还剩%1分钟</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="67"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>预计完成时间还剩%1秒</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="97"/>
         <source>Creating Backup File...</source>
         <translation>创建备份文件中...</translation>
     </message>
@@ -963,12 +1050,12 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>ZipWork</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="283"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="328"/>
         <source>%1 File compression failed</source>
         <translation>%1 文件压缩失败</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="213"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="252"/>
         <source>Back up file done</source>
         <translation>备份文件结束</translation>
     </message>
@@ -976,7 +1063,7 @@ UOS，助您无缝更换系统</translation>
 <context>
     <name>data_transfer_core::MainWindowPrivate</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="37"/>
         <source>UOS data transfer</source>
         <translation>UOS迁移工具</translation>
     </message>

--- a/translations/deepin-data-transfer/deepin-data-transfer_zh_HK.ts
+++ b/translations/deepin-data-transfer/deepin-data-transfer_zh_HK.ts
@@ -1,48 +1,50 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AppSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="42"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="50"/>
         <source>Check transfer application will automatically install the corresponding UOS version of the application.</source>
         <translation>若勾選同步應用，將為您自動安裝對應UOS版本應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="64"/>
         <source>Confirm</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="62"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Application</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Recommendation</source>
         <translation>遷移建議</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="113"/>
         <source>Transferable</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="124"/>
         <source>Not Suitable</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
         <source>Select apps to transfer</source>
         <translation>選擇要同步的應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
         <source>Please select the applications to back up</source>
         <translation>選擇要備份的應用</translation>
     </message>
@@ -50,12 +52,12 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="86"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="41"/>
         <source>UOS data transfer</source>
         <translation>UOS遷移工具</translation>
     </message>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="91"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="45"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to UOS, helping you seamlessly replace your system.</source>
         <translation>UOS遷移工具，一鍵將您的文件、個人數據和應用數據遷移到UOS，助您無縫更換系統</translation>
     </message>
@@ -63,32 +65,32 @@
 <context>
     <name>ChooseWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
         <source>Export to local directory</source>
         <translation>本地導出備份</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="46"/>
         <source>Select a transfer way</source>
         <translation>選擇資訊遷移方式</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="61"/>
         <source>Unable to connect to the network， please check your network connection or select export to local directory.</source>
         <translation>無法連接伺服器！請檢測網絡連接或者使用備份文件遷移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="74"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
         <source>From Windows PC</source>
         <translation>從Windows PC</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
         <source>Import from backup files</source>
         <translation>從備份文件導入</translation>
     </message>
@@ -96,54 +98,54 @@
 <context>
     <name>ConfigSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="47"/>
         <source>Check transfer configuration will automatically apply to UOS.</source>
         <translation>已掃描當前系統的個人配置，請選擇需要遷移的配置項</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="59"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="57"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
         <source>Browser bookmarks</source>
         <translation>瀏覽器書籤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Recommendation</source>
         <translation>遷移建議</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="98"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="139"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="109"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="154"/>
         <source>Transferable</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Personal Settings</source>
         <translation>個人配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="153"/>
         <source>Customized Wallpaper</source>
         <translation>自定義桌面</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
         <source>Select the configuration to transfer</source>
         <translation>選擇要同步的配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
         <source>Please select the configurations to back up</source>
         <translation>請選擇要備份的配置</translation>
     </message>
@@ -151,52 +153,57 @@
 <context>
     <name>ConnectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="44"/>
         <source>Ready to connect</source>
         <translation>準備連接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="49"/>
         <source>Please open data transfer on Windows, and imput the IP and connect code</source>
         <translation>請在Windows端打開遷移工具，輸入本機IP和連接密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="56"/>
         <source>Download Windows client</source>
         <translation>下載Windows客戶端</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="68"/>
         <source>Connect code is expired, please refresh for new code</source>
         <translation>連接密碼已過期，請刷新獲取新密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="84"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="104"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="114"/>
         <source>computer</source>
         <translation>電腦</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="107"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="135"/>
         <source>Local IP</source>
         <translation>本機IP</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="163"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="147"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="210"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>The code will be expired in</source>
         <translation>密碼有效時間還剩</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>please input connect code as soon as possible</source>
         <translation>請盡快輸入連接密碼</translation>
     </message>
@@ -204,62 +211,62 @@
 <context>
     <name>CreateBackupFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="87"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="98"/>
         <source>Create data backup</source>
         <translation>創建備份文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="106"/>
         <source>File information</source>
         <translation>文件資訊</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="126"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="144"/>
         <source>size:0B</source>
         <translation>大小：0B</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="152"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="163"/>
         <source>Location</source>
         <translation>保存位置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="162"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="173"/>
         <source>(Select Backup Disk)</source>
         <translation>（選擇備份磁盤）</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="187"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="198"/>
         <source>Insufficient space in the selected disk, please clean the space</source>
         <translation>當前磁盤空間不足，請清除理磁盤空間</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="206"/>
         <source>Backup</source>
         <translation>開始備份</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="193"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="204"/>
         <source>Cancel</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="339"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="369"/>
         <source>Size:%1</source>
         <translation>大小：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="382"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="420"/>
         <source>local disk</source>
         <translation>本地磁盤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="388"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="426"/>
         <source>%1/%2 available</source>
         <translation>%1/%2可用</translation>
     </message>
@@ -267,22 +274,22 @@
 <context>
     <name>CustomMessageBox</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="72"/>
         <source>Reselect</source>
         <translation>重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="81"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="87"/>
         <source>Continue</source>
         <translation>繼續傳輸</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>The presence of outstanding transfer tasks between you and the target device has been detected.</source>
         <translation>已檢測到您和目標設備之間存在未完成的傳輸任務。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>Do you want to continue with the last transfer?</source>
         <translation>您想繼續上次的傳輸任務嗎？</translation>
     </message>
@@ -290,42 +297,42 @@
 <context>
     <name>ErrorWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="63"/>
         <source>Transfer will be completed in</source>
         <translation>預計遷移還剩</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="78"/>
         <source>Try again</source>
         <translation>重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="75"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="31"/>
         <source>Network Error</source>
         <translation>網絡錯誤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="30"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
         <source>Transfer interrupted</source>
         <translation>遷移中斷</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
         <source>The network disconnected, transfer failed, please connect the network and try again</source>
         <translation>網絡連接斷開，遷移失敗，請檢查網絡連接或者重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
         <source>Insufficient space in UOS, please clear at least %1 GB and try again</source>
         <translation>UOS剩餘空間不足，請至少清理%1GB然後重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="38"/>
         <source>Insufficient space in UOS, Please reserve enough space</source>
         <translation>UOS剩餘空間不足夠,請預留足夠空間</translation>
     </message>
@@ -333,37 +340,37 @@
 <context>
     <name>FileSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="60"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="69"/>
         <source>When transfer completed, the data will be placed in the user&apos;s home directory</source>
         <translation>傳輸完成的數據，將被存放在用戶的home目錄下</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="82"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="80"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
         <source>Select the file to transfer</source>
         <translation>請選擇要遷移的文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
         <source>Please select the files to back up</source>
         <translation>請選擇要備份的文件</translation>
     </message>
@@ -371,25 +378,44 @@
 <context>
     <name>NetworkDisconnectionWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="38"/>
         <source>The network has been disconnected. Please check your network</source>
         <translation>網絡已斷開，請檢查您的網絡</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="44"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="45"/>
         <source>Try again</source>
         <translation>重試</translation>
     </message>
 </context>
 <context>
+    <name>NetworkUtil</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="472"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="496"/>
+        <source>Transfering</source>
+        <translation>傳輸中</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkUtilPrivate</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="145"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="165"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="188"/>
+        <source>Transfering</source>
+        <translation>傳輸中</translation>
+    </message>
+</context>
+<context>
     <name>ProcessWindow</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="297"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="352"/>
         <source>Installing</source>
         <translation>正在安裝</translation>
     </message>
@@ -397,87 +423,149 @@
 <context>
     <name>PromptWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="35"/>
         <source>Before tranfer</source>
         <translation>開始之前</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="40"/>
         <source>Data transfer requires some time, to avoid interrupting the migration due to low battery, please keep connect to the  power.</source>
         <translation>遷移需要一定的時間，避免斷電中斷遷移，請插上電源。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="42"/>
         <source>Other applications may slowdown the transfer speed. For smoother experience, please close other applications.</source>
         <translation>其他應用可能會干擾遷移速度，為了遷移更流暢，請關閉其他應用。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="44"/>
         <source>For the security of your transfer, please use a trusted network.</source>
         <translation>為了您的傳輸資訊安全，請使用可信網絡。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="68"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="70"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="116"/>
+        <source>Port number must be between %1 and %2</source>
+        <translation>端口號必須在 %1 和 %2 之間</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="120"/>
+        <source>Port is already in use, please change</source>
+        <translation>端口已被佔用，請修改</translation>
+    </message>
+</context>
+<context>
+    <name>QuaGzipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="44"/>
+        <source>QIODevice::Append is not supported for GZIP</source>
+        <translation>GZIP 不支援 QIODevice::Append 模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="51"/>
+        <source>Opening gzip for both reading and writing is not supported</source>
+        <translation>不支援同時以讀寫方式打開 gzip</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="60"/>
+        <source>You can open a gzip either for reading or for writing. Which is it?</source>
+        <translation>gzip 只能以讀或寫方式打開，請指定其一</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="67"/>
+        <source>Could not gzopen() file</source>
+        <translation>無法打開 gzip 文件</translation>
+    </message>
+</context>
+<context>
+    <name>QuaZIODevice</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="138"/>
+        <source>QIODevice::Append is not supported for QuaZIODevice</source>
+        <translation>QuaZIODevice 不支援 QIODevice::Append 模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="144"/>
+        <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
+        <translation>QuaZIODevice 不支援 QIODevice::ReadWrite 模式</translation>
+    </message>
+</context>
+<context>
+    <name>QuaZipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quazipfile.cpp" line="246"/>
+        <source>ZIP/UNZIP API error %1</source>
+        <translation>ZIP/UNZIP API 錯誤 %1</translation>
+    </message>
+</context>
+<context>
     <name>ReadyWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="113"/>
         <source>Ready to connect</source>
         <translation>準備連接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="117"/>
         <source>IP</source>
         <translation>IP位址</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="125"/>
         <source>Please input the IP of UOS</source>
         <translation>請輸入UOS端的IP位址</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="79"/>
-        <source>Please open data transfer on UOS, and get the IP</source>
-        <translation>請打開UOS端的數據遷移工具，並可查看IP位址</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="85"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="148"/>
         <source>Connect code</source>
         <translation>連接密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="159"/>
         <source>Please input the connect code on UOS</source>
         <translation>請輸入UOS端顯示的連接密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="118"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="184"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="33"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="112"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="167"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="178"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="250"/>
         <source>connect...</source>
         <translation>連接中...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="49"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="186"/>
         <source>Connect</source>
         <translation>連接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="258"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="242"/>
+        <source>Port is unreachable, please change the port on both devices and retry</source>
+        <translation>端口無法通訊，請修改兩端端口號後重試</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="354"/>
         <source>Failed to connect, please check your input</source>
         <translation>連接失敗，請檢查輸入</translation>
     </message>
@@ -485,28 +573,28 @@
 <context>
     <name>ResultDisplayWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="128"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="154"/>
         <source>Transfer completed partially</source>
         <translation>部分遷移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="32"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="125"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="150"/>
         <source>Transfer completed</source>
         <translation>遷移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="45"/>
         <source>Partial information migration failed, please go to UOS for manual transfer</source>
         <translation>部分資訊遷移失敗，請前往UOS手動遷移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="57"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="59"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -514,19 +602,19 @@
 <context>
     <name>SelectItem</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="216"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="263"/>
         <source>Selected:0</source>
         <translation>選擇：0</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="239"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="241"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="289"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="292"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="295"/>
         <source>Selected:%1</source>
         <translation>已選：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="304"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="361"/>
         <source>Edit</source>
         <translation>編輯</translation>
     </message>
@@ -534,42 +622,42 @@
 <context>
     <name>SelectMainWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="116"/>
         <source>File</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="121"/>
         <source>App</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="97"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="123"/>
         <source>Config</source>
         <translation>配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="138"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="72"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
         <source>Select data to transfer</source>
         <translation>選擇要遷移的數據</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="76"/>
         <source>Please select the content to back up</source>
         <translation>請選擇要備份的內容</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="74"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="77"/>
         <source>Start transfer</source>
         <translation>開始遷移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="78"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
@@ -577,117 +665,130 @@
 <context>
     <name>SettingHelper</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Profiles</source>
         <translation>配置文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Wrong or missing profile</source>
         <translation>配置文件錯誤或丟失</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
         <source>My Wallpaper</source>
         <translation>我的壁紙</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="234"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <source>File not found</source>
+        <translation>未找到文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <source>Failed to move wallpaper file</source>
+        <translation>移動壁紙文件失敗</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="293"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer completed</source>
         <translation>遷移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
+        <source>Failed to set wallpaper</source>
+        <translation>設置壁紙失敗</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Browser Bookmarks</source>
         <translation>瀏覽器書籤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
         <source>BrowserBookMark</source>
         <translation>瀏覽器書籤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="176"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="226"/>
         <source>is installed</source>
         <translation>已安裝</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="200"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="250"/>
         <source>Installing</source>
         <translation>正在安裝</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer failed</source>
         <translation>遷移失敗</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
         <source>Format error</source>
         <translation>格式錯誤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Setup failed, configuration can be imported manually</source>
         <translation>配置失敗，請手動導入</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="157"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="188"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="201"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="297"/>
         <source>Installation failed, please go to the app store to install</source>
         <translation>安裝失敗，請前往應用商店安裝</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="249"/>
-        <source>Transfer Complete</source>
-        <translation>遷移完成</translation>
     </message>
 </context>
 <context>
     <name>SidebarWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="21"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
         <source>Videos</source>
         <translation>影片</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
         <source>Pictures</source>
         <translation>圖片</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
         <source>Documents</source>
         <translation>文檔</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
         <source>Downloads</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="27"/>
         <source>Music</source>
         <translation>音樂</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="28"/>
         <source>Desktop</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="80"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="94"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="399"/>
         <source>Select:%1</source>
         <translation>已選：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="225"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="267"/>
         <source>local disk</source>
         <translation>本地磁盤</translation>
     </message>
@@ -695,83 +796,74 @@
 <context>
     <name>StartWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
         <source>UOS data transfer</source>
         <translation>UOS遷移工具</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="43"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to
 UOS, helping you seamlessly replace your system.</source>
         <translation>UOS遷移工具，一鍵將您的文件、個人數據和應用數據遷移到
 UOS，助您無縫更換系統</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="50"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
 </context>
 <context>
-    <name>TransferHandle</name>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/transferworker.cpp" line="326"/>
-        <source>Transfering</source>
-        <translation>傳輸中</translation>
-    </message>
-</context>
-<context>
     <name>TransferringWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="42"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="193"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="230"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="221"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="264"/>
         <source>Transferring...</source>
         <translation>正在傳輸...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="57"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="229"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="65"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="218"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="263"/>
         <source>Calculationing...</source>
         <translation>計算中...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="63"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="132"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="147"/>
         <source>Show processes</source>
         <translation>顯示進程</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="119"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="133"/>
         <source>Hide processes</source>
         <translation>隱藏進程</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="154"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="170"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="223"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>預計遷移時間還剩 %1 分鐘</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="171"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="243"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="281"/>
         <source>Transfering</source>
         <translation>傳輸中</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="199"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="227"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>預計遷移時間還剩 %1 秒</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="202"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="231"/>
         <source>Transfer will be completed in --</source>
         <translation>預計遷移時間還剩--</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="272"/>
         <source>Decompressing</source>
         <translation>解壓中</translation>
     </message>
@@ -779,8 +871,8 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>UnzipWorker</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="126"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="137"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="140"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="151"/>
         <source>Decompressing</source>
         <translation>解壓中</translation>
     </message>
@@ -788,34 +880,34 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>UploadFileFrame</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="197"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="256"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="212"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="274"/>
         <source>Drag file here </source>
         <translation>拖拽文件至此</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="202"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="257"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="217"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="275"/>
         <source>Import file</source>
         <translation>導入文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="276"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="296"/>
         <source>Only .zip is supported, please</source>
         <translation>僅支持zip格式，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="277"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="297"/>
         <source>reselect</source>
         <translation>重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>select zip file</source>
         <translation>選擇zip文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>ZIP file (*.zip)</source>
         <translation>ZIP文件(*.zip)</translation>
     </message>
@@ -823,48 +915,43 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>UploadFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
         <source>Select data transfer file</source>
         <translation>選擇數據遷移文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
         <source>File error, cannot transfer, please reselect</source>
         <translation>文件錯誤，無法遷移，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="108"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="113"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="121"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="76"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="80"/>
         <source>Retry</source>
         <translation>重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="130"/>
         <source>The file is corrupted and cannot be migrated. Please replace it with a backup file.</source>
         <translation>文件錯誤，無法遷移，請更換備份文件</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="133"/>
-        <source>Insufficient space on UOS. Please reserve at least %1G of space and try again.</source>
-        <translation>UOS空間不足，請至少預留 %1G 空間後重試</translation>
     </message>
 </context>
 <context>
     <name>UserSelectFileSize</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/userselectfilesize.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/userselectfilesize.cpp" line="28"/>
         <source>Calculating</source>
         <translation>計算中</translation>
     </message>
@@ -872,33 +959,33 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>WaitTransferWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="36"/>
         <source>Waiting for transfer...</source>
         <translation>等待傳輸</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="37"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="41"/>
         <source>Please select the data to transfer on Windows</source>
         <translation>請在Windows端選擇要傳輸的內容</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="47"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="98"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="113"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="99"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="114"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="116"/>
         <source>This operation will clear the transmission progress, Do you want to continue.</source>
         <translation>此操作將清除傳輸進度，是否要繼續。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="117"/>
         <source>This operation is not recoverable</source>
         <translation>此操作不可恢復</translation>
     </message>
@@ -906,32 +993,32 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>ZipFileProcessResultWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="37"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="54"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="91"/>
         <source>Back up succeed</source>
         <translation>備份完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="97"/>
         <source>Congratulations, Your Information has been Successfully Backed Up.</source>
         <translation>恭喜你，資訊備份成功</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="102"/>
         <source>Go to View</source>
         <translation>前往查看</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="131"/>
         <source>Back up failed</source>
         <translation>備份失敗</translation>
     </message>
@@ -939,23 +1026,23 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>ZipFileProcessWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="44"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="51"/>
         <source>Packing  %1</source>
         <translation>正在打包：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="53"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="114"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>預計完成時間還剩%1分鐘</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="67"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>預計完成時間還剩%1秒</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="97"/>
         <source>Creating Backup File...</source>
         <translation>創建備份文件中...</translation>
     </message>
@@ -963,12 +1050,12 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>ZipWork</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="283"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="328"/>
         <source>%1 File compression failed</source>
         <translation>%1 文件壓縮失敗</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="213"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="252"/>
         <source>Back up file done</source>
         <translation>備份文件結束</translation>
     </message>
@@ -976,7 +1063,7 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>data_transfer_core::MainWindowPrivate</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="37"/>
         <source>UOS data transfer</source>
         <translation>UOS遷移工具</translation>
     </message>

--- a/translations/deepin-data-transfer/deepin-data-transfer_zh_TW.ts
+++ b/translations/deepin-data-transfer/deepin-data-transfer_zh_TW.ts
@@ -1,48 +1,50 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AppSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="42"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="50"/>
         <source>Check transfer application will automatically install the corresponding UOS version of the application.</source>
         <translation>若勾選同步應用，將為您自動安裝對應UOS版本應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="64"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="62"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Application</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="77"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="88"/>
         <source>Recommendation</source>
         <translation>遷移建議</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="113"/>
         <source>Transferable</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.cpp" line="124"/>
         <source>Not Suitable</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="46"/>
         <source>Select apps to transfer</source>
         <translation>選擇要同步的應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/appselectwidget.h" line="47"/>
         <source>Please select the applications to back up</source>
         <translation>選擇要備份的應用</translation>
     </message>
@@ -50,12 +52,12 @@
 <context>
     <name>Application</name>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="86"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="41"/>
         <source>UOS data transfer</source>
         <translation>UOS遷移工具</translation>
     </message>
     <message>
-        <location filename="../../src/apps/data-transfer/main.cpp" line="91"/>
+        <location filename="../../src/apps/data-transfer/main.cpp" line="45"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to UOS, helping you seamlessly replace your system.</source>
         <translation>UOS遷移工具，一鍵將您的文件、個人資料和應用資料遷移到UOS，助您無縫更換系統</translation>
     </message>
@@ -63,32 +65,32 @@
 <context>
     <name>ChooseWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="35"/>
         <source>Export to local directory</source>
         <translation>本機匯出備份</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="46"/>
         <source>Select a transfer way</source>
         <translation>選擇資訊遷移方式</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="61"/>
         <source>Unable to connect to the network， please check your network connection or select export to local directory.</source>
         <translation>無法連接伺服器！請檢測網路連接或者使用備份文件遷移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.cpp" line="74"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="33"/>
         <source>From Windows PC</source>
         <translation>從Windows PC</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/choosewidget.h" line="39"/>
         <source>Import from backup files</source>
         <translation>從備份文件匯入</translation>
     </message>
@@ -96,54 +98,54 @@
 <context>
     <name>ConfigSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="47"/>
         <source>Check transfer configuration will automatically apply to UOS.</source>
         <translation>已掃描目前系統的個人配置，請選擇需要遷移的配置項</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="59"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="57"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
         <source>Browser bookmarks</source>
         <translation>瀏覽器書籤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="75"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="86"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Recommendation</source>
         <translation>遷移建議</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="98"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="139"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="109"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="154"/>
         <source>Transferable</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="116"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="131"/>
         <source>Personal Settings</source>
         <translation>個人配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.cpp" line="153"/>
         <source>Customized Wallpaper</source>
         <translation>自訂桌面</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="49"/>
         <source>Select the configuration to transfer</source>
         <translation>選擇要同步的配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/configselectwidget.h" line="50"/>
         <source>Please select the configurations to back up</source>
         <translation>請選擇要備份的配置</translation>
     </message>
@@ -151,52 +153,57 @@
 <context>
     <name>ConnectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="44"/>
         <source>Ready to connect</source>
         <translation>準備連接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="49"/>
         <source>Please open data transfer on Windows, and imput the IP and connect code</source>
         <translation>請在Windows端打開遷移工具，輸入本機IP和連接密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="56"/>
         <source>Download Windows client</source>
         <translation>下載Windows用戶端</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="68"/>
         <source>Connect code is expired, please refresh for new code</source>
         <translation>連接密碼已過期，請重新整理獲取新密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="84"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="104"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="114"/>
         <source>computer</source>
         <translation>電腦</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="107"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="135"/>
         <source>Local IP</source>
         <translation>本機IP</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="163"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="147"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="210"/>
         <source>Refresh</source>
         <translation>重新整理</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>The code will be expired in</source>
         <translation>密碼有效時間還剩</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/connectwidget.cpp" line="171"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/connectwidget.cpp" line="218"/>
         <source>please input connect code as soon as possible</source>
         <translation>請盡快輸入連接密碼</translation>
     </message>
@@ -204,62 +211,62 @@
 <context>
     <name>CreateBackupFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="87"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="98"/>
         <source>Create data backup</source>
         <translation>建立備份文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="106"/>
         <source>File information</source>
         <translation>文件資訊</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="126"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="144"/>
         <source>size:0B</source>
         <translation>大小：0B</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="152"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="163"/>
         <source>Location</source>
         <translation>儲存位置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="162"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="173"/>
         <source>(Select Backup Disk)</source>
         <translation>（選擇備份磁碟）</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="187"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="198"/>
         <source>Insufficient space in the selected disk, please clean the space</source>
         <translation>目前磁碟空間不足，請清除理磁碟空間</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="206"/>
         <source>Backup</source>
         <translation>開始備份</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="193"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="204"/>
         <source>Cancel</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="339"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="369"/>
         <source>Size:%1</source>
         <translation>大小：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="382"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="420"/>
         <source>local disk</source>
         <translation>本機磁碟</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="388"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/createbackupfilewidget.cpp" line="426"/>
         <source>%1/%2 available</source>
         <translation>%1/%2可用</translation>
     </message>
@@ -267,22 +274,22 @@
 <context>
     <name>CustomMessageBox</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="72"/>
         <source>Reselect</source>
         <translation>重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="81"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="87"/>
         <source>Continue</source>
         <translation>繼續傳輸</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>The presence of outstanding transfer tasks between you and the target device has been detected.</source>
         <translation>已檢測到您和目標裝置之間存在未完成的傳輸任務。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/custommessagebox.cpp" line="138"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/custommessagebox.cpp" line="146"/>
         <source>Do you want to continue with the last transfer?</source>
         <translation>您想繼續上次的傳輸任務嗎？</translation>
     </message>
@@ -290,42 +297,42 @@
 <context>
     <name>ErrorWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="54"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="63"/>
         <source>Transfer will be completed in</source>
         <translation>預計遷移還剩</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="78"/>
         <source>Try again</source>
         <translation>重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.cpp" line="66"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.cpp" line="75"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="31"/>
         <source>Network Error</source>
         <translation>網路錯誤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="30"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
         <source>Transfer interrupted</source>
         <translation>遷移中斷</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
         <source>The network disconnected, transfer failed, please connect the network and try again</source>
         <translation>網路連接斷開，遷移失敗，請檢查網路連接或者重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
         <source>Insufficient space in UOS, please clear at least %1 GB and try again</source>
         <translation>UOS剩餘空間不足，請至少清理%1GB然後重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/errorwidget.h" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/errorwidget.h" line="38"/>
         <source>Insufficient space in UOS, Please reserve enough space</source>
         <translation>UOS剩餘空間不足夠,請預留足夠空間</translation>
     </message>
@@ -333,37 +340,37 @@
 <context>
     <name>FileSelectWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="59"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="60"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="69"/>
         <source>When transfer completed, the data will be placed in the user&apos;s home directory</source>
         <translation>傳輸完成的資料，將被存放在使用者的home目錄下</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="82"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.cpp" line="80"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="56"/>
         <source>Select the file to transfer</source>
         <translation>請選擇要遷移的文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/fileselectwidget.h" line="57"/>
         <source>Please select the files to back up</source>
         <translation>請選擇要備份的文件</translation>
     </message>
@@ -371,25 +378,44 @@
 <context>
     <name>NetworkDisconnectionWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="38"/>
         <source>The network has been disconnected. Please check your network</source>
         <translation>網路已斷開，請檢查您的網路</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="44"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/networkdisconnectionwidget.cpp" line="45"/>
         <source>Try again</source>
         <translation>重試</translation>
     </message>
 </context>
 <context>
+    <name>NetworkUtil</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="472"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="496"/>
+        <source>Transfering</source>
+        <translation>傳輸中</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkUtilPrivate</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="145"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="165"/>
+        <location filename="../../src/lib/data-transfer/core/net/networkutil.cpp" line="188"/>
+        <source>Transfering</source>
+        <translation>傳輸中</translation>
+    </message>
+</context>
+<context>
     <name>ProcessWindow</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="297"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="352"/>
         <source>Installing</source>
         <translation>正在安裝</translation>
     </message>
@@ -397,87 +423,149 @@
 <context>
     <name>PromptWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="29"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="35"/>
         <source>Before tranfer</source>
         <translation>開始之前</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="34"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="40"/>
         <source>Data transfer requires some time, to avoid interrupting the migration due to low battery, please keep connect to the  power.</source>
         <translation>遷移需要一定的時間，避免斷電中斷遷移，請插上電源。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="36"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="42"/>
         <source>Other applications may slowdown the transfer speed. For smoother experience, please close other applications.</source>
         <translation>其他應用可能會干擾遷移速度，為了遷移更流暢，請關閉其他應用。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="44"/>
         <source>For the security of your transfer, please use a trusted network.</source>
         <translation>為了您的傳輸資訊安全，請使用可信網路。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="68"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/promptwidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/promptwidget.cpp" line="70"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="116"/>
+        <source>Port number must be between %1 and %2</source>
+        <translation>連接埠號必須在 %1 和 %2 之間</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/portmanager.cpp" line="120"/>
+        <source>Port is already in use, please change</source>
+        <translation>連接埠已被佔用，請修改</translation>
+    </message>
+</context>
+<context>
+    <name>QuaGzipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="44"/>
+        <source>QIODevice::Append is not supported for GZIP</source>
+        <translation>GZIP 不支援 QIODevice::Append 模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="51"/>
+        <source>Opening gzip for both reading and writing is not supported</source>
+        <translation>不支援同時以讀寫方式打開 gzip</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="60"/>
+        <source>You can open a gzip either for reading or for writing. Which is it?</source>
+        <translation>gzip 只能以讀或寫方式打開，請指定其一</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quagzipfile.cpp" line="67"/>
+        <source>Could not gzopen() file</source>
+        <translation>無法打開 gzip 檔案</translation>
+    </message>
+</context>
+<context>
+    <name>QuaZIODevice</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="138"/>
+        <source>QIODevice::Append is not supported for QuaZIODevice</source>
+        <translation>QuaZIODevice 不支援 QIODevice::Append 模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quaziodevice.cpp" line="144"/>
+        <source>QIODevice::ReadWrite is not supported for QuaZIODevice</source>
+        <translation>QuaZIODevice 不支援 QIODevice::ReadWrite 模式</translation>
+    </message>
+</context>
+<context>
+    <name>QuaZipFile</name>
+    <message>
+        <location filename="../../src/lib/data-transfer/quazip/quazipfile.cpp" line="246"/>
+        <source>ZIP/UNZIP API error %1</source>
+        <translation>ZIP/UNZIP API 錯誤 %1</translation>
+    </message>
+</context>
+<context>
     <name>ReadyWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="48"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="113"/>
         <source>Ready to connect</source>
         <translation>準備連接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="117"/>
         <source>IP</source>
         <translation>IP位址</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="59"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="125"/>
         <source>Please input the IP of UOS</source>
         <translation>請輸入UOS端的IP位址</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="79"/>
-        <source>Please open data transfer on UOS, and get the IP</source>
-        <translation>請打開UOS端的資料遷移工具，並可查看IP位址</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="85"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="148"/>
         <source>Connect code</source>
         <translation>連接密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="159"/>
         <source>Please input the connect code on UOS</source>
         <translation>請輸入UOS端顯示的連接密碼</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="118"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="184"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="33"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="112"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="167"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="41"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="178"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="250"/>
         <source>connect...</source>
         <translation>連線中...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="49"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="186"/>
         <source>Connect</source>
         <translation>連接</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/readywidget.cpp" line="258"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="242"/>
+        <source>Port is unreachable, please change the port on both devices and retry</source>
+        <translation>連接埠無法通訊，請修改兩端連接埠號後重試</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/readywidget.cpp" line="354"/>
         <source>Failed to connect, please check your input</source>
         <translation>連線失敗，請檢查輸入</translation>
     </message>
@@ -485,28 +573,28 @@
 <context>
     <name>ResultDisplayWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="128"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="154"/>
         <source>Transfer completed partially</source>
         <translation>部分遷移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="32"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="125"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="150"/>
         <source>Transfer completed</source>
         <translation>遷移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="38"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="45"/>
         <source>Partial information migration failed, please go to UOS for manual transfer</source>
         <translation>部分資訊遷移失敗，請前往UOS手動遷移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="57"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/resultdisplay.cpp" line="52"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/resultdisplay.cpp" line="59"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
@@ -514,19 +602,19 @@
 <context>
     <name>SelectItem</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="216"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="263"/>
         <source>Selected:0</source>
         <translation>選擇：0</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="239"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="241"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="289"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="292"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="295"/>
         <source>Selected:%1</source>
         <translation>已選：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="304"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="361"/>
         <source>Edit</source>
         <translation>編輯</translation>
     </message>
@@ -534,42 +622,42 @@
 <context>
     <name>SelectMainWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="116"/>
         <source>File</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="121"/>
         <source>App</source>
         <translation>應用</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="97"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="123"/>
         <source>Config</source>
         <translation>配置</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.cpp" line="112"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.cpp" line="138"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="72"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
         <source>Select data to transfer</source>
         <translation>選擇要遷移的資料</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="73"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="76"/>
         <source>Please select the content to back up</source>
         <translation>請選擇要備份的內容</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="74"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="77"/>
         <source>Start transfer</source>
         <translation>開始遷移</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/selectmainwidget.h" line="75"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/selectmainwidget.h" line="78"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
@@ -577,117 +665,130 @@
 <context>
     <name>SettingHelper</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Profiles</source>
         <translation>配置檔案</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="63"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="82"/>
         <source>Wrong or missing profile</source>
         <translation>配置檔案錯誤或遺失</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
         <source>My Wallpaper</source>
         <translation>我的桌布</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="111"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="234"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="122"/>
+        <source>File not found</source>
+        <translation>未找到檔案</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="130"/>
+        <source>Failed to move wallpaper file</source>
+        <translation>移動桌布檔案失敗</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="157"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="293"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer completed</source>
         <translation>遷移完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="161"/>
+        <source>Failed to set wallpaper</source>
+        <translation>設定桌布失敗</translation>
+    </message>
+    <message>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Browser Bookmarks</source>
         <translation>瀏覽器書籤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="146"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="190"/>
         <source>BrowserBookMark</source>
         <translation>瀏覽器書籤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="176"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="226"/>
         <source>is installed</source>
         <translation>已安裝</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="200"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="250"/>
         <source>Installing</source>
         <translation>正在安裝</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="268"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="328"/>
         <source>Transfer failed</source>
         <translation>遷移失敗</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="133"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="177"/>
         <source>Format error</source>
         <translation>格式錯誤</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="143"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="187"/>
         <source>Setup failed, configuration can be imported manually</source>
         <translation>配置失敗，請手動匯入</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="157"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="188"/>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="201"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="238"/>
+        <location filename="../../src/lib/data-transfer/core/utils/settinghepler.cpp" line="297"/>
         <source>Installation failed, please go to the app store to install</source>
         <translation>安裝失敗，請前往應用商店安裝</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/settinghepler.cpp" line="249"/>
-        <source>Transfer Complete</source>
-        <translation>遷移完成</translation>
     </message>
 </context>
 <context>
     <name>SidebarWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="21"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
         <source>Videos</source>
         <translation>影片</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
         <source>Pictures</source>
         <translation>圖片</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="23"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
         <source>Documents</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="24"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
         <source>Downloads</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="25"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="27"/>
         <source>Music</source>
         <translation>音樂</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="26"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="28"/>
         <source>Desktop</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="80"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="94"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="399"/>
         <source>Select:%1</source>
         <translation>已選：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/siderbarwidget.cpp" line="225"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/siderbarwidget.cpp" line="267"/>
         <source>local disk</source>
         <translation>本機磁碟</translation>
     </message>
@@ -695,83 +796,74 @@
 <context>
     <name>StartWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="35"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
         <source>UOS data transfer</source>
         <translation>UOS遷移工具</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="39"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="43"/>
         <source>UOS transfer tool enables one click migration of your files, personal data, and applications to
 UOS, helping you seamlessly replace your system.</source>
         <translation>UOS遷移工具，一鍵將您的文件、個人資料和應用資料遷移到
 UOS，助您無縫更換系統</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/connect/startwidget.cpp" line="46"/>
+        <location filename="../../src/lib/data-transfer/core/gui/connect/startwidget.cpp" line="50"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
 </context>
 <context>
-    <name>TransferHandle</name>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/utils/transferworker.cpp" line="326"/>
-        <source>Transfering</source>
-        <translation>傳輸中</translation>
-    </message>
-</context>
-<context>
     <name>TransferringWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="42"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="193"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="230"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="50"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="221"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="264"/>
         <source>Transferring...</source>
         <translation>正在傳輸...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="57"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="229"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="65"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="218"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="263"/>
         <source>Calculationing...</source>
         <translation>計算中...</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="63"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="132"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="71"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="147"/>
         <source>Show processes</source>
         <translation>顯示行程</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="119"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="133"/>
         <source>Hide processes</source>
         <translation>隱藏行程</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="154"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="195"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="170"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="223"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>預計遷移時間還剩 %1 分鐘</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="171"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="243"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="191"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="281"/>
         <source>Transfering</source>
         <translation>傳輸中</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="199"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="227"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>預計遷移時間還剩 %1 秒</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="202"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="231"/>
         <source>Transfer will be completed in --</source>
         <translation>預計遷移時間還剩--</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/transferringwidget.cpp" line="237"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/transferringwidget.cpp" line="272"/>
         <source>Decompressing</source>
         <translation>解壓中</translation>
     </message>
@@ -779,8 +871,8 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>UnzipWorker</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="126"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/unzipwoker.cpp" line="137"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="140"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/unzipwoker.cpp" line="151"/>
         <source>Decompressing</source>
         <translation>解壓中</translation>
     </message>
@@ -788,34 +880,34 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>UploadFileFrame</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="197"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="256"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="212"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="274"/>
         <source>Drag file here </source>
         <translation>拖曳文件至此</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="202"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="257"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="217"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="275"/>
         <source>Import file</source>
         <translation>匯入文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="276"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="296"/>
         <source>Only .zip is supported, please</source>
         <translation>僅支持zip格式，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="277"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="297"/>
         <source>reselect</source>
         <translation>重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>select zip file</source>
         <translation>選擇zip文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="351"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="377"/>
         <source>ZIP file (*.zip)</source>
         <translation>ZIP文件(*.zip)</translation>
     </message>
@@ -823,48 +915,43 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>UploadFileWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="40"/>
         <source>Select data transfer file</source>
         <translation>選擇資料遷移文件</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="49"/>
         <source>File error, cannot transfer, please reselect</source>
         <translation>文件錯誤，無法遷移，請重新選擇</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="62"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="108"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="113"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="64"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="115"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="121"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="76"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="69"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="80"/>
         <source>Retry</source>
         <translation>重試</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="122"/>
+        <location filename="../../src/lib/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="130"/>
         <source>The file is corrupted and cannot be migrated. Please replace it with a backup file.</source>
         <translation>文件錯誤，無法遷移，請更換備份文件</translation>
-    </message>
-    <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/backupload/uploadfilewidget.cpp" line="133"/>
-        <source>Insufficient space on UOS. Please reserve at least %1G of space and try again.</source>
-        <translation>UOS空間不足，請至少預留 %1G 空間後重試</translation>
     </message>
 </context>
 <context>
     <name>UserSelectFileSize</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/select/userselectfilesize.cpp" line="22"/>
+        <location filename="../../src/lib/data-transfer/core/gui/select/userselectfilesize.cpp" line="28"/>
         <source>Calculating</source>
         <translation>計算中</translation>
     </message>
@@ -872,33 +959,33 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>WaitTransferWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="36"/>
         <source>Waiting for transfer...</source>
         <translation>等待傳輸</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="37"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="41"/>
         <source>Please select the data to transfer on Windows</source>
         <translation>請在Windows端選擇要傳輸的內容</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="47"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="98"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="51"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="113"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="99"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="114"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="116"/>
         <source>This operation will clear the transmission progress, Do you want to continue.</source>
         <translation>此操作將清除傳輸進度，是否要繼續。</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="102"/>
+        <location filename="../../src/lib/data-transfer/core/gui/transfer/waittransferwidget.cpp" line="117"/>
         <source>This operation is not recoverable</source>
         <translation>此操作不可復原</translation>
     </message>
@@ -906,32 +993,32 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>ZipFileProcessResultWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="37"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="49"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="54"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="91"/>
         <source>Back up succeed</source>
         <translation>備份完成</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="90"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="97"/>
         <source>Congratulations, Your Information has been Successfully Backed Up.</source>
         <translation>恭喜你，資訊備份成功</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="95"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="102"/>
         <source>Go to View</source>
         <translation>前往查看</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="120"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocessresultwidget.cpp" line="131"/>
         <source>Back up failed</source>
         <translation>備份失敗</translation>
     </message>
@@ -939,23 +1026,23 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>ZipFileProcessWidget</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="44"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="51"/>
         <source>Packing  %1</source>
         <translation>正在打包：%1</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="53"/>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="101"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="62"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="114"/>
         <source>Transfer will be completed in %1 minutes</source>
         <translation>預計完成時間還剩%1分鐘</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="56"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="67"/>
         <source>Transfer will be completed in %1 secondes</source>
         <translation>預計完成時間還剩%1秒</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="84"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipfileprocesswidget.cpp" line="97"/>
         <source>Creating Backup File...</source>
         <translation>建立備份文件中...</translation>
     </message>
@@ -963,12 +1050,12 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>ZipWork</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="283"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="328"/>
         <source>%1 File compression failed</source>
         <translation>%1 文件壓縮失敗</translation>
     </message>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/getbackup/zipworker.cpp" line="213"/>
+        <location filename="../../src/lib/data-transfer/core/gui/getbackup/zipworker.cpp" line="252"/>
         <source>Back up file done</source>
         <translation>備份文件結束</translation>
     </message>
@@ -976,7 +1063,7 @@ UOS，助您無縫更換系統</translation>
 <context>
     <name>data_transfer_core::MainWindowPrivate</name>
     <message>
-        <location filename="../../src/plugins/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="32"/>
+        <location filename="../../src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp" line="37"/>
         <source>UOS data transfer</source>
         <translation>UOS遷移工具</translation>
     </message>


### PR DESCRIPTION
…sh translations

- Change lupdate source directory from ./plugins/data-transfer to ./lib/data-transfer in data-transfer-translate.sh to match the new module layout
- Update SPDX copyright year range from 2022 - 2023 to 2022 - 2026
- Regenerate all translation .ts files (bo, ug, zh_CN, zh_HK, zh_TW and source template) against the new source path

构建(i18n): 更新 lupdate 源码路径为 lib 目录并刷新翻译文件

- 在 data-transfer-translate.sh 中将 lupdate 源码目录由 ./plugins/data-transfer 改为 ./lib/data-transfer，以匹配新的模块目录结构
- 更新 SPDX 版权年份范围，由 2022 - 2023 更新为 2022 - 2026
- 使用新的源码路径重新生成所有翻译 .ts 文件（bo、ug、zh_CN、zh_HK、zh_TW 及源模板）

Log: 更新数据迁移翻译脚本源码目录为 lib 并重新生成各语言翻译文件
Task: https://pms.uniontech.com/task-view-390795.html