### PR TITLE
feat(transfer): add DSG config for data transfer control port

### DIFF
--- a/assets/configs/org.deepin.dde.cooperation.transfer.json
+++ b/assets/configs/org.deepin.dde.cooperation.transfer.json
@@ -1,0 +1,17 @@
+{
+    "magic":"dsg.config.meta",
+    "version":"1.0",
+    "contents":{
+        "cooperation.transfer.port":{
+            "value":0,
+            "serial":0,
+            "flags":[],
+            "name":"Data Transfer Session Port",
+            "name[zh_CN]":"数据传输会话端口",
+            "description[zh_CN]":"用于配置数据迁移工具的控制通信端口。为0时使用默认端口或用户设置，非0时覆盖用户设置且不受端口范围限制。",
+            "description":"Configures the control communication port for the data transfer tool. When set to 0, the default port or user setting is used. Non-zero values override user settings without range restrictions.",
+            "permissions":"readwrite",
+            "visibility":"private"
+        }
+    }
+}

--- a/debian/deepin-data-transfer.install
+++ b/debian/deepin-data-transfer.install
@@ -6,3 +6,4 @@ usr/share/icons/hicolor/scalable/apps/deepin-data-transfer.svg
 usr/share/applications/deepin-data-transfer.desktop
 usr/share/deepin-log-viewer/deepin-log.conf.d/deepin-data-transfer.json
 usr/share/deepin-manual/manual-assets/application/deepin-data-transfer
+usr/share/dsg/configs/org.deepin.dde.cooperation.transfer/*.json


### PR DESCRIPTION
- Add org.deepin.dde.cooperation.transfer.json DSG config metadata defining cooperation.transfer.port to configure the data transfer control communication port (0 = use default port or user setting; non-zero overrides user settings without range restriction)
- Add install rule for usr/share/dsg/configs/org.deepin.dde.cooperation.transfer/*.json in deepin-data-transfer.install to ship the new config file

新增(transfer): 增加数据传输控制端口 DSG 配置项

- 新增 org.deepin.dde.cooperation.transfer.json DSG 配置元数据，定义 cooperation.transfer.port 用于配置数据传输控制通信端口（值为 0 时使用默认端口或用户设置，非 0 时覆盖用户设置且不受端口范围限制）
- 在 deepin-data-transfer.install 中增加 usr/share/dsg/configs/org.deepin.dde.cooperation.transfer/*.json 安装规则，随包安装新配置文件

Log: 为数据迁移工具新增控制通信端口的 DSG 配置项，并补充对应的打包安装规则
Task: https://pms.uniontech.com/task-view-390795.html

## Summary by Sourcery

Add DSG configuration support for controlling the data transfer tool’s control communication port and ensure the new configuration is shipped with the package.

New Features:
- Introduce a DSG configuration schema org.deepin.dde.cooperation.transfer.json defining cooperation.transfer.port for configuring the data transfer control communication port.

Build:
- Add an install rule to include org.deepin.dde.cooperation.transfer DSG config files in the deepin-data-transfer package.