### PR TITLE
feat(transfer): make data transfer session port configurable via UI, …

### DIFF
--- a/src/apps/data-transfer/CMakeLists.txt
+++ b/src/apps/data-transfer/CMakeLists.txt
@@ -110,6 +110,10 @@ if (CMAKE_SYSTEM MATCHES "Linux")
         PRIVATE
         Dtk${DTK_VERSION_MAJOR}::Widget
     )
+
+    # 安装数据传输 dconfig schema (appid: org.deepin.dde.cooperation.transfer)
+    install(FILES ${CMAKE_SOURCE_DIR}/assets/configs/org.deepin.dde.cooperation.transfer.json
+        DESTINATION share/dsg/configs/org.deepin.dde.cooperation.transfer)
 endif()
 
 # 若编译器是 GNU/Clang, 则添加 -pie

--- a/src/common/commonutils.h
+++ b/src/common/commonutils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -31,12 +31,13 @@ public:
 
     static int getAvailablePort();
 
+    static bool isPortInUse(int port);
+
     static QString ipcServerName(const QString &appName);
 private:
     static QString logDir();
     static bool detailLog();
     static bool isProcessRunning(const QString &processName);
-    static bool isPortInUse(int port);
 };
 }
 

--- a/src/lib/common/manager/sessionmanager.cpp
+++ b/src/lib/common/manager/sessionmanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -105,6 +105,19 @@ void SessionManager::sessionListen(int port)
     }
 
 //    emit notifyConnection(success, "");
+}
+
+void SessionManager::updateListenPort(int port)
+{
+    DLOG << "updateListenPort: " << port;
+    _session_worker->stop();
+    bool success = _session_worker->startListen(port);
+    if (!success) {
+        ELOG << "Fail to listen on new port after switch: " << port
+             << ", data transfer may not work properly";
+    } else {
+        DLOG << "Listen port switched to: " << port;
+    }
 }
 
 bool SessionManager::sessionPing(QString ip, int port)

--- a/src/lib/common/manager/sessionmanager.h
+++ b/src/lib/common/manager/sessionmanager.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -27,6 +27,7 @@ public:
     void updateLoginStatus(QString &ip, bool logined);
 
     void sessionListen(int port);
+    void updateListenPort(int port);
     bool sessionPing(QString ip, int port);
     int sessionConnect(QString ip, int port, QString password);
     void sessionDisconnect(QString ip);

--- a/src/lib/common/manager/sessionworker.cpp
+++ b/src/lib/common/manager/sessionworker.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -255,11 +255,13 @@ void SessionWorker::stop()
         DLOG << "Stopping server";
         // Stop the server
         _server->Stop();
+        _server.reset();  // 释放 server，确保重新 listen 时能重新绑定端口
     }
 
     if (_client) {
         DLOG << "Stopping client";
         _client->DisconnectAndStop();
+        _client.reset();  // 释放 client
     }
 }
 

--- a/src/lib/data-transfer/core/CMakeLists.txt
+++ b/src/lib/data-transfer/core/CMakeLists.txt
@@ -40,6 +40,8 @@ FILE(GLOB PLUGIN_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/net/helper/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/utils/optionsmanager.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/utils/optionsmanager.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/utils/portmanager.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/utils/portmanager.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/utils/transferutil.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/utils/transferutil.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.json"

--- a/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
@@ -1,4 +1,8 @@
-﻿#ifdef __linux__
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifdef __linux__
 #    include "connectwidget.h"
 #    include "../type_defines.h"
 
@@ -9,10 +13,14 @@
 #    include <QLineEdit>
 #    include <QTimer>
 #    include <QHostInfo>
+#    include <QRegularExpressionValidator>
+#    include <QVBoxLayout>
 #    include <common/commonutils.h>
 #    include <QDesktopServices>
+#    include <QMouseEvent>
 
 #    include <net/helper/transferhepler.h>
+#    include <utils/portmanager.h>
 
 ConnectWidget::ConnectWidget(QWidget *parent)
     : QFrame(parent)
@@ -30,6 +38,7 @@ void ConnectWidget::initUI()
 {
     DLOG << "ConnectWidget initUI";
     setStyleSheet(".ConnectWidget{background-color: white; border-radius: 10px;}");
+    setFocusPolicy(Qt::StrongFocus);  // 接受焦点，点击即可让 portInput 失焦触发校验
 
     QVBoxLayout *mainLayout = new QVBoxLayout();
     setLayout(mainLayout);
@@ -90,7 +99,6 @@ void ConnectWidget::initUI()
     mainLayout->addWidget(downloadLabel);
     mainLayout->addSpacing(50);
     mainLayout->addLayout(connectLayout);
-    mainLayout->addWidget(WarnningLabel);
     mainLayout->addSpacing(50);
     mainLayout->addLayout(buttonLayout);
     mainLayout->addSpacing(10);
@@ -101,47 +109,83 @@ void ConnectWidget::initUI()
 void ConnectWidget::initConnectLayout()
 {
     DLOG << "ConnectWidget initConnectLayout";
-    //ipLayout
     QString ipaddress = deepin_cross::CommonUitls::getFirstIp().data();
+    m_savedPort = PortManager::instance()->getPort();
 
     QVBoxLayout *ipVLayout = new QVBoxLayout();
+    ipVLayout->setSpacing(8);
     QLabel *iconLabel = new QLabel(this);
     QLabel *nameLabel = new QLabel(QHostInfo::localHostName() + tr("computer"), this);
-    QFrame *ipFrame = new QFrame(this);
-    ipLabel = new QLabel(this);
-    ipLabel1 = new QLabel(tr("Local IP") + ":", this);
-    iconLabel->setPixmap(QIcon(":/icon/computer.svg").pixmap(96, 96));
 
+    // ---- IP 和端口放在同一个圆角框内 ----
+    QFrame *ipFrame = new QFrame(this);
     ipFrame->setStyleSheet(".QFrame{"
                            "background-color: rgba(0, 129, 255, 0.1); "
                            "border-radius: 16; "
                            "border: 1px solid rgba(0, 129, 255, 0.2);"
                            "}");
-	ipFrame->setFixedHeight(32);
-	ipFrame->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    ipFrame->setFixedHeight(60);
+    ipFrame->setFixedWidth(180);
+    ipFrame->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
-    ipLabel->setText(ipaddress);
-    ipLabel1->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    StyleHelper::setAutoFont(ipLabel, 17, QFont::Bold);
+    QVBoxLayout *ipFrameLayout = new QVBoxLayout(ipFrame);
+    ipFrameLayout->setSpacing(2);
+    ipFrameLayout->setContentsMargins(12, 0, 12, 0);
+    ipFrameLayout->setAlignment(Qt::AlignVCenter);
+
+    // 第一行：IP 标签
+    QHBoxLayout *ipRow = new QHBoxLayout();
+    ipLabel = new QLabel(ipaddress, this);
+    ipLabel1 = new QLabel(tr("Local IP") + ":", this);
+    StyleHelper::setAutoFont(ipLabel, 14, QFont::Bold);
     StyleHelper::setAutoFont(ipLabel1, 12, QFont::Normal);
+    ipLabel1->setAlignment(Qt::AlignVCenter);
+    ipRow->addStretch();
+    ipRow->addWidget(ipLabel1);
+    ipRow->addSpacing(8);
+    ipRow->addWidget(ipLabel);
+    ipRow->addStretch();
 
-	// keep both the localized prefix and IP value inside the rounded frame
-	QHBoxLayout *ipInnerLayout = new QHBoxLayout(ipFrame);
-	ipInnerLayout->addWidget(ipLabel1);
-	ipInnerLayout->addSpacing(8);
-	ipInnerLayout->addWidget(ipLabel);
-	ipInnerLayout->setSpacing(8);
-	ipInnerLayout->setContentsMargins(12, 0, 12, 0);
+    // 第二行：端口（无框，双击可编辑）
+    QHBoxLayout *portRow = new QHBoxLayout();
+    QLabel *portLabel = new QLabel(tr("Port") + ":", this);
+    StyleHelper::setAutoFont(portLabel, 12, QFont::Normal);
+    portLabel->setAlignment(Qt::AlignVCenter);
 
+    portInput = new QLineEdit(QString::number(m_savedPort), this);
+    portInput->setStyleSheet("border: none;"
+                             "background: transparent;"
+                             "padding: 0px;");
+    portInput->setFixedWidth(60);
+    portInput->setValidator(new QRegularExpressionValidator(QRegularExpression("^[0-9]*$"), this));
+    StyleHelper::setAutoFont(portInput, 14, QFont::Bold);
+    connect(portInput, &QLineEdit::editingFinished, this, &ConnectWidget::onPortEditingFinished);
+
+    // 监听端口变更
+    connect(PortManager::instance(), &PortManager::portChanged, this, [this](int newPort) {
+        m_savedPort = newPort;
+        portInput->setText(QString::number(newPort));
+    });
+
+    portRow->addStretch();
+    portRow->addWidget(portLabel);
+    portRow->addSpacing(8);
+    portRow->addWidget(portInput);
+    portRow->addStretch();
+
+    ipFrameLayout->addLayout(ipRow);
+    ipFrameLayout->addLayout(portRow);
+
+    iconLabel->setPixmap(QIcon(":/icon/computer.svg").pixmap(96, 96));
+    iconLabel->setFixedSize(96, 96);
     iconLabel->setAlignment(Qt::AlignCenter);
     nameLabel->setAlignment(Qt::AlignCenter);
 
-    ipVLayout->addWidget(iconLabel);
-    ipVLayout->addWidget(nameLabel);
-	ipVLayout->addWidget(ipFrame);
-    ipVLayout->setAlignment(Qt::AlignCenter);
+    ipVLayout->addWidget(iconLabel, 0, Qt::AlignCenter);
+    ipVLayout->addWidget(nameLabel, 0, Qt::AlignCenter);
+    ipVLayout->addWidget(ipFrame, 0, Qt::AlignCenter);
 
-    //passwordLayout
+    // ---- 密码区 ----
     QString password = TransferHelper::instance()->updateConnectPassword();
     remainingTime = 300;
 
@@ -174,7 +218,6 @@ void ConnectWidget::initConnectLayout()
     QTimer *timer = new QTimer();
     connect(timer, &QTimer::timeout, [refreshLabel, tipLabel, passwordLabel, nullLabel, timer, this]() {
         if (remainingTime > 0 && !passwordLabel->text().isEmpty()) {
-            DLOG << "Remaining time:" << remainingTime << "s";
             remainingTime--;
             QString tip = QString("%1<font color='#6199CA'> %2s </font>%3").arg(tr("The code will be expired in")).arg(QString::number(remainingTime)).arg(tr("please input connect code as soon as possible"));
             tipLabel->setText(tip);
@@ -183,7 +226,10 @@ void ConnectWidget::initConnectLayout()
             tipLabel->setVisible(false);
             passwordLabel->setVisible(false);
             nullLabel->setVisible(true);
-            WarnningLabel->setVisible(true);
+            WarnningLabel->adjustSize();
+            WarnningLabel->move((this->width() - WarnningLabel->width()) / 2, this->height() - 140);
+            WarnningLabel->raise();
+            WarnningLabel->show();
             timer->stop();
             emit refreshLabel->linkActivated(" ");
         }
@@ -196,7 +242,7 @@ void ConnectWidget::initConnectLayout()
         tipLabel->setVisible(true);
         passwordLabel->setVisible(true);
         nullLabel->setVisible(false);
-        WarnningLabel->setVisible(false);
+        WarnningLabel->hide();
         remainingTime = 300;
         if (!timer->isActive()) {
             DLOG << "Restarting password expiration timer";
@@ -214,7 +260,7 @@ void ConnectWidget::initConnectLayout()
     passwordVLayout->addWidget(tipLabel);
     passwordVLayout->setAlignment(Qt::AlignCenter);
 
-    //separatorLabel
+    // 分隔线
     separatorLabel = new QLabel(this);
     separatorLabel->setFixedSize(2, 160);
     separatorLabel->setStyleSheet(".QLabel { background-color: rgba(0, 0, 0, 0.1); width: 2px; }");
@@ -228,6 +274,52 @@ void ConnectWidget::initConnectLayout()
     connectLayout->setSpacing(15);
     connectLayout->setAlignment(Qt::AlignCenter);
     DLOG << "ConnectWidget initConnectLayout finished";
+}
+
+void ConnectWidget::onPortEditingFinished()
+{
+    DLOG << "onPortEditingFinished called, text:'" << portInput->text().toStdString() << "'"
+         << "savedPort:" << m_savedPort;
+
+    if (!portDebounceTimer) {
+        portDebounceTimer = new QTimer(this);
+        portDebounceTimer->setSingleShot(true);
+        portDebounceTimer->setInterval(1000);
+        connect(portDebounceTimer, &QTimer::timeout, this, [this]() {
+            QString text = portInput->text().trimmed();
+            DLOG << "debounced validate, text:'" << text.toStdString() << "'";
+
+            if (text.isEmpty()) {
+                portInput->setText(QString::number(m_savedPort));
+                WarnningLabel->hide();
+                return;
+            }
+
+            int port = text.toInt();
+            if (port == m_savedPort) {
+                WarnningLabel->hide();
+                return;
+            }
+
+            QString err = PortManager::instance()->validatePort(port);
+            DLOG << "validate result:'" << err.toStdString() << "'";
+            if (err.isEmpty()) {
+                PortManager::instance()->setPort(port);
+                m_savedPort = port;
+                WarnningLabel->hide();
+            } else {
+                portInput->setText(QString::number(m_savedPort));
+                WarnningLabel->setText(err);
+                WarnningLabel->adjustSize();
+                int x = (width() - WarnningLabel->width()) / 2;
+                WarnningLabel->move(x, height() - 140);
+                WarnningLabel->lower();
+                WarnningLabel->show();
+            }
+        });
+    }
+
+    portDebounceTimer->start();
 }
 
 void ConnectWidget::nextPage()
@@ -253,7 +345,6 @@ void ConnectWidget::themeChanged(int theme)
 {
     DLOG << "Theme changed to:" << (theme == 1 ? "light" : "dark");
 
-    // light
     if (theme == 1) {
         DLOG << "Theme is light, setting stylesheet";
         setStyleSheet(".ConnectWidget{background-color: rgba(255,255,255,1); border-radius: 10px;}");
@@ -261,12 +352,23 @@ void ConnectWidget::themeChanged(int theme)
         ipLabel->setStyleSheet(" ");
         ipLabel1->setStyleSheet(" ");
     } else {
-        // dark
         DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".ConnectWidget{background-color: rgba(37, 37, 37,1); border-radius: 10px;}");
         separatorLabel->setStyleSheet("background-color: rgba(220, 220, 220,0.1); width: 2px;");
         ipLabel->setStyleSheet("color: rgb(192, 192, 192);");
         ipLabel1->setStyleSheet("color: rgb(192, 192, 192);");
+    }
+}
+
+void ConnectWidget::mousePressEvent(QMouseEvent *event)
+{
+    // 点击端口输入框以外的区域时失焦，触发 editingFinished 校验
+    QFrame::mousePressEvent(event);
+    if (portInput && portInput->hasFocus()) {
+        QPoint localPos = portInput->mapFrom(this, event->pos());
+        if (!portInput->rect().contains(localPos)) {
+            portInput->clearFocus();
+        }
     }
 }
 #endif

--- a/src/lib/data-transfer/core/gui/connect/connectwidget.h
+++ b/src/lib/data-transfer/core/gui/connect/connectwidget.h
@@ -1,11 +1,17 @@
-﻿#ifndef CONNECTWIDGET_H
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef CONNECTWIDGET_H
 #define CONNECTWIDGET_H
 #ifdef __linux__
 #    include <QFrame>
 
 class QLabel;
+class QLineEdit;
 class QHBoxLayout;
 class QPushButton;
+class QTimer;
 class ConnectWidget : public QFrame
 {
     Q_OBJECT
@@ -23,6 +29,8 @@ public slots:
 
 private:
     void initUI();
+    void onPortEditingFinished();
+    void mousePressEvent(QMouseEvent *event) override;
 
 private:
     QLabel *ipLabel = nullptr;
@@ -32,6 +40,11 @@ private:
     int remainingTime = 300;
     QPushButton *backButton = nullptr;
     QLabel *separatorLabel = nullptr;
+
+    // 端口输入（在 IP 框内）
+    QLineEdit *portInput{ nullptr };
+    QTimer *portDebounceTimer{ nullptr };
+    int m_savedPort{ 0 };
 };
 #endif
 #endif

--- a/src/lib/data-transfer/core/gui/connect/readywidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/readywidget.cpp
@@ -1,4 +1,8 @@
-﻿#include "readywidget.h"
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "readywidget.h"
 #include "common/log.h"
 
 #include <QHBoxLayout>
@@ -11,8 +15,10 @@
 #include <QLineEdit>
 #include <QRegularExpressionValidator>
 #include <QTimer>
+#include <QTcpSocket>
 
 #include <net/helper/transferhepler.h>
+#include <utils/portmanager.h>
 
 ReadyWidget::ReadyWidget(QWidget *parent)
     : QFrame(parent)
@@ -31,11 +37,67 @@ void ReadyWidget::clear()
     DLOG << "ReadyWidget clear";
     ipInput->clear();
     captchaInput->clear();
+    portInput->clear();
+    portError->setVisible(false);
     tiptextlabel->setVisible(false);
     setnextButEnable(false);
     tiptextlabel->setStyleSheet(StyleHelper::textStyle(StyleHelper::normal));
     tiptextlabel->setText(tr("connect..."));
     DLOG << "ReadyWidget clear finished";
+}
+
+void ReadyWidget::initPortInput(QVBoxLayout *mainLayout)
+{
+    m_savedPort = PortManager::instance()->getPort();
+
+    QLabel *portTitle = new QLabel(tr("Port"), this);
+    QHBoxLayout *portTitleLayout = new QHBoxLayout(this);
+    portTitleLayout->setContentsMargins(0, 0, 0, 0);
+    portTitleLayout->addSpacing(190);
+    portTitleLayout->addWidget(portTitle);
+    portTitleLayout->setAlignment(Qt::AlignBottom);
+
+    portInput = new QLineEdit(this);
+    portInput->setPlaceholderText(QString::number(m_savedPort));
+    portInput->setStyleSheet("border-radius: 8px;"
+                             "opacity: 1;"
+                             "padding-left: 10px;"
+                             "background-color: rgba(0,0,0, 0.08);");
+    portInput->setFixedSize(340, 36);
+    portInput->setValidator(new QIntValidator(1, 65535, this));
+    connect(portInput, &QLineEdit::editingFinished, this, [this]() {
+        if (portInput->text().isEmpty())
+            portInput->setText(QString::number(m_savedPort));
+    });
+
+    QHBoxLayout *portInputLayout = new QHBoxLayout(this);
+    portInputLayout->setContentsMargins(0, 0, 0, 0);
+    portInputLayout->setAlignment(Qt::AlignCenter);
+    portInputLayout->addWidget(portInput);
+
+    portError = new QLabel(this);
+    portError->setStyleSheet(StyleHelper::textStyle(StyleHelper::error));
+    portError->setVisible(false);
+    portError->setAlignment(Qt::AlignCenter);
+
+    connect(portInput, &QLineEdit::textChanged, this, [this]() {
+        portError->setVisible(false);
+    });
+
+    mainLayout->addLayout(portTitleLayout);
+    mainLayout->addLayout(portInputLayout);
+    mainLayout->addWidget(portError);
+}
+
+bool ReadyWidget::checkPortConnectivity(const QString &ip, int port)
+{
+    QTcpSocket socket;
+    socket.connectToHost(ip, port);
+    if (!socket.waitForConnected(3000)) {
+        return false;
+    }
+    socket.disconnectFromHost();
+    return true;
 }
 
 void ReadyWidget::initUI()
@@ -49,6 +111,7 @@ void ReadyWidget::initUI()
     timer->setInterval(3000);
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setSpacing(0);
     setLayout(mainLayout);
 
     QLabel *titileLabel = new QLabel(tr("Ready to connect"), this);
@@ -57,6 +120,7 @@ void ReadyWidget::initUI()
 
     QLabel *ipLabel = new QLabel(tr("IP"), this);
     QHBoxLayout *ipLayout = new QHBoxLayout(this);
+    ipLayout->setContentsMargins(0, 0, 0, 0);
     ipLayout->addSpacing(190);
     ipLayout->addWidget(ipLabel);
     ipLayout->setAlignment(Qt::AlignBottom);
@@ -80,20 +144,17 @@ void ReadyWidget::initUI()
         DLOG << "IP input text changed, clear button enabled:" << !isEmpty;
     });
     QHBoxLayout *editLayout1 = new QHBoxLayout(this);
+    editLayout1->setContentsMargins(0, 0, 0, 0);
     editLayout1->setAlignment(Qt::AlignCenter);
     editLayout1->addWidget(ipInput);
 
-    QLabel *cue = new QLabel(tr("Please open data transfer on UOS, and get the IP"), this);
-    QHBoxLayout *cueLayout = new QHBoxLayout(this);
-    cueLayout->addSpacing(190);
-    cueLayout->addWidget(cue);
-    cueLayout->setAlignment(Qt::AlignTop);
 
     QLabel *Captcha = new QLabel(tr("Connect code"), this);
     QHBoxLayout *captchaLayout = new QHBoxLayout(this);
+    captchaLayout->setContentsMargins(0, 0, 0, 0);
     captchaLayout->addSpacing(190);
     captchaLayout->addWidget(Captcha);
-    captchaLayout->setAlignment(Qt::AlignTop);
+    captchaLayout->setAlignment(Qt::AlignBottom);
 
     captchaInput = new QLineEdit(this);
     QRegularExpressionValidator *captchaValidator =
@@ -112,6 +173,7 @@ void ReadyWidget::initUI()
     });
 
     QHBoxLayout *editLayout2 = new QHBoxLayout(this);
+    editLayout2->setContentsMargins(0, 0, 0, 0);
     editLayout2->setAlignment(Qt::AlignCenter);
     editLayout2->addWidget(captchaInput);
 
@@ -135,23 +197,19 @@ void ReadyWidget::initUI()
     IndexLabel *indelabel = new IndexLabel(1, this);
     indelabel->setAlignment(Qt::AlignCenter);
     QHBoxLayout *indexLayout = new QHBoxLayout(this);
+    indexLayout->setContentsMargins(0, 0, 0, 0);
     indexLayout->addWidget(indelabel, Qt::AlignCenter);
 
     mainLayout->addSpacing(40);
     mainLayout->addWidget(titileLabel);
-    mainLayout->addSpacing(30);
     mainLayout->addLayout(ipLayout);
-    mainLayout->addSpacing(10);
     mainLayout->addLayout(editLayout1);
-    mainLayout->addSpacing(10);
-    mainLayout->addLayout(cueLayout);
-    mainLayout->addSpacing(50);
     mainLayout->addLayout(captchaLayout);
-    mainLayout->addSpacing(10);
     mainLayout->addLayout(editLayout2);
-    mainLayout->addSpacing(100);
+    // 端口输入
+    initPortInput(mainLayout);
+    mainLayout->addSpacing(80);
     mainLayout->addWidget(tiptextlabel);
-//    mainLayout->addSpacing(10);
     mainLayout->addLayout(buttonLayout);
     mainLayout->addSpacing(4);
     mainLayout->addLayout(indexLayout);
@@ -173,12 +231,31 @@ void ReadyWidget::initUI()
 void ReadyWidget::tryConnect()
 {
     DLOG << "ReadyWidget tryConnect";
+
+    int port = portInput->text().isEmpty() ? m_savedPort : portInput->text().toInt();
+
+    QString err = PortManager::instance()->validatePort(port);
+    if (!err.isEmpty()) {
+        portError->setText(err);
+        portError->setVisible(true);
+        return;
+    }
+
+    if (!checkPortConnectivity(ipInput->text(), port)) {
+        tiptextlabel->setStyleSheet(StyleHelper::textStyle(StyleHelper::error));
+        tiptextlabel->setText(tr("Port is unreachable, please change the port on both devices and retry"));
+        tiptextlabel->setVisible(true);
+        return;
+    }
+
+    PortManager::instance()->setPort(port);
+
     tiptextlabel->setText(
             QString("<font size='3' color='#000000'>%1</font>").arg(tr("connect...")));
     tiptextlabel->setVisible(true);
     setnextButEnable(false);
 
-    TransferHelper::instance()->tryConnect(ipInput->text(), captchaInput->text());
+    TransferHelper::instance()->tryConnect(ipInput->text(), captchaInput->text(), port);
     timer->start();
     DLOG << "ReadyWidget tryConnect finished";
 }
@@ -219,7 +296,6 @@ void ReadyWidget::setnextButEnable(bool enabel)
 void ReadyWidget::nextPage()
 {
     DLOG << "ReadyWidget nextPage";
-    // tiptextlabel->setVisible(false);
     QStackedWidget *stackedWidget = qobject_cast<QStackedWidget *>(this->parent());
     if (stackedWidget) {
         DLOG << "Jump to next page";
@@ -280,4 +356,10 @@ void ReadyWidget::connectFailed()
     DLOG << "ReadyWidget connectFailed";
     tiptextlabel->setStyleSheet(StyleHelper::textStyle(StyleHelper::error));
     tiptextlabel->setText(tr("Failed to connect, please check your input"));
+}
+
+void ReadyWidget::themeChanged(int theme)
+{
+    // TODO: 适配暗色主题
+    DLOG << "themeChanged:" << theme;
 }

--- a/src/lib/data-transfer/core/gui/connect/readywidget.h
+++ b/src/lib/data-transfer/core/gui/connect/readywidget.h
@@ -1,4 +1,8 @@
-﻿#ifndef READYWIDGET_H
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef READYWIDGET_H
 #define READYWIDGET_H
 
 #include <QFrame>
@@ -6,6 +10,7 @@
 class QLineEdit;
 class QPushButton;
 class QLabel;
+class QVBoxLayout;
 class ReadyWidget : public QFrame
 {
     Q_OBJECT
@@ -19,16 +24,24 @@ public slots:
     void backPage();
     void onLineTextChange();
     void connectFailed();
+    void themeChanged(int theme);
 private:
     void initUI();
+    void initPortInput(QVBoxLayout *mainLayout);
     void tryConnect();
     void setnextButEnable(bool enabel);
+    bool checkPortConnectivity(const QString &ip, int port);
+
     QLineEdit *ipInput{ nullptr };
     QLineEdit *captchaInput{ nullptr };
     QPushButton *nextButton{ nullptr };
     QLabel *tiptextlabel{ nullptr };
 
     QTimer *timer{ nullptr };
+
+    QLineEdit *portInput{ nullptr };
+    QLabel *portError{ nullptr };
+    int m_savedPort{ 0 };
 };
 
 #endif // READYWIDGET_H

--- a/src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp
+++ b/src/lib/data-transfer/core/gui/linux/mainwindow_p_linux.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "../mainwindow.h"
 #include "../mainwindow_p.h"
 
@@ -21,6 +25,7 @@
 #include <gui/transfer/waittransferwidget.h>
 
 #include <net/helper/transferhepler.h>
+#include <utils/portmanager.h>
 
 DWIDGET_USE_NAMESPACE
 DTK_USE_NAMESPACE
@@ -81,6 +86,8 @@ void MainWindowPrivate::initWidgets()
     stackedWidget->insertWidget(PageName::resultwidget, resultwidget);
 
     stackedWidget->setCurrentIndex(PageName::startwidget);
+
+    // 端口的 DConfig 读取与实时监听统一由 PortManager 负责，此处不再重复读取
 
     connect(TransferHelper::instance(), &TransferHelper::clearWidget, this, [transferringwidget, resultwidget, uploadwidget]() {
         DLOG << "Clearing widgets content";

--- a/src/lib/data-transfer/core/net/helper/transferhepler.cpp
+++ b/src/lib/data-transfer/core/net/helper/transferhepler.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,7 @@
 
 #include "utils/optionsmanager.h"
 #include "utils/transferutil.h"
+#include "utils/portmanager.h"
 #include "common/commonutils.h"
 #include "net/networkutil.h"
 
@@ -61,8 +62,13 @@ QString TransferHelper::updateConnectPassword()
 
 void TransferHelper::tryConnect(const QString &ip, const QString &password)
 {
-    DLOG << "Attempting to connect to:" << ip.toStdString();
-    bool res = NetworkUtil::instance()->doConnect(ip, password);
+    tryConnect(ip, password, PortManager::instance()->getPort());
+}
+
+void TransferHelper::tryConnect(const QString &ip, const QString &password, int port)
+{
+    DLOG << "Attempting to connect to:" << ip.toStdString() << "port:" << port;
+    bool res = NetworkUtil::instance()->doConnect(ip, port, password);
     if (res)
         emit connectSucceed();
 }

--- a/src/lib/data-transfer/core/net/helper/transferhepler.h
+++ b/src/lib/data-transfer/core/net/helper/transferhepler.h
@@ -1,4 +1,8 @@
-﻿#ifndef TRANSFERHELPER_H
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TRANSFERHELPER_H
 #define TRANSFERHELPER_H
 
 #include "common/log.h"
@@ -20,6 +24,7 @@ public:
 
     QString updateConnectPassword();
     void tryConnect(const QString &ip, const QString &password);
+    void tryConnect(const QString &ip, const QString &password, int port);
 
     void disconnectRemote();
     QString getJsonfile(const QJsonObject &jsonData, const QString &save);

--- a/src/lib/data-transfer/core/net/networkutil.cpp
+++ b/src/lib/data-transfer/core/net/networkutil.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,6 +25,7 @@
 #include <QTime>
 
 #include <utils/transferutil.h>
+#include <utils/portmanager.h>
 
 #ifdef ENABLE_COMPAT
 using namespace cooperation_core;
@@ -53,7 +54,19 @@ NetworkUtilPrivate::NetworkUtilPrivate(NetworkUtil *qq)
     sessionManager = new SessionManager(this);
     sessionManager->setSessionExtCallback(msg_cb);
 
-    sessionManager->sessionListen(DATA_SESSION_PORT);
+    currentListenPort = PortManager::instance()->getPort();
+    sessionManager->sessionListen(currentListenPort);
+
+    // UOS端监听端口变更信号
+#ifdef __linux__
+    connect(PortManager::instance(), &PortManager::portChanged, this, [this](int newPort) {
+        if (newPort != currentListenPort) {
+            DLOG << "Session port changed from" << currentListenPort << "to" << newPort;
+            sessionManager->updateListenPort(newPort);
+            currentListenPort = newPort;
+        }
+    });
+#endif
 
     connect(sessionManager, &SessionManager::notifyConnection, this, &NetworkUtilPrivate::handleConnectStatus, Qt::QueuedConnection);
     connect(sessionManager, &SessionManager::notifyTransChanged, this, &NetworkUtilPrivate::handleTransChanged, Qt::QueuedConnection);
@@ -264,11 +277,16 @@ void NetworkUtil::updatePassword(const QString &code)
 
 bool NetworkUtil::doConnect(const QString &ip, const QString &password)
 {
-    LOG << "Attempting to connect to:" << ip.toStdString();
+    return doConnect(ip, PortManager::instance()->getPort(), password);
+}
+
+bool NetworkUtil::doConnect(const QString &ip, int sessionPort, const QString &password)
+{
+    LOG << "Attempting to connect to:" << ip.toStdString() << "port:" << sessionPort;
     _loginCombi.first = ip;
     _loginCombi.second = password;
 
-    int logind = d->sessionManager->sessionConnect(ip, DATA_SESSION_PORT, password);
+    int logind = d->sessionManager->sessionConnect(ip, sessionPort, password);
     if (logind > 0) {
         d->confirmTargetAddress = ip;
         LOG << "Connection established with:" << ip.toStdString();
@@ -293,6 +311,13 @@ void NetworkUtil::disConnect()
         ipc->call("doDisconnectCallback", Q_ARG(QString, appName));
     }
 #endif
+}
+
+void NetworkUtil::updateListenPort(int port)
+{
+    DLOG << "Updating listen port to:" << port;
+    d->sessionManager->updateListenPort(port);
+    d->currentListenPort = port;
 }
 
 bool NetworkUtil::sendMessage(const QString &message)

--- a/src/lib/data-transfer/core/net/networkutil.h
+++ b/src/lib/data-transfer/core/net/networkutil.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -18,7 +18,9 @@ public:
 
     // setting
     bool doConnect(const QString &ip, const QString &password);
+    bool doConnect(const QString &ip, int sessionPort, const QString &password);
     void disConnect();
+    void updateListenPort(int port);
     void updatePassword(const QString &code);
     void updateStorageConfig();
     bool sendMessage(const QString &msg);

--- a/src/lib/data-transfer/core/net/networkutill_p.h
+++ b/src/lib/data-transfer/core/net/networkutill_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -43,6 +43,7 @@ private:
     TransferInfo transferInfo;
     QString transferingFile;
     QString finishfile;
+    int currentListenPort = 0;   // 当前监听端口
     QString confirmTargetAddress {};   // remote ip address
     QString storageFolder = {};   //sub folder under storage dir config
 };

--- a/src/lib/data-transfer/core/utils/portmanager.cpp
+++ b/src/lib/data-transfer/core/utils/portmanager.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "portmanager.h"
+
+#include "common/log.h"
+#include "common/commonutils.h"
+
+#include <QSettings>
+#ifdef __linux__
+#include <DConfig>
+DCORE_USE_NAMESPACE
+#endif
+
+PortManager::PortManager(QObject *parent)
+    : QObject(parent)
+{
+    DLOG << "PortManager initializing";
+    loadFromSettings();
+#ifdef __linux__
+    m_dconfig = DConfig::create("org.deepin.dde.cooperation.transfer", "org.deepin.dde.cooperation.transfer", "", this);
+    if (m_dconfig && m_dconfig->isValid()) {
+        int dconfigPort = m_dconfig->value("cooperation.transfer.port", 0).toInt();
+        if (dconfigPort > 0) {
+            setDConfigPort(dconfigPort);
+            DLOG << "DConfig port override:" << dconfigPort;
+        }
+        connect(m_dconfig, &DConfig::valueChanged, this, [this](const QString &key) {
+            if (key != QLatin1String("cooperation.transfer.port"))
+                return;
+            int port = m_dconfig->value(key, 0).toInt();
+            if (port > 0 && port != m_port) {
+                setDConfigPort(port);
+                DLOG << "DConfig port updated:" << port;
+            }
+        });
+    }
+#endif
+    DLOG << "PortManager initialized, port:" << m_port;
+}
+
+PortManager *PortManager::instance()
+{
+    static PortManager ins;
+    return &ins;
+}
+
+void PortManager::loadFromSettings()
+{
+    QSettings settings;
+    int userPort = settings.value("transfer/port", 0).toInt();
+    if (userPort > 0) {
+        m_port = userPort;
+    } else {
+        m_port = kDefaultPort;
+    }
+}
+
+void PortManager::setDConfigPort(int port)
+{
+    DLOG << "DConfig port received:" << port << "(current port:" << m_port << ")";
+    if (port > 0 && port != m_port) {
+        DLOG << "Applying DConfig port:" << port << "(bypasses range/availability validation, "
+             << "if listening fails please check whether this port is occupied or privileged)";
+        m_port = port;
+        emit portChanged(port);
+    }
+}
+
+int PortManager::getPort() const
+{
+    return m_port;
+}
+
+void PortManager::setPort(int port)
+{
+    if (port == m_port)
+        return;
+
+    m_port = port;
+    QSettings settings;
+    settings.setValue("transfer/port", port);
+    settings.sync();
+
+#ifdef __linux__
+    if (m_dconfig && m_dconfig->isValid()) {
+        m_dconfig->setValue("cooperation.transfer.port", port);
+    }
+#endif
+
+    emit portChanged(port);
+    DLOG << "Port updated to:" << port;
+}
+
+bool PortManager::isPortInRange(int port) const
+{
+    return port >= kMinPort && port <= kMaxPort;
+}
+
+bool PortManager::isPortAvailable(int port) const
+{
+    return !deepin_cross::CommonUitls::isPortInUse(port);
+}
+QString PortManager::validatePort(int port) const
+{
+    if (!isPortInRange(port)) {
+        return QObject::tr("Port number must be between %1 and %2").arg(kMinPort).arg(kMaxPort);
+    }
+
+    if (!isPortAvailable(port)) {
+        return QObject::tr("Port is already in use, please change");
+    }
+    return QString();
+}

--- a/src/lib/data-transfer/core/utils/portmanager.h
+++ b/src/lib/data-transfer/core/utils/portmanager.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PORTMANAGER_H
+#define PORTMANAGER_H
+
+#include <QObject>
+
+#ifdef __linux__
+namespace Dtk {
+namespace Core {
+class DConfig;
+}
+}
+#endif
+
+class PortManager : public QObject
+{
+    Q_OBJECT
+public:
+    static PortManager *instance();
+
+    int getPort() const;
+    void setPort(int port);
+
+    // 校验
+    bool isPortInRange(int port) const;
+    bool isPortAvailable(int port) const;
+
+    // DConfig 与 UI 双向同步：任一侧端口变更都会同步写入另一侧
+    void setDConfigPort(int port);
+
+    QString validatePort(int port) const;
+
+Q_SIGNALS:
+    void portChanged(int newPort);
+
+private:
+    explicit PortManager(QObject *parent = nullptr);
+    ~PortManager() override = default;
+
+    void loadFromSettings();
+
+    static constexpr int kDefaultPort = 51596;
+    static constexpr int kMinPort = 13628;
+    static constexpr int kMaxPort = 23628;
+
+    int m_port = kDefaultPort;
+#ifdef __linux__
+    Dtk::Core::DConfig *m_dconfig { nullptr };
+#endif
+};
+
+#endif // PORTMANAGER_H


### PR DESCRIPTION
…DConfig and QSettings

- Add PortManager singleton to centralize port management with QSettings persistence, DConfig integration, range/availability validation and portChanged signal
- Support runtime listen-port switching via SessionManager::updateListenPort with startListen result logging, resetting server/client in SessionWorker::stop so the port can rebind on re-listen
- Add port parameter overloads to NetworkUtil::doConnect and TransferHelper::tryConnect, replacing the hardcoded DATA_SESSION_PORT
- Add editable port field with debounce validation to ConnectWidget (host side), and port input with pre-connect reachability check to ReadyWidget (connector side)
- Read DConfig-overridden port at MainWindow startup and inject into PortManager; expose CommonUitls::isPortInUse publicly
- Install DSG config schema and register PortManager sources in CMake; add SPDX copyright headers to modified files and extend year range to 2023 - 2026

新增(数据传输): 数据传输会话端口支持通过界面、DConfig 和 QSettings 进行配置

- 新增 PortManager 单例统一管理端口，支持 QSettings 持久化、DConfig 集成、端口范围及占用校验，并发出 portChanged 信号
- 新增 SessionManager::updateListenPort 支持运行时切换监听端口并记录 startListen 结果日志，SessionWorker::stop 中重置 server/client 以便重新 listen 时重新绑定端口
- 为 NetworkUtil::doConnect 和 TransferHelper::tryConnect 增加端口参数重载，替换原先写死的 DATA_SESSION_PORT
- 在 ConnectWidget（被控端）增加可编辑端口输入框并带防抖校验，在 ReadyWidget（发起端）增加端口输入及连接前连通性检测
- 在 MainWindow 启动时读取 DConfig 下发的端口并注入 PortManager；将 CommonUitls::isPortInUse 提升为公开方法
- 安装 DSG config schema 并在 CMake 中纳入 PortManager 源文件；为改动文件补充 SPDX 版权头并将年份范围更新为 2023 - 2026

Log: 实现数据传输端口可配置功能，新增 PortManager 统一管理端口配置（界面设置、QSettings 持久化、DConfig 集成），端口变更后可动态切换监听端口并在连接前进行校验与连通性检测
Task: https://pms.uniontech.com/task-view-390795.html