### PR TITLE
fix(security): harden RPC file transfer against path traversal

### DIFF
--- a/src/compat/plugins/daemon/core/service/job/transferjob.cpp
+++ b/src/compat/plugins/daemon/core/service/job/transferjob.cpp
@@ -148,6 +148,16 @@ fastring TransferJob::acName(const fastring &name)
 
 fastring TransferJob::getSaveFullpath(const fastring &rootdir, const fastring &filename)
 {
+    // V20 增强：第一层安全检查（文件名合法性）
+    if (filename.empty()) {
+        ELOG << "Empty filename rejected";
+        return "";
+    }
+    if (filename.contains("..") || filename.starts_with("/") || filename.starts_with("\\")) {
+        ELOG << "Path traversal attempt detected, filename rejected: " << filename;
+        return "";
+    }
+
     // 第一层子目录已存在则尝试获取已重命名后的名字，比如 abc/ddd/eee.txt -> abc(1)/ddd/eee.txt
     auto acfilename = filename;
     if (acfilename.contains("/")) {
@@ -166,6 +176,30 @@ fastring TransferJob::getSaveFullpath(const fastring &rootdir, const fastring &f
     }
 
     fastring fullpath = path::join(rootdir, acfilename);
+
+    // isPathWithinDir 只做词法规范化（. / ..），realpath 额外处理符号链接
+    // 以 DaemonConfig::getStorageDir() 作为可信根目录，而非客户端传来的 rootdir
+    fastring allowedRoot = DaemonConfig::instance()->getStorageDir(_app_name);
+    char *realRoot = realpath(allowedRoot.c_str(), nullptr);
+    char *realFull = realpath(fullpath.c_str(), nullptr);
+    if (realFull == nullptr) {
+        std::pair<fastring, fastring> pairs = path::split(fullpath);
+        fastring parentDir = pairs.first;
+        realFull = realpath(parentDir.c_str(), nullptr);
+    }
+    if (realRoot != nullptr && realFull != nullptr) {
+        fastring rootPath(realRoot);
+        fastring fullPath(realFull);
+        if (!fullPath.starts_with(rootPath)) {
+            ELOG << "Path traversal detected! Target outside allowed directory: " << fullpath;
+            free(realRoot);
+            free(realFull);
+            return "";
+        }
+    }
+    if (realRoot) free(realRoot);
+    if (realFull) free(realFull);
+
     if (!isPathWithinDir(fullpath, rootdir)) {
         ELOG << "path traversal blocked in getSaveFullpath: fullpath=" << fullpath
              << " rootdir=" << rootdir;
@@ -667,6 +701,15 @@ void TransferJob::readFileBlock(fastring filepath, int fileid, const fastring su
 bool TransferJob::writeAndCreateFile(const QSharedPointer<FSDataBlock> block, const fastring fullpath)
 {
     _notify_fileid = block->file_id;
+
+    // 安全检查：路径为空表示路径验证失败（可能是路径穿越攻击）
+    if (fullpath.empty() && !(block->flags & JobTransFileOp::FILE_COUNTED)
+        && !(block->flags & JobTransFileOp::FILE_COUNTING)
+        && !(block->flags & JobTransFileOp::FILE_TRANS_OVER)) {
+        ELOG << "Invalid file path, possible path traversal attack";
+        return false;
+    }
+
     // 创建文件
     if (block->flags & JobTransFileOp::FIlE_DIR_CREATE) {
         if (!createFile(fullpath, true))

--- a/src/compat/plugins/daemon/core/service/jobmanager.cpp
+++ b/src/compat/plugins/daemon/core/service/jobmanager.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,26 @@ JobManager::~JobManager()
 {
 }
 
+void JobManager::confirmTransfer(const QString &appName)
+{
+    QWriteLocker lk(&_confirm_mutex);
+    _confirmed_transfers.insert(appName);
+    DLOG << "Transfer confirmed for app: " << appName.toStdString();
+}
+
+void JobManager::removeConfirmedTransfer(const QString &appName)
+{
+    QWriteLocker lk(&_confirm_mutex);
+    _confirmed_transfers.remove(appName);
+    DLOG << "Transfer confirmation removed for app: " << appName.toStdString();
+}
+
+bool JobManager::isTransferConfirmed(const QString &appName)
+{
+    QReadLocker lk(&_confirm_mutex);
+    return _confirmed_transfers.contains(appName);
+}
+
 bool JobManager::handleRemoteRequestJob(QString json, QString *targetAppName)
 {
     co::Json info;
@@ -38,6 +58,17 @@ bool JobManager::handleRemoteRequestJob(QString json, QString *targetAppName)
     if (targetAppName)
         *targetAppName = QString(tarAppname.c_str());
     SendRpcService::instance()->removePing(tarAppname.c_str());
+
+    // 安全验证：如果是写入作业（接收文件），必须验证用户已确认接收
+    if (fsjob.write) {
+        QString sourceApp = QString(appName.c_str());
+        if (!isTransferConfirmed(sourceApp)) {
+            ELOG << "Security: Rejected file transfer from " << appName
+                 << " - user has not confirmed acceptance";
+            return false;
+        }
+    }
+
     QSharedPointer<TransferJob> job(new TransferJob());
     job->initJob(fsjob.app_who, tarAppname, jobId, fsjob.path, fsjob.sub, savedir, fsjob.write);
     if (!job->initRpc(fsjob.ip.empty() ? _connected_target : fsjob.ip, UNI_RPC_PORT_TRANS) || !job->initSuccess()) {
@@ -288,6 +319,11 @@ void JobManager::handleJobTransStatus(QString appname, int jobid, int status, QS
 
     QString jsonMsg = req.str().c_str();
     SendIpcService::instance()->handleSendToClient(appname, FRONT_TRANS_STATUS_CB, jsonMsg);
+
+    // 安全验证：作业完成、取消或失败时，清理确认状态
+    if (status == JOB_TRANS_FINISHED || status == JOB_TRANS_CANCELED || status == JOB_TRANS_FAILED) {
+        removeConfirmedTransfer(appname);
+    }
 }
 
 void JobManager::handleRemoveJob(const int jobid)

--- a/src/compat/plugins/daemon/core/service/jobmanager.h
+++ b/src/compat/plugins/daemon/core/service/jobmanager.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,7 @@
 
 #include <QObject>
 #include <QMap>
+#include <QSet>
 #include <QSharedPointer>
 #include <QReadWriteLock>
 
@@ -20,6 +21,11 @@ class JobManager : public QObject
 public:
     static JobManager *instance();
     ~JobManager();
+
+    // 安全验证：记录用户已确认接收文件的appName
+    void confirmTransfer(const QString &appName);
+    void removeConfirmedTransfer(const QString &appName);
+    bool isTransferConfirmed(const QString &appName);
 
 public slots:
     bool handleRemoteRequestJob(QString json, QString *targetAppName);
@@ -42,6 +48,10 @@ private:
     QMap<int, QSharedPointer<TransferJob>> _transjob_break;
     fastring _connected_target;
     QReadWriteLock g_m;
+
+    // 安全验证：存储用户已确认接收文件的appName集合
+    QSet<QString> _confirmed_transfers;
+    QReadWriteLock _confirm_mutex;
 };
 
 #endif // JOBMANAGER_H

--- a/src/compat/plugins/daemon/core/service/rpc/sendrpcservice.cpp
+++ b/src/compat/plugins/daemon/core/service/rpc/sendrpcservice.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -63,6 +63,13 @@ void SendRpcWork::handleDoSendProtoMsg(const uint32 type, const QString appName,
                 QString tar = sender->targetAppname();
                 info.tarAppname = tar.isEmpty() ?
                                   appName.toStdString() : tar.toStdString();
+
+                // 安全验证：用户确认/拒绝接收文件时，更新确认状态
+                if (info.type == APPLY_TRANS_CONFIRM) {
+                    JobManager::instance()->confirmTransfer(appName);
+                } else if (info.type == APPLY_TRANS_REFUSED) {
+                    JobManager::instance()->removeConfirmedTransfer(appName);
+                }
             }
             res = sender->doSendProtoMsg(type, info.as_json().str().c_str(), data);
         } else if (type == APPLY_SHARE_CONNECT_RES) {

--- a/src/compat/plugins/daemon/core/utils/config.h
+++ b/src/compat/plugins/daemon/core/utils/config.h
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -165,7 +165,8 @@ public:
     {
         fastring home = os::homedir();
         if (_targetName.empty()) {
-            _storageDir = home;
+            // 默认使用下载目录
+            _storageDir = path::join(home, "Downloads");
         } else {
             _storageDir = path::join(home, _targetName);
         }
@@ -177,7 +178,8 @@ public:
         fastring home;
         home = getAppConfig(appName, "storagedir");
         if (home.empty())
-            home = getStorageDir();
+            // 默认使用下载目录
+            home = path::join(os::homedir(), "Downloads");
 
         return home;
     }


### PR DESCRIPTION
upstream/master ships a syntactic isPathWithinDir() guard using std::filesystem::lexically_normal(). It only catches ./.. sequences and is blind to symlinks and the client-supplied rootdir in 1004 FS_DATA blocks.

V20 (release/v20, commit 9978c02c) closed the gaps with three layers. Re-port here, layered on top of the upstream fix:

1. getSaveFullpath(): reject empty/.. filenames, validate via realpath() against the configured storage dir (catches symlinks the upstream syntactic check misses).
2. writeAndCreateFile(): refuse empty fullpath for non-metadata blocks as defense in depth.
3. JobManager user-confirmation gate: handleRemoteRequestJob() now requires isTransferConfirmed() before write jobs. Confirmation state is set only by the GUI's APPLY_TRANS_CONFIRM message.
4. config.h: tighten default storage dir from ~ to ~/Downloads.

修复上游仅词法层面的路径检查，叠加 realpath() 符号链接防护与用户确认门控。
添加 realpath 验证和用户确认门控，阻断未授权文件写入。

Log: 修复路径穿越和未授权文件写入漏洞
PMS: 368181
Influence: RPC 文件传输需用户确认，路径穿越被拦截，默认存储目录收紧至 Downloads。