### PR TITLE
fix(ui): apply theme-aware style for port label and input on connect …

### DIFF
--- a/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
+++ b/src/lib/data-transfer/core/gui/connect/connectwidget.cpp
@@ -126,7 +126,7 @@ void ConnectWidget::initConnectLayout()
     StyleHelper::setAutoFont(ipLabel1, 12, QFont::Normal);
 
     // 端口（可见输入框，可直接编辑）
-    QLabel *portLabel = new QLabel(tr("Port") + ":", this);
+    portLabel = new QLabel(tr("Port") + ":", this);
     StyleHelper::setAutoFont(portLabel, 12, QFont::Normal);
 
     portInput = new QLineEdit(QString::number(m_savedPort), this);
@@ -339,12 +339,23 @@ void ConnectWidget::themeChanged(int theme)
         separatorLabel->setStyleSheet("QLabel { background-color: rgba(0, 0, 0, 0.1); width: 2px; }");
         ipLabel->setStyleSheet(" ");
         ipLabel1->setStyleSheet(" ");
+        portLabel->setStyleSheet(" ");
+        portInput->setStyleSheet("background-color: white;"
+                                 "border: 1px solid #d8d7d7;"
+                                 "border-radius: 8px;"
+                                 "padding: 2px 8px;");
     } else {
         DLOG << "Theme is dark, setting stylesheet";
         setStyleSheet(".ConnectWidget{background-color: rgba(37, 37, 37,1); border-radius: 10px;}");
         separatorLabel->setStyleSheet("background-color: rgba(220, 220, 220,0.1); width: 2px;");
         ipLabel->setStyleSheet("color: rgb(192, 192, 192);");
         ipLabel1->setStyleSheet("color: rgb(192, 192, 192);");
+        portLabel->setStyleSheet("color: rgb(192, 192, 192);");
+        portInput->setStyleSheet("background-color: rgb(45, 45, 45);"
+                                 "border: 1px solid rgba(220, 220, 220, 0.2);"
+                                 "border-radius: 8px;"
+                                 "padding: 2px 8px;"
+                                 "color: rgb(192, 192, 192);");
     }
 }
 

--- a/src/lib/data-transfer/core/gui/connect/connectwidget.h
+++ b/src/lib/data-transfer/core/gui/connect/connectwidget.h
@@ -35,6 +35,7 @@ private:
 private:
     QLabel *ipLabel = nullptr;
     QLabel *ipLabel1 = nullptr;
+    QLabel *portLabel = nullptr;
     QLabel *WarnningLabel = nullptr;
     QHBoxLayout *connectLayout = nullptr;
     int remainingTime = 300;


### PR DESCRIPTION
…page

- Promote portLabel from local variable to member in ConnectWidget so it can be restyled on theme switch
- Add light-theme style for portLabel and portInput (white background, rounded gray border) in ConnectWidget::themeChanged()
- Add dark-theme style for portLabel (light gray text) and portInput (dark background, translucent border) in ConnectWidget::themeChanged()

修复(ui): 为连接页端口标签和输入框补充主题适配样式

- 将 ConnectWidget 中的 portLabel 由局部变量提升为成员变量，以便主题切换时重新设置样式
- 在 ConnectWidget::themeChanged() 中为浅色主题的端口标签和输入框补充样式（白色背景、灰色圆角边框）
- 在 ConnectWidget::themeChanged() 中为深色主题的端口标签（浅灰文字）和输入框（深色背景、半透明边框）补充样式

Log: 修复连接页端口输入框和标签在浅色/深色主题切换下缺少样式适配的问题，与 IP 标签的处理保持一致
Bug: https://pms.uniontech.com/bug-view-368811.html