### PR TITLE
test(coop): 搭建 lib/cooperation 单元测试框架并覆盖核心/GUI 模块

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,4 +2,5 @@
 # 参考 deepin-system-monitor: 集中在根 tests/ 下, 子目录按 target 隔离。
 add_subdirectory(logic)
 add_subdirectory(coop)
+add_subdirectory(coop_gui)
 add_subdirectory(compat)

--- a/tests/coop/CMakeLists.txt
+++ b/tests/coop/CMakeLists.txt
@@ -40,16 +40,24 @@ file(GLOB COOP_SRC
     "${CD}/gui/*.h" "${CD}/gui/*_p.h" "${CD}/gui/*/*.h" "${CD}/*_p.h")
 
 find_package(GTest REQUIRED)
-find_package(Qt6 COMPONENTS Core Widgets Gui Network Concurrent DBus REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets Gui Network Concurrent DBus Test REQUIRED)
 find_package(Dtk6 COMPONENTS Core Gui Widget REQUIRED)
 find_library(QRENCODE_LIBRARY qrencode)
 find_library(VNCCLIENT_LIBRARY vncclient)
 
 set(CMAKE_AUTOMOC ON)
 add_executable(coop_tests ${COOP_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/discover_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/helper_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/coop_searchedit_stub.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/coop_searchedit_stub.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cooconfig_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/historymanager_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cooperationutil_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sharehelper_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/transferhelper_core_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/compatwrapper_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/transferwrapper_test.cpp)
 target_compile_options(coop_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_tests PRIVATE
@@ -58,8 +66,8 @@ target_include_directories(coop_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/3rdparty/QtZeroConf
     ${CD}/gui/win)
 target_link_libraries(coop_tests PRIVATE
-    GTest::GTest GTest::Main
-    Qt6::Core Qt6::Widgets Qt6::Gui Qt6::Network Qt6::Concurrent Qt6::DBus
+    GTest::GTest
+    Qt6::Core Qt6::Widgets Qt6::Gui Qt6::Network Qt6::Concurrent Qt6::DBus Qt6::Test
     Dtk6::Core Dtk6::Gui Dtk6::Widget
     QtZeroConf slotipc
     logging sessionmanager sslconf basekit fmt proto httpweb session)

--- a/tests/coop/compatwrapper_test.cpp
+++ b/tests/coop/compatwrapper_test.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QString>
+#include "lib/cooperation/core/net/compatwrapper.h"
+
+using cooperation_core::CompatWrapper;
+
+// 单例身份:两次 instance() 返回同一指针。
+TEST(CompatWrapperTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(CompatWrapper::instance(), CompatWrapper::instance());
+}
+
+// session() 返回 d->sessionId;daemon 未连接时该字段保持空字符串。
+// 构造函数启动的 IPC 定时器连接不到 daemon,不会写入 sessionId。
+TEST(CompatWrapperTest, SessionIsEmptyBeforeBackendConnect)
+{
+    EXPECT_EQ(CompatWrapper::instance()->session().toStdString(), "");
+}
+
+// ipcInterface() 在构造时已由 CompatWrapperPrivate 创建,永不返回 nullptr。
+TEST(CompatWrapperTest, IpcInterfaceReturnsNonNull)
+{
+    EXPECT_NE(CompatWrapper::instance()->ipcInterface(), nullptr);
+}
+
+// 多次调用 ipcInterface() 返回同一对象(构造时创建,非延迟分配)。
+TEST(CompatWrapperTest, IpcInterfaceReturnsSamePointer)
+{
+    auto *a = CompatWrapper::instance()->ipcInterface();
+    auto *b = CompatWrapper::instance()->ipcInterface();
+    EXPECT_EQ(a, b);
+}

--- a/tests/coop/cooconfig_test.cpp
+++ b/tests/coop/cooconfig_test.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QHostInfo>
+#include <QSettings>
+#include <QString>
+#include <QTemporaryDir>
+
+#include "lib/cooperation/core/share/cooconfig.h"
+
+class CooConfigTest : public ::testing::Test {
+protected:
+    QTemporaryDir tmpDir;
+    QString iniPath;
+    CooConfig *cfg = nullptr;
+    QSettings *settings = nullptr;
+
+    void SetUp() override
+    {
+        iniPath = tmpDir.path() + "/test.ini";
+        settings = new QSettings(iniPath, QSettings::IniFormat);
+        cfg = new CooConfig(settings);
+    }
+
+    void TearDown() override
+    {
+        // CooConfig destructor does NOT delete m_pSettings (only calls
+        // saveSettings()), so we own and delete the QSettings here.
+        delete cfg;
+        cfg = nullptr;
+        delete settings;
+        settings = nullptr;
+    }
+};
+
+TEST_F(CooConfigTest, DefaultPortIsStandardSharePort)
+{
+    // loadSettings() defaults port to UNI_SHARE_SERVER_PORT (24802) when the
+    // settings file has no "port" key.
+    EXPECT_EQ(cfg->port(), 24802);
+}
+
+TEST_F(CooConfigTest, DefaultCryptoEnabledIsTrue)
+{
+    // loadSettings() defaults cryptoEnabled to true.
+    EXPECT_TRUE(cfg->getCryptoEnabled());
+}
+
+TEST_F(CooConfigTest, DefaultScreenNameIsLocalHostName)
+{
+    // loadSettings() defaults screenName to QHostInfo::localHostName().
+    EXPECT_EQ(cfg->screenName().toStdString(),
+              QHostInfo::localHostName().toStdString());
+}
+
+TEST_F(CooConfigTest, SetPortAndGetReturnsValue)
+{
+    cfg->setPort(24800);
+    cfg->saveSettings();
+    EXPECT_EQ(cfg->port(), 24800);
+}
+
+TEST_F(CooConfigTest, SetServerIpAndGetReturnsValue)
+{
+    cfg->setServerIp("192.168.1.100");
+    cfg->saveSettings();
+    EXPECT_EQ(cfg->serverIp().toStdString(), "192.168.1.100");
+}
+
+TEST_F(CooConfigTest, SetScreenNameAndGetReturnsValue)
+{
+    cfg->setScreenName("MyScreen");
+    cfg->saveSettings();
+    EXPECT_EQ(cfg->screenName().toStdString(), "MyScreen");
+}
+
+TEST_F(CooConfigTest, CryptoEnabledRoundTrip)
+{
+    cfg->setCryptoEnabled(false);
+    cfg->saveSettings();
+    EXPECT_FALSE(cfg->getCryptoEnabled());
+    cfg->setCryptoEnabled(true);
+    cfg->saveSettings();
+    EXPECT_TRUE(cfg->getCryptoEnabled());
+}
+
+TEST_F(CooConfigTest, ProfileDirRoundTrip)
+{
+    cfg->setProfileDir("/tmp/test-profile");
+    EXPECT_EQ(cfg->profileDir().toStdString(), "/tmp/test-profile");
+}
+
+TEST_F(CooConfigTest, SettingsPersistAcrossInstances)
+{
+    // Write values through one CooConfig instance, then create a new instance
+    // pointing at the same QSettings file and confirm the values survive.
+    cfg->setPort(12345);
+    cfg->setServerIp("10.0.0.5");
+    cfg->setScreenName("Persisted");
+    cfg->setCryptoEnabled(false);
+    cfg->saveSettings();
+    settings->sync();
+
+    CooConfig cfg2(settings);
+    EXPECT_EQ(cfg2.port(), 12345);
+    EXPECT_EQ(cfg2.serverIp().toStdString(), "10.0.0.5");
+    EXPECT_EQ(cfg2.screenName().toStdString(), "Persisted");
+    EXPECT_FALSE(cfg2.getCryptoEnabled());
+}

--- a/tests/coop/cooperationutil_test.cpp
+++ b/tests/coop/cooperationutil_test.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Unit tests for CooperationUtil (cooperation_core::CooperationUtil).
+//
+// CooperationUtil is a process-wide singleton QObject. Its instance() does not
+// dereference qApp directly, but several related facilities (ConfigManager,
+// deviceInfo()) rely on QCoreApplication being available. The QtAppEnvironment
+// registered in historymanager_test.cpp runs SetUp() before any test, so a
+// QCoreApplication already exists when these tests run — we deliberately do
+// NOT register a second one (that would create two QApp instances and crash).
+//
+// setStorageConfig emits the storageConfig(QString) signal synchronously
+// (direct emit, no queueing), so QSignalSpy::count() is read immediately.
+//
+// closeOption() reads ConfigManager::appAttribute(CacheGroup, CloseOptionKey)
+// which may be empty when no value has been persisted; we only assert no-crash.
+// localIPAddress() returns the first non-loopback IPv4 found via
+// deepin_cross::CommonUitls::getFirstIp(), which may be empty on hosts without
+// a usable network interface; we only assert no-crash.
+
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+#include <QString>
+#include <QVariantMap>
+
+#include "lib/cooperation/core/utils/cooperationutil.h"
+
+using cooperation_core::CooperationUtil;
+
+TEST(CooperationUtilTest, InstanceReturnsNonNullSingleton)
+{
+    EXPECT_NE(CooperationUtil::instance(), nullptr);
+}
+
+TEST(CooperationUtilTest, InstanceReturnsSamePointer)
+{
+    auto *a = CooperationUtil::instance();
+    auto *b = CooperationUtil::instance();
+    EXPECT_EQ(a, b);
+}
+
+TEST(CooperationUtilTest, LocalIPAddressReturnsQStringNoCrash)
+{
+    // 静态方法; 返回值可能为空(无网卡)或 IP 字符串, 只验证不崩
+    EXPECT_NO_FATAL_FAILURE(CooperationUtil::localIPAddress());
+    QString ip = CooperationUtil::localIPAddress();
+    (void)ip;  // 避免未使用变量告警
+    SUCCEED();
+}
+
+TEST(CooperationUtilTest, CloseOptionReturnsQStringNoCrash)
+{
+    // closeOption() 读取 ConfigManager 缓存项, 可能为空(未持久化), 只验证不崩
+    EXPECT_NO_FATAL_FAILURE(CooperationUtil::closeOption());
+    QString opt = CooperationUtil::closeOption();
+    (void)opt;
+    SUCCEED();
+}
+
+TEST(CooperationUtilTest, SaveOptionDoesNotCrash)
+{
+    // saveOption 写入 ConfigManager, 不直接返回值; 只验证不崩
+    EXPECT_NO_FATAL_FAILURE(CooperationUtil::saveOption(true));
+    EXPECT_NO_FATAL_FAILURE(CooperationUtil::saveOption(false));
+}
+
+TEST(CooperationUtilTest, SetStorageConfigEmitsSignalSynchronously)
+{
+    auto *util = CooperationUtil::instance();
+    ASSERT_NE(util, nullptr);
+    QSignalSpy spy(util, &CooperationUtil::storageConfig);
+    ASSERT_TRUE(spy.isValid());
+    const QString payload = "/tmp/coop-util-test-storage-9";
+    util->setStorageConfig(payload);
+    // 同步 emit, 直接读取 count()
+    EXPECT_GE(spy.count(), 1);
+    if (spy.count() > 0) {
+        const auto args = spy.takeFirst();
+        ASSERT_EQ(args.size(), 1);
+        EXPECT_EQ(args.at(0).toString().toStdString(), payload.toStdString());
+    }
+}

--- a/tests/coop/historymanager_test.cpp
+++ b/tests/coop/historymanager_test.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Unit tests for HistoryManager (cooperation_core::HistoryManager).
+//
+// HistoryManager is a process-wide singleton QObject backed by ConfigManager
+// (which itself uses a fixed JSON config path derived from qApp's organization
+// / application name). Because it is a singleton, state leaks across tests:
+// later tests may observe entries written by earlier tests, and pre-existing
+// on-disk entries may show up as well. We therefore avoid exact-count
+// assertions and prefer tolerant checks (EXPECT_GE / non-crash).
+//
+// Signal flow is fully synchronous in the same thread:
+//   writeInto*History() -> ConfigManager::setAppAttribute()
+//                         -> Settings::setValue() -> Q_EMIT valueChanged(...)
+//                         -> ConfigManager::appAttributeChanged
+//                         -> HistoryManager::onAttributeChanged
+//                         -> Q_EMIT transHistoryUpdated()/connectHistoryUpdated()
+// so QSignalSpy::count() can be read immediately after the call. Using
+// QSignalSpy::wait() here would MISS the signal because it is emitted BEFORE
+// wait() starts the event loop, and wait() then blocks for the full timeout
+// waiting for a second emission that never arrives.
+//
+// HistoryManager::getTransHistory() dereferences qApp->property("onlyTransfer")
+// which requires a QCoreApplication to exist. gtest_main does not create one,
+// so we install a global testing Environment that constructs a QCoreApplication
+// once before any test runs.
+//
+// Note: writeIntoConnectHistory/writeIntoTransHistory skip the update (and the
+// signal) when an identical (ip, value) pair is already present. To guarantee
+// a signal we therefore write a value that differs from any prior run by
+// appending a monotonic suffix.
+
+#include <gtest/gtest.h>
+
+#include <QDateTime>
+#include <QMap>
+#include <QObject>
+#include <QSignalSpy>
+#include <QString>
+
+#include "lib/cooperation/core/utils/historymanager.h"
+
+using cooperation_core::HistoryManager;
+
+class HistoryManagerTest : public ::testing::Test {
+protected:
+    HistoryManager *mgr = nullptr;
+
+    static QString uniqueSuffix() {
+        // Per-process monotonic counter combined with a timestamp so the value
+        // is unique across runs (the config file persists between invocations,
+        // and a duplicate (ip, value) pair would cause writeInto* to skip the
+        // update and emit no signal).
+        static int c = 0;
+        return QString::number(QDateTime::currentMSecsSinceEpoch()) + "-" + QString::number(++c);
+    }
+
+    void SetUp() override {
+        mgr = HistoryManager::instance();
+        ASSERT_NE(mgr, nullptr);
+    }
+};
+
+TEST_F(HistoryManagerTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(HistoryManager::instance(), mgr);
+}
+
+TEST_F(HistoryManagerTest, GetConnectHistoryReturnsMap)
+{
+    // getConnectHistory() should at minimum not crash; it returns a map
+    // (possibly empty if no prior history).
+    QMap<QString, QString> hist = mgr->getConnectHistory();
+    EXPECT_GE(hist.size(), 0);
+}
+
+TEST_F(HistoryManagerTest, GetTransHistoryReturnsMap)
+{
+    // getTransHistory() dereferences qApp->property("onlyTransfer"); with the
+    // QCoreApplication installed above it returns a (possibly empty) map.
+    QMap<QString, QString> hist = mgr->getTransHistory();
+    EXPECT_GE(hist.size(), 0);
+}
+
+TEST_F(HistoryManagerTest, WriteIntoConnectHistoryEmitsSignal)
+{
+    QSignalSpy spy(mgr, &HistoryManager::connectHistoryUpdated);
+    ASSERT_TRUE(spy.isValid());
+    // Use a counter-suffixed device name so the entry differs from any prior
+    // run; otherwise writeIntoConnectHistory would skip the (no-change) update
+    // and emit nothing.
+    const QString ip = QString("10.0.0.1");
+    const QString dev = "DevA-" + uniqueSuffix();
+    mgr->writeIntoConnectHistory(ip, dev);
+    // Synchronous emission — read count() immediately (see file header).
+    EXPECT_GE(spy.count(), 1);
+}
+
+TEST_F(HistoryManagerTest, WriteIntoTransHistoryEmitsSignal)
+{
+    QSignalSpy spy(mgr, &HistoryManager::transHistoryUpdated);
+    ASSERT_TRUE(spy.isValid());
+    const QString ip = QString("10.0.0.3");
+    const QString savePath = "/tmp/save-" + uniqueSuffix();
+    mgr->writeIntoTransHistory(ip, savePath);
+    EXPECT_GE(spy.count(), 1);
+}
+
+TEST_F(HistoryManagerTest, WriteIntoConnectHistoryPersistsAndReadback)
+{
+    // Use a unique IP + counter-suffixed name to force a real write and then
+    // read it back through the config.
+    const QString ip = QString("10.0.0.42");
+    const QString dev = "DevPersist-" + uniqueSuffix();
+    mgr->writeIntoConnectHistory(ip, dev);
+    QMap<QString, QString> hist = mgr->getConnectHistory();
+    EXPECT_TRUE(hist.contains(ip));
+    EXPECT_EQ(hist.value(ip).toStdString(), dev.toStdString());
+}
+
+TEST_F(HistoryManagerTest, RemoveTransHistoryDoesNotCrash)
+{
+    // Insert then remove; removal of a missing key is also a valid no-op.
+    mgr->writeIntoTransHistory("10.0.0.4", "/tmp/x-" + uniqueSuffix());
+    EXPECT_NO_FATAL_FAILURE(mgr->removeTransHistory("10.0.0.4"));
+    // Removing again (now absent) must also be safe.
+    EXPECT_NO_FATAL_FAILURE(mgr->removeTransHistory("10.0.0.4"));
+}
+
+TEST_F(HistoryManagerTest, RemoveTransHistoryEmitsNoSignalForMissingKey)
+{
+    // removeTransHistory only writes back when an entry was actually removed;
+    // for a key that was never present it returns early without touching the
+    // config, so no transHistoryUpdated signal should fire.
+    QSignalSpy spy(mgr, &HistoryManager::transHistoryUpdated);
+    ASSERT_TRUE(spy.isValid());
+    const QString absent = "203.0.113.254";
+    // Ensure the key really is absent first.
+    mgr->removeTransHistory(absent);
+    spy.clear();
+    mgr->removeTransHistory(absent);
+    EXPECT_EQ(spy.count(), 0);
+}

--- a/tests/coop/main.cpp
+++ b/tests/coop/main.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Custom main for coop_tests.
+//
+// Why a custom main (instead of linking GTest::Main):
+//  - Several cooperation-core singletons (ShareHelper::instance() in particular)
+//    lazily create QWidget subclasses (CooperationTaskDialog), which requires a
+//    QApplication — not just QCoreApplication. gtest_main does not create one.
+//  - A QCoreApplication used to be installed via a global testing Environment,
+//    but QApplication is a QWidget-capable superset and works for every test.
+//  - At process exit a static ConfigManager destructor races against Qt
+//    teardown and calls free() on an already-freed pointer, aborting with
+//    SIGABRT (exit 134). The abort skips __gcov_dump()'s atexit handler, so
+//    no .gcda coverage files are written and lcov reports zero coverage for
+//    coop_tests. A custom main that explicitly calls __gcov_dump()/__gcov_flush()
+//    before returning — and returns normally instead of letting the abort
+//    happen — produces .gcda files.
+//
+// __gcov_dump() (gcc 11+) flushes all coverage counters; on older toolchains
+// __gcov_flush() is the equivalent. We declare them as extern "C" weak so the
+// binary still links if the toolchain lacks one of them.
+
+#include <QApplication>
+#include <gtest/gtest.h>
+
+extern "C" void __gcov_dump() __attribute__((weak));
+extern "C" void __gcov_flush() __attribute__((weak));
+
+static void flushCoverage()
+{
+    if (__gcov_dump) {
+        __gcov_dump();
+    } else if (__gcov_flush) {
+        __gcov_flush();
+    }
+}
+
+int main(int argc, char **argv)
+{
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication app(argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    // Flush coverage counters *before* static destructors run (the
+    // ConfigManager/QApplication teardown races cause the exit-134 abort that
+    // would otherwise skip gcov finalization).
+    flushCoverage();
+    return result;
+}

--- a/tests/coop/sharehelper_test.cpp
+++ b/tests/coop/sharehelper_test.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Unit tests for ShareHelper (cooperation_core::ShareHelper).
+//
+// ShareHelper is a process-wide singleton QObject backed by a state machine
+// that drives DBus notifications, network apply/disconnect and a barrier
+// server/client. Most slots touch NetworkUtil / ShareCooperationServiceManager
+// / DiscoverController, which would block or spawn processes. We therefore
+// restrict ourselves to the non-blocking surface: static button callbacks,
+// early-return branches of the state-machine slots (no target device / not
+// connected / unknown ids), selfSharing for unknown IPs, and
+// switchPeripheralShared when the client is null.
+//
+// QApplication is provided by main.cpp (custom main with __gcov_dump flush).
+
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+#include <QString>
+
+#include "lib/cooperation/core/net/helper/sharehelper.h"
+#include "lib/cooperation/core/discover/deviceinfo.h"
+
+using cooperation_core::DeviceInfo;
+using cooperation_core::ShareHelper;
+using ::DeviceInfoPointer;
+
+class ShareHelperTest : public ::testing::Test {
+protected:
+    ShareHelper *helper = nullptr;
+    void SetUp() override { helper = ShareHelper::instance(); }
+};
+
+TEST_F(ShareHelperTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(ShareHelper::instance(), helper);
+}
+
+TEST_F(ShareHelperTest, SelfSharingReturnsNegOneForUnknownIp)
+{
+    // Non-local IP never matches CooperationUtil::localIPAddress() → -1.
+    EXPECT_EQ(helper->selfSharing("0.0.0.0"), -1);
+}
+
+TEST_F(ShareHelperTest, ButtonVisibleReturnsFalseForUnknownId)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.1", "Dev"));
+    EXPECT_FALSE(ShareHelper::buttonVisible("unknown_id", info));
+}
+
+TEST_F(ShareHelperTest, ButtonVisibleConnectFalseWhenNotConnectable)
+{
+    // Default-constructed DeviceInfo is not Connectable, so connect button hidden.
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.2", "Dev2"));
+    EXPECT_FALSE(ShareHelper::buttonVisible("connect-button", info));
+}
+
+TEST_F(ShareHelperTest, ButtonVisibleDisconnectFalseWhenNotConnected)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.3", "Dev3"));
+    EXPECT_FALSE(ShareHelper::buttonVisible("disconnect-button", info));
+}
+
+TEST_F(ShareHelperTest, ButtonVisibleConnectTrueWhenConnectable)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.4", "Dev4"));
+    info->setConnectStatus(DeviceInfo::ConnectStatus::Connectable);
+    EXPECT_TRUE(ShareHelper::buttonVisible("connect-button", info));
+}
+
+TEST_F(ShareHelperTest, ButtonVisibleDisconnectTrueWhenConnected)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.5", "Dev5"));
+    info->setConnectStatus(DeviceInfo::ConnectStatus::Connected);
+    EXPECT_TRUE(ShareHelper::buttonVisible("disconnect-button", info));
+}
+
+TEST_F(ShareHelperTest, ButtonClickedWithUnknownIdDoesNotCrash)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.6", "Dev6"));
+    EXPECT_NO_FATAL_FAILURE(ShareHelper::buttonClicked("unknown_id", info));
+}
+
+TEST_F(ShareHelperTest, HandleConnectResultIgnoredWithoutTarget)
+{
+    // No target device set → early return (line 438-441).
+    EXPECT_NO_FATAL_FAILURE(helper->handleConnectResult(-1, ""));
+}
+
+TEST_F(ShareHelperTest, HandleConnectResultWithUnknownCodeDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->handleConnectResult(9999, ""));
+}
+
+TEST_F(ShareHelperTest, HandleDisConnectResultEarlyReturnWithoutTarget)
+{
+    // No target device → early return (line 538-541).
+    EXPECT_NO_FATAL_FAILURE(helper->handleDisConnectResult("10.0.0.7"));
+}
+
+TEST_F(ShareHelperTest, HandleCancelCooperApplyDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->handleCancelCooperApply());
+}
+
+TEST_F(ShareHelperTest, HandleNetworkDismissWithGenericErrorDoesNotCrash)
+{
+    // Message without errorType -1 → generic notify branch.
+    EXPECT_NO_FATAL_FAILURE(helper->handleNetworkDismiss("some error"));
+}
+
+TEST_F(ShareHelperTest, HandleNetworkDismissWithErrorTypeMinusOneDoesNotCrash)
+{
+    // Message with errorType -1 and dialog not visible → early return.
+    EXPECT_NO_FATAL_FAILURE(helper->handleNetworkDismiss("\"errorType\":-1"));
+}
+
+TEST_F(ShareHelperTest, OnShareExceptedIgnoredWhenNotConnected)
+{
+    // No target device → early return (line 633-636).
+    EXPECT_NO_FATAL_FAILURE(helper->onShareExcepted(1, "10.0.0.8"));
+}
+
+TEST_F(ShareHelperTest, OnVerifyTimeoutDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->onVerifyTimeout());
+}
+
+TEST_F(ShareHelperTest, SwitchPeripheralSharedReturnsFalseWhenClientNull)
+{
+    // Client is not started in test env → isNull() true → return false.
+    EXPECT_FALSE(helper->switchPeripheralShared(true));
+}

--- a/tests/coop/transferhelper_core_test.cpp
+++ b/tests/coop/transferhelper_core_test.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include "lib/cooperation/core/net/helper/transferhelper.h"
+#include "lib/cooperation/core/discover/deviceinfo.h"
+
+using cooperation_core::DeviceInfo;
+using cooperation_core::TransferHelper;
+using ::DeviceInfoPointer;
+
+class TransferHelperCoreTest : public ::testing::Test {
+protected:
+    TransferHelper *helper = nullptr;
+    void SetUp() override { helper = TransferHelper::instance(); }
+};
+
+TEST_F(TransferHelperCoreTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(TransferHelper::instance(), helper);
+}
+
+TEST_F(TransferHelperCoreTest, InitialTransferStatusIsIdle)
+{
+    EXPECT_EQ(helper->transferStatus(), TransferHelper::Idle);
+}
+
+TEST_F(TransferHelperCoreTest, ButtonVisibleReturnsBoolForUnknownId)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.1", "Dev"));
+    bool v = TransferHelper::buttonVisible("unknown", info);
+    (void)v;
+    SUCCEED();
+}
+
+TEST_F(TransferHelperCoreTest, ButtonClickableReturnsBoolForUnknownId)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.2", "Dev2"));
+    bool c = TransferHelper::buttonClickable("unknown", info);
+    (void)c;
+    SUCCEED();
+}
+
+TEST_F(TransferHelperCoreTest, ButtonClickedWithUnknownIdDoesNotCrash)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.3", "Dev3"));
+    EXPECT_NO_FATAL_FAILURE(TransferHelper::buttonClicked("unknown", info));
+}
+
+TEST_F(TransferHelperCoreTest, CancelTransferApplyDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->cancelTransferApply());
+}
+
+TEST_F(TransferHelperCoreTest, HandleCancelTransferApplyDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->handleCancelTransferApply());
+}
+
+TEST_F(TransferHelperCoreTest, CloseAllNotificationsDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->closeAllNotifications());
+}
+
+TEST_F(TransferHelperCoreTest, OnVerifyTimeoutDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->onVerifyTimeout());
+}
+
+TEST_F(TransferHelperCoreTest, OpenFileLocationWithInvalidPathDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->openFileLocation("/nonexistent/path"));
+}
+
+TEST_F(TransferHelperCoreTest, OnActionTriggeredWithUnknownActionDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->onActionTriggered("unknown_action"));
+}
+
+TEST_F(TransferHelperCoreTest, AcceptedDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->accepted());
+}
+
+TEST_F(TransferHelperCoreTest, RejectedDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->rejected());
+}
+
+TEST_F(TransferHelperCoreTest, CancelTransferFalseDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->cancelTransfer(false));
+}
+
+TEST_F(TransferHelperCoreTest, CancelTransferTrueDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->cancelTransfer(true));
+}
+
+TEST_F(TransferHelperCoreTest, OnTransferExceptedWhenIdleDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->onTransferExcepted(1, "10.0.0.9"));
+}
+
+TEST_F(TransferHelperCoreTest, UpdateProgressDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->updateProgress(50, "00:01:00"));
+}
+
+TEST_F(TransferHelperCoreTest, TransferResultFalseDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->transferResult(false, "error"));
+}
+
+TEST_F(TransferHelperCoreTest, CompatFileTransStatusChangedDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->compatFileTransStatusChanged(1000, 500, 200));
+}
+
+TEST_F(TransferHelperCoreTest, CompatTransJobStatusChangedDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->compatTransJobStatusChanged(1, 0, "ok"));
+}
+
+TEST_F(TransferHelperCoreTest, OnTransChangedIdleDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(helper->onTransChanged(0, "/tmp", 100));
+}
+
+TEST_F(TransferHelperCoreTest, DeliverSignalIsEmittable)
+{
+    QSignalSpy spy(helper, &TransferHelper::deliverMessage);
+    helper->transferResult(true, "msg");
+    (void)spy.count();
+    SUCCEED();
+}
+
+TEST_F(TransferHelperCoreTest, OnActionTriggeredViewBranchDoesNotCrash)
+{
+    // "view" matches NotifyViewAction; reads config, no NetworkUtil/DBus call
+    EXPECT_NO_FATAL_FAILURE(helper->onActionTriggered("view"));
+}
+
+TEST_F(TransferHelperCoreTest, OnActionTriggeredCloseBranchDoesNotCrash)
+{
+    // "close" matches NotifyCloseAction; calls notice->closeNotification() on linux
+    EXPECT_NO_FATAL_FAILURE(helper->onActionTriggered("close"));
+}

--- a/tests/coop/transferwrapper_test.cpp
+++ b/tests/coop/transferwrapper_test.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QStringList>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include "lib/cooperation/core/net/transferwrapper.h"
+#include "lib/cooperation/core/discover/deviceinfo.h"
+
+using cooperation_core::TransferWrapper;
+using cooperation_core::DeviceInfo;
+using ::DeviceInfoPointer;
+
+// ============ 单例身份 ============
+
+TEST(TransferWrapperTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(TransferWrapper::instance(), TransferWrapper::instance());
+}
+
+// ============ public slot:DoesNotCrash(委托给控制器,可能触发发现/网络) ============
+// 用 EXPECT_NO_FATAL_FAILURE 包裹,避免后台异常带垮整个测试进程。
+
+TEST(TransferWrapperTest, OnRefreshDeviceDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(TransferWrapper::instance()->onRefreshDevice());
+}
+
+TEST(TransferWrapperTest, OnSearchDeviceWithInvalidIpDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(TransferWrapper::instance()->onSearchDevice("0.0.0.0"));
+}
+
+TEST(TransferWrapperTest, OnSendFilesWithEmptyListDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(
+        TransferWrapper::instance()->onSendFiles("10.0.0.1", "Dev", QStringList{}));
+}
+
+// ============ 私有 slot:onDeviceOnline 三分支(纯信号转发) ============
+// -fno-access-control 允许直接调用 private slot。
+
+// 空 infoList → devList 为空 → 早返回,不发任何信号。
+TEST(TransferWrapperTest, OnDeviceOnlineEmptyListEmitsNothing)
+{
+    QSignalSpy searchedSpy(TransferWrapper::instance(), &TransferWrapper::searched);
+    QSignalSpy refreshedSpy(TransferWrapper::instance(), &TransferWrapper::refreshed);
+    TransferWrapper::instance()->onDeviceOnline(QList<DeviceInfoPointer>{});
+    EXPECT_EQ(searchedSpy.count(), 0);
+    EXPECT_EQ(refreshedSpy.count(), 0);
+}
+
+// 单设备(size<2) → 发 searched,负载是该设备的 JSON 字符串。
+TEST(TransferWrapperTest, OnDeviceOnlineSingleDeviceEmitsSearched)
+{
+    QSignalSpy searchedSpy(TransferWrapper::instance(), &TransferWrapper::searched);
+    QSignalSpy refreshedSpy(TransferWrapper::instance(), &TransferWrapper::refreshed);
+    QList<DeviceInfoPointer> list{ DeviceInfoPointer(new DeviceInfo("10.0.0.1", "DevA")) };
+    TransferWrapper::instance()->onDeviceOnline(list);
+    EXPECT_EQ(searchedSpy.count(), 1);
+    EXPECT_EQ(refreshedSpy.count(), 0);
+    // 负载是 JSON,包含我们设置的 IP。
+    QString payload = searchedSpy.takeFirst().at(0).toString();
+    EXPECT_TRUE(payload.contains("10.0.0.1")) << payload.toStdString();
+}
+
+// 多设备(size>=2) → 发 refreshed,负载是 QStringList。
+TEST(TransferWrapperTest, OnDeviceOnlineMultipleDevicesEmitsRefreshed)
+{
+    QSignalSpy searchedSpy(TransferWrapper::instance(), &TransferWrapper::searched);
+    QSignalSpy refreshedSpy(TransferWrapper::instance(), &TransferWrapper::refreshed);
+    QList<DeviceInfoPointer> list{
+        DeviceInfoPointer(new DeviceInfo("10.0.0.1", "DevA")),
+        DeviceInfoPointer(new DeviceInfo("10.0.0.2", "DevB")),
+    };
+    TransferWrapper::instance()->onDeviceOnline(list);
+    EXPECT_EQ(searchedSpy.count(), 0);
+    EXPECT_EQ(refreshedSpy.count(), 1);
+    QStringList payload = refreshedSpy.takeFirst().at(0).toStringList();
+    EXPECT_EQ(payload.size(), 2);
+}
+
+// ============ 私有 slot:onDeviceOffline / onFinishedDiscovery ============
+
+TEST(TransferWrapperTest, OnDeviceOfflineEmitsDeviceChanged)
+{
+    QSignalSpy spy(TransferWrapper::instance(), &TransferWrapper::deviceChanged);
+    TransferWrapper::instance()->onDeviceOffline("10.0.0.9");
+    EXPECT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_FALSE(args.at(0).toBool());          // found = false
+    EXPECT_EQ(args.at(1).toString().toStdString(), "10.0.0.9");
+}
+
+// hasFound=false → 发空 searched("")。
+TEST(TransferWrapperTest, OnFinishedDiscoveryFalseEmitsEmptySearched)
+{
+    QSignalSpy spy(TransferWrapper::instance(), &TransferWrapper::searched);
+    TransferWrapper::instance()->onFinishedDiscovery(false);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString().toStdString(), "");
+}
+
+// hasFound=true → 不发 searched(无操作分支)。
+TEST(TransferWrapperTest, OnFinishedDiscoveryTrueEmitsNothing)
+{
+    QSignalSpy spy(TransferWrapper::instance(), &TransferWrapper::searched);
+    TransferWrapper::instance()->onFinishedDiscovery(true);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// ============ 私有方法:variantMapToQString ============
+
+TEST(TransferWrapperTest, VariantMapToQStringProducesValidJson)
+{
+    QVariantMap map;
+    map.insert("ip", "10.0.0.1");
+    map.insert("name", "DevA");
+    QString json = TransferWrapper::instance()->variantMapToQString(map);
+    ASSERT_FALSE(json.isEmpty());
+    QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_EQ(obj.value("ip").toString().toStdString(), "10.0.0.1");
+    EXPECT_EQ(obj.value("name").toString().toStdString(), "DevA");
+}
+
+TEST(TransferWrapperTest, VariantMapToQStringEmptyMapProducesEmptyJson)
+{
+    QString json = TransferWrapper::instance()->variantMapToQString(QVariantMap{});
+    QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_TRUE(obj.isEmpty());
+}

--- a/tests/coop_gui/CMakeLists.txt
+++ b/tests/coop_gui/CMakeLists.txt
@@ -1,0 +1,70 @@
+# cooperation GUI 单元测试 (深黑盒: QTest + QSignalSpy + stub.h + addr_pri.h)
+set(CD ${CMAKE_SOURCE_DIR}/src/lib/cooperation/core)
+
+# === glob cooperation-core GUI 源码 (复用 tests/coop 的依赖集) ===
+file(GLOB COOP_GUI_SRC
+    "${CMAKE_SOURCE_DIR}/src/base/baseutils.cpp"
+    "${CMAKE_SOURCE_DIR}/src/singleton/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/configs/settings/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/common/logger.cpp"
+    "${CMAKE_SOURCE_DIR}/src/common/commonutils.cpp"
+    "${CD}/cooperationcoreplugin.cpp"
+    "${CD}/gui/*.cpp"
+    "${CD}/gui/dialogs/*.cpp"
+    "${CD}/gui/widgets/*.cpp"
+    "${CD}/gui/utils/*.cpp"
+    "${CD}/gui/phone/*.cpp"
+    "${CD}/transfer/*.cpp"
+    "${CD}/utils/*.cpp"
+    "${CD}/discover/*.cpp"
+    "${CD}/share/*.cpp"
+    "${CD}/net/networkutil*.cpp"
+    "${CD}/net/helper/*.cpp"
+    "${CD}/net/helper/dialogs/*.cpp"
+    "${CD}/net/compatwrapper*.cpp"
+    "${CD}/net/transferwrapper*.cpp"
+    "${CD}/net/linux/*.cpp"
+    "${CD}/gui/linux/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/base/reportlog/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/base/reportlog/*/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/configs/dconfig/*.cpp"
+    "${CD}/*.h" "${CD}/*_p.h" "${CD}/gui/*.h" "${CD}/gui/*/*.h"
+    "${CD}/discover/*.h" "${CD}/net/*.h" "${CD}/net/*_p.h" "${CD}/net/helper/*_p.h")
+
+find_package(GTest REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets Gui Network Concurrent Test DBus REQUIRED)
+find_package(Dtk6 COMPONENTS Core Gui Widget REQUIRED)
+find_library(QRENCODE_LIBRARY qrencode)
+find_library(VNCCLIENT_LIBRARY vncclient)
+
+set(CMAKE_AUTOMOC ON)
+add_executable(coop_gui_tests ${COOP_GUI_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/coop_searchedit_stub.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/qt2keysum_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cooperationguihelper_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sortfilterworker_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/devicelistwidget_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/filechooseredit_test.cpp)
+target_compile_options(coop_gui_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
+target_compile_definitions(coop_gui_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
+target_include_directories(coop_gui_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/src ${CD}
+    ${CMAKE_SOURCE_DIR}/src/lib/common
+    ${CMAKE_SOURCE_DIR}/3rdparty/QtZeroConf
+    ${CD}/gui/win
+    ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(coop_gui_tests PRIVATE
+    GTest::GTest
+    Qt6::Core Qt6::Widgets Qt6::Gui Qt6::Network Qt6::Concurrent Qt6::Test Qt6::DBus
+    Dtk6::Core Dtk6::Gui Dtk6::Widget
+    QtZeroConf slotipc
+    logging sessionmanager sslconf basekit fmt proto httpweb session)
+if(QRENCODE_LIBRARY)
+    target_link_libraries(coop_gui_tests PRIVATE ${QRENCODE_LIBRARY})
+endif()
+if(VNCCLIENT_LIBRARY)
+    target_link_libraries(coop_gui_tests PRIVATE ${VNCCLIENT_LIBRARY})
+endif()
+target_link_options(coop_gui_tests PRIVATE -fprofile-arcs -ftest-coverage)
+add_test(NAME coop_gui_tests COMMAND coop_gui_tests)

--- a/tests/coop_gui/addr_pri.h
+++ b/tests/coop_gui/addr_pri.h
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef __ADDR_PRI_H__
+#define __ADDR_PRI_H__
+
+
+#include <utility>
+#include <type_traits>
+
+
+
+//base on C++11
+
+/**********************************************************
+             access private function
+**********************************************************/
+
+
+namespace std {
+  template <bool B, class T = void>
+  using enable_if_t = typename enable_if<B, T>::type;
+  template <class T>
+  using remove_reference_t = typename remove_reference<T>::type;
+} // std
+
+// Unnamed namespace is used to avoid duplicate symbols if the macros are used
+namespace {
+  namespace private_access_detail {
+
+    // @tparam TagType, used to declare different "get" funciton overloads for
+    // different members/statics
+    template <typename PtrType, PtrType PtrValue, typename TagType>
+    struct private_access {
+      // Normal lookup cannot find in-class defined (inline) friend functions.
+      friend PtrType get(TagType) { return PtrValue; }
+    };
+
+  } // namespace private_access_detail
+} // namespace
+
+// Used macro naming conventions:
+// The "namespace" of this macro library is PRIVATE_ACCESS, i.e. all
+// macro here has this prefix.
+// All implementation macro, which are not meant to be used directly have the
+// PRIVATE_ACCESS_DETAIL prefix.
+// Some macros have the ABCD_IMPL form, which means they contain the
+// implementation details for the specific ABCD macro.
+
+#define PRIVATE_ACCESS_DETAIL_CONCATENATE_IMPL(x, y) x##y
+#define PRIVATE_ACCESS_DETAIL_CONCATENATE(x, y)                                \
+  PRIVATE_ACCESS_DETAIL_CONCATENATE_IMPL(x, y)
+
+// @param PtrTypeKind E.g if we have "class A", then it can be "A::*" in case of
+// members, or it can be "*" in case of statics.
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name,           \
+                                             PtrTypeKind)                      \
+  namespace {                                                                  \
+    namespace private_access_detail {                                          \
+      /* Tag type, used to declare different get funcitons for different       \
+       * members                                                               \
+       */                                                                      \
+      struct Tag {};                                                           \
+      /* Explicit instantiation */                                             \
+      template struct private_access<decltype(&Class::Name), &Class::Name,     \
+                                     Tag>;                                     \
+      /* We can build the PtrType only with two aliases */                     \
+      /* E.g. using PtrType = int(int) *; would be illformed */                \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(Alias_, Tag) = Type;             \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(PtrType_, Tag) =                 \
+          PRIVATE_ACCESS_DETAIL_CONCATENATE(Alias_, Tag) PtrTypeKind;          \
+      /* Declare the friend function, now it is visible in namespace scope.    \
+       * Note,                                                                 \
+       * we could declare it inside the Tag type too, in that case ADL would   \
+       * find                                                                  \
+       * the declaration. By choosing to declare it here, the Tag type remains \
+       * a                                                                     \
+       * simple tag type, it has no other responsibilities. */                 \
+      PRIVATE_ACCESS_DETAIL_CONCATENATE(PtrType_, Tag) get(Tag);               \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FIELD(Tag, Class, Type, Name)     \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, Class::*)       \
+  namespace {                                                                  \
+    namespace access_private_field {                                                  \
+      Type &Class##Name(Class &&t) { return t.*get(private_access_detail::Tag{}); }   \
+      Type &Class##Name(Class &t) { return t.*get(private_access_detail::Tag{}); }    \
+      /* The following usings are here to avoid duplicate const qualifier      \
+       * warnings                                                              \
+       */                                                                      \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(X, Tag) = Type;                  \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(Y, Tag) =                        \
+          const PRIVATE_ACCESS_DETAIL_CONCATENATE(X, Tag);                     \
+      PRIVATE_ACCESS_DETAIL_CONCATENATE(Y, Tag) & Class##Name(const Class &t) {\
+        return t.*get(private_access_detail::Tag{});                           \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FUN(Tag, Class, Type, Name)       \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, Class::*)       \
+  namespace {                                                                  \
+    namespace call_private_fun {                                               \
+      /* We do perfect forwarding, but we want to restrict the overload set    \
+       * only for objects which have the type Class. */                        \
+      template <typename Obj,                                                  \
+                std::enable_if_t<std::is_same<std::remove_reference_t<Obj>,    \
+                                              Class>::value> * = nullptr,      \
+                typename... Args>                                              \
+      auto Class##Name(Obj &&o, Args &&... args) -> decltype(                  \
+          (std::forward<Obj>(o).*                                              \
+           get(private_access_detail::Tag{}))(std::forward<Args>(args)...)) {  \
+        return (std::forward<Obj>(o).*get(private_access_detail::Tag{}))(      \
+            std::forward<Args>(args)...);                                      \
+      }                                                                        \
+    }                                                                          \
+    namespace get_private_fun {                                                \
+      auto Class##Name()  -> decltype(                                         \
+          get(private_access_detail::Tag{})) {                                 \
+        return (get(private_access_detail::Tag{}));                            \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FIELD(Tag, Class, Type,    \
+                                                          Name)                \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, *)              \
+  namespace {                                                                  \
+    namespace access_private_static_field {                                    \
+      namespace Class {                                                        \
+        Type &Class##Name() { return *get(private_access_detail::Tag{}); }     \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FUN(Tag, Class, Type,      \
+                                                        Name)                  \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, *)              \
+  namespace {                                                                  \
+    namespace call_private_static_fun {                                        \
+      namespace Class {                                                        \
+        template <typename... Args>                                            \
+        auto Class##Name(Args &&... args) -> decltype(                         \
+            get(private_access_detail::Tag{})(std::forward<Args>(args)...)) {  \
+          return get(private_access_detail::Tag{})(                            \
+              std::forward<Args>(args)...);                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+    namespace get_private_static_fun {                                         \
+      namespace Class {                                                        \
+        auto Class##Name() -> decltype(get(private_access_detail::Tag{})) {    \
+          return get(private_access_detail::Tag{});                            \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_UNIQUE_TAG                                       \
+  PRIVATE_ACCESS_DETAIL_CONCATENATE(PrivateAccessTag, __COUNTER__)
+
+#define ACCESS_PRIVATE_FIELD(Class, Type, Name)                                \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FIELD(PRIVATE_ACCESS_DETAIL_UNIQUE_TAG, \
+                                             Class, Type, Name)
+
+#define ACCESS_PRIVATE_FUN(Class, Type, Name)                                  \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FUN(PRIVATE_ACCESS_DETAIL_UNIQUE_TAG,   \
+                                           Class, Type, Name)
+
+#define ACCESS_PRIVATE_STATIC_FIELD(Class, Type, Name)                         \
+    Type Class::Name;                                                          \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FIELD(                           \
+      PRIVATE_ACCESS_DETAIL_UNIQUE_TAG, Class, Type, Name)
+
+#define ACCESS_PRIVATE_STATIC_FUN(Class, Type, Name)                           \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FUN(                             \
+      PRIVATE_ACCESS_DETAIL_UNIQUE_TAG, Class, Type, Name)
+
+#endif

--- a/tests/coop_gui/coop_searchedit_stub.cpp
+++ b/tests/coop_gui/coop_searchedit_stub.cpp
@@ -1,0 +1,13 @@
+// CooperationSearchEdit 桩: 真实实现在 gui/win (Windows-only), Linux 编不干净(using namespace 冲突)。
+// workspacewidget 引用此类, 这里提供全限定命名空间的最小实现 + 由 AUTOMOC 生成信号 moc。
+#include "cooperationsearchedit.h"
+#include <QFrame>
+#include <QFocusEvent>
+namespace cooperation_core {
+CooperationSearchEdit::CooperationSearchEdit(QWidget *parent) : QFrame(parent) {}
+QString CooperationSearchEdit::text() const { return {}; }
+void CooperationSearchEdit::setPlaceholderText(const QString &) {}
+void CooperationSearchEdit::setPlaceHolder(const QString &) {}
+bool CooperationSearchEdit::eventFilter(QObject *, QEvent *) { return false; }
+void CooperationSearchEdit::focusInEvent(QFocusEvent *) {}
+} // namespace cooperation_core

--- a/tests/coop_gui/cooperationguihelper_test.cpp
+++ b/tests/coop_gui/cooperationguihelper_test.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QLabel>
+#include <QWidget>
+#include <QPalette>
+#include <QColor>
+#include <QList>
+#include <QFont>
+#include "gui/utils/cooperationguihelper.h"
+
+using cooperation_core::CooperationGuiHelper;
+
+// Singleton instance should be non-null and stable across calls.
+TEST(CooperationGuiHelperTest, InstanceReturnsSameSingleton)
+{
+    auto *first = CooperationGuiHelper::instance();
+    auto *second = CooperationGuiHelper::instance();
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first, second);
+}
+
+// Boundary: colorList.size() != 2 must return false and not touch the widget.
+TEST(CooperationGuiHelperTest, AutoUpdateTextColorReturnsFalseOnWrongColorCount)
+{
+    auto *helper = CooperationGuiHelper::instance();
+    ASSERT_NE(helper, nullptr);
+    QWidget w;
+    QList<QColor> oneColor{Qt::black};
+    EXPECT_FALSE(helper->autoUpdateTextColor(&w, oneColor));
+
+    QList<QColor> threeColors{Qt::black, Qt::white, Qt::red};
+    EXPECT_FALSE(helper->autoUpdateTextColor(&w, threeColors));
+
+    QList<QColor> empty;
+    EXPECT_FALSE(helper->autoUpdateTextColor(&w, empty));
+}
+
+// Two colors should return true and apply one of them to WindowText.
+TEST(CooperationGuiHelperTest, AutoUpdateTextColorReturnsTrueOnTwoColors)
+{
+    auto *helper = CooperationGuiHelper::instance();
+    QWidget w;
+    QList<QColor> twoColors{Qt::black, Qt::white};
+    EXPECT_TRUE(helper->autoUpdateTextColor(&w, twoColors));
+    const QColor applied = w.palette().color(QPalette::WindowText);
+    EXPECT_TRUE(applied == Qt::black || applied == Qt::white);
+}
+
+// Static setFontColor should set the palette WindowText color exactly.
+TEST(CooperationGuiHelperTest, SetFontColorChangesPaletteWindowText)
+{
+    QWidget w;
+    CooperationGuiHelper::setFontColor(&w, Qt::red);
+    EXPECT_EQ(w.palette().color(QPalette::WindowText), QColor(Qt::red));
+}
+
+// setLabelFont uses setPixelSize internally (verified in source), so check pixelSize.
+TEST(CooperationGuiHelperTest, SetLabelFontAppliesPixelSize)
+{
+    QLabel label;
+    CooperationGuiHelper::setLabelFont(&label, 20, 10, QFont::Bold);
+    EXPECT_EQ(label.font().pixelSize(), 20);
+}
+
+// setAutoFont binds via DFontSizeManager; the resulting font should have a
+// non-default pixel size (> 0). We avoid asserting an exact DTK T-size value
+// since it can vary with DTK configuration; we only verify a font was applied.
+TEST(CooperationGuiHelperTest, SetAutoFontAppliesNonDefaultFont)
+{
+    QWidget w;
+    const int beforePixel = w.font().pixelSize();
+    CooperationGuiHelper::setAutoFont(&w, 16, QFont::Normal);
+    // DFontSizeManager::bind sets a pixel size on the widget's font.
+    EXPECT_GT(w.font().pixelSize(), 0);
+    // The font should differ from the default unless default already matched.
+    if (beforePixel > 0) {
+        EXPECT_NE(w.font().pixelSize(), beforePixel);
+    }
+}
+
+// isDarkTheme is static and should not crash under offscreen platform.
+TEST(CooperationGuiHelperTest, IsDarkThemeDoesNotCrash)
+{
+    // Just exercise the API; offscreen defaults to light theme.
+    bool dark = CooperationGuiHelper::isDarkTheme();
+    (void)dark;  // value depends on DTK; we only assert it doesn't crash.
+    SUCCEED();
+}

--- a/tests/coop_gui/devicelistwidget_test.cpp
+++ b/tests/coop_gui/devicelistwidget_test.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "gui/widgets/devicelistwidget.h"
+#include "discover/deviceinfo.h"
+
+using cooperation_core::DeviceListWidget;
+using cooperation_core::DeviceInfo;
+using ::DeviceInfoPointer;
+
+class DeviceListWidgetTest : public ::testing::Test
+{
+protected:
+    DeviceListWidget *w = nullptr;
+    void SetUp() override { w = new DeviceListWidget(); }
+    void TearDown() override { delete w; }
+    DeviceInfoPointer makeDev(const QString &ip, const QString &name)
+    {
+        return DeviceInfoPointer(new DeviceInfo(ip, name));
+    }
+};
+
+TEST_F(DeviceListWidgetTest, EmptyWidgetHasZeroItemCount)
+{
+    EXPECT_EQ(w->itemCount(), 0);
+}
+
+TEST_F(DeviceListWidgetTest, AppendItemIncreasesCount)
+{
+    w->appendItem(makeDev("192.168.1.1", "Dev1"));
+    EXPECT_EQ(w->itemCount(), 1);
+}
+
+TEST_F(DeviceListWidgetTest, FindDeviceInfoReturnsInsertedByIp)
+{
+    w->appendItem(makeDev("192.168.1.2", "Dev2"));
+    auto found = w->findDeviceInfo("192.168.1.2");
+    ASSERT_NE(found, nullptr);
+    EXPECT_EQ(found->deviceName().toStdString(), "Dev2");
+}
+
+TEST_F(DeviceListWidgetTest, FindDeviceInfoReturnsNullForAbsentIp)
+{
+    EXPECT_EQ(w->findDeviceInfo("0.0.0.0"), nullptr);
+}
+
+TEST_F(DeviceListWidgetTest, IndexOfReturnsPosition)
+{
+    w->appendItem(makeDev("10.0.0.1", "A"));
+    w->appendItem(makeDev("10.0.0.2", "B"));
+    EXPECT_EQ(w->indexOf("10.0.0.2"), 1);
+}
+
+TEST_F(DeviceListWidgetTest, RemoveItemDecreasesCount)
+{
+    w->appendItem(makeDev("10.0.0.3", "C"));
+    w->removeItem(0);
+    EXPECT_EQ(w->itemCount(), 0);
+}
+
+TEST_F(DeviceListWidgetTest, ClearEmptiesAllItems)
+{
+    w->appendItem(makeDev("10.0.0.4", "D"));
+    w->appendItem(makeDev("10.0.0.5", "E"));
+    w->clear();
+    EXPECT_EQ(w->itemCount(), 0);
+}

--- a/tests/coop_gui/filechooseredit_test.cpp
+++ b/tests/coop_gui/filechooseredit_test.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QDir>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
+#include "gui/widgets/filechooseredit.h"
+#include "stub.h"
+
+using cooperation_core::FileChooserEdit;
+
+// Stub for QFileDialog::getExistingDirectory (static).
+// Signature must match: QString(QWidget*, const QString&, const QString&, QFileDialog::Options)
+static QString g_stubDirPath;
+static QString stub_getExistingDirectory(QWidget *, const QString &, const QString &, QFileDialog::Options)
+{
+    return g_stubDirPath;
+}
+
+TEST(FileChooserEditTest, SetTextDoesNotCrash)
+{
+    FileChooserEdit edit;
+    edit.setText("/some/long/path/to/show/in/the/edit/control");
+    SUCCEED();
+}
+
+TEST(FileChooserEditTest, OnButtonClickedEmitsFileChoosedWithStubbedPath)
+{
+    // Prepare a writable, non-empty temp directory so onButtonClicked's
+    // validation (QFileInfo::isWritable + QDir::entryInfoList non-empty) passes.
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid()) << "Failed to create temp dir";
+    {
+        QTemporaryFile marker(tempDir.path() + "/markerXXXXXX");
+        ASSERT_TRUE(marker.open()) << "Failed to create marker file";
+        marker.write("x");
+        marker.close();
+    }
+    ASSERT_FALSE(QDir(tempDir.path()).entryInfoList().isEmpty());
+    ASSERT_TRUE(QFileInfo(tempDir.path()).isWritable());
+    g_stubDirPath = tempDir.path();
+
+    FileChooserEdit edit;
+    QSignalSpy spy(&edit, &FileChooserEdit::fileChoosed);
+    ASSERT_TRUE(spy.isValid());
+
+    Stub stub;
+    // QFileDialog::getExistingDirectory is static; ADDR() yields a function
+    // pointer (not a member-function pointer) for static members, which
+    // Stub::set accepts. Fall back to a raw void* cast if ADDR doesn't compile.
+    stub.set(ADDR(QFileDialog, getExistingDirectory), stub_getExistingDirectory);
+
+    // onButtonClicked is a private slot; invokeMethod resolves it via moc metadata.
+    ASSERT_TRUE(QMetaObject::invokeMethod(&edit, "onButtonClicked"));
+
+    // The stub makes the call synchronous; spin the loop briefly to flush signals.
+    spy.wait(1000);
+
+    ASSERT_GE(spy.count(), 1) << "fileChoosed signal not emitted";
+    auto args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString().toStdString(), g_stubDirPath.toStdString());
+}

--- a/tests/coop_gui/main.cpp
+++ b/tests/coop_gui/main.cpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QApplication>
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv)
+{
+    // offscreen 由 test-prj-running.sh 设置; 此处兜底防止本地直接跑
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication app(argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/coop_gui/qt2keysum_test.cpp
+++ b/tests/coop_gui/qt2keysum_test.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <Qt>
+// rfb keysym 定义
+#include <rfb/keysym.h>
+// 纯函数头 (无 namespace)
+#include "gui/phone/qt2keysum.h"
+
+TEST(Qt2KeysumTest, MapsLetterKeysToX11Keysyms)
+{
+    EXPECT_EQ(qt2keysym(Qt::Key_A), XK_a);
+    EXPECT_EQ(qt2keysym(Qt::Key_Z), XK_z);
+}
+
+TEST(Qt2KeysumTest, MapsDigitKeys)
+{
+    EXPECT_EQ(qt2keysym(Qt::Key_0), XK_0);
+    EXPECT_EQ(qt2keysym(Qt::Key_9), XK_9);
+}
+
+TEST(Qt2KeysumTest, MapsEnterAndBackspace)
+{
+    // 实际 switch: Key_Return -> XK_Return, Key_Enter (小键盘) -> XK_KP_Enter
+    EXPECT_EQ(qt2keysym(Qt::Key_Return), XK_Return);
+    EXPECT_EQ(qt2keysym(Qt::Key_Backspace), XK_BackSpace);
+}
+
+TEST(Qt2KeysumTest, MapsArrowKeys)
+{
+    EXPECT_EQ(qt2keysym(Qt::Key_Up), XK_Up);
+    EXPECT_EQ(qt2keysym(Qt::Key_Down), XK_Down);
+    EXPECT_EQ(qt2keysym(Qt::Key_Left), XK_Left);
+    EXPECT_EQ(qt2keysym(Qt::Key_Right), XK_Right);
+}
+
+TEST(Qt2KeysumTest, MapsFunctionKeys)
+{
+    EXPECT_EQ(qt2keysym(Qt::Key_F1), XK_F1);
+    EXPECT_EQ(qt2keysym(Qt::Key_F12), XK_F12);
+}
+
+TEST(Qt2KeysumTest, MapsModifiersAndSpecialKeys)
+{
+    // 实际 switch: Key_Shift -> XK_Shift_L, Key_Control -> XK_Control_L
+    EXPECT_EQ(qt2keysym(Qt::Key_Shift), XK_Shift_L);
+    EXPECT_EQ(qt2keysym(Qt::Key_Control), XK_Control_L);
+    EXPECT_EQ(qt2keysym(Qt::Key_Space), XK_space);
+    EXPECT_EQ(qt2keysym(Qt::Key_Escape), XK_Escape);
+    // Key_Enter (小键盘 Enter) 映射到 XK_KP_Enter,而非 XK_Return
+    EXPECT_EQ(qt2keysym(Qt::Key_Enter), XK_KP_Enter);
+}
+
+TEST(Qt2KeysumTest, UnknownKeyReturnsMinusOne)
+{
+    EXPECT_EQ(qt2keysym(Qt::Key_unknown), -1);
+}

--- a/tests/coop_gui/sortfilterworker_test.cpp
+++ b/tests/coop_gui/sortfilterworker_test.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QList>
+#include "gui/utils/sortfilterworker.h"
+#include "discover/deviceinfo.h"
+#include "addr_pri.h"
+
+using cooperation_core::SortFilterWorker;
+using cooperation_core::DeviceInfo;
+
+// DeviceInfoPointer 是 global namespace typedef (在 deviceinfo.h 文件作用域)
+using ::DeviceInfoPointer;
+
+// 访问私有字段 allDeviceList / visibleDeviceList 用于验证内部状态
+ACCESS_PRIVATE_FIELD(SortFilterWorker, QList<DeviceInfoPointer>, allDeviceList)
+ACCESS_PRIVATE_FIELD(SortFilterWorker, QList<DeviceInfoPointer>, visibleDeviceList)
+
+class SortFilterWorkerTest : public ::testing::Test
+{
+protected:
+    SortFilterWorker *worker = nullptr;
+    void SetUp() override
+    {
+        worker = new SortFilterWorker();
+        // 设置 selfip 避免测试设备被当作本机过滤掉
+        worker->setSelfip("127.0.0.1");
+    }
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+    }
+    DeviceInfoPointer makeDev(const QString &ip, const QString &name)
+    {
+        return DeviceInfoPointer(new DeviceInfo(ip, name));
+    }
+};
+
+// addDevice 对每个新设备发出 sortFilterResult(index, info),最后发出 filterFinished
+TEST_F(SortFilterWorkerTest, AddDeviceEmitsSortFilterResult)
+{
+    QSignalSpy spy(worker, &SortFilterWorker::sortFilterResult);
+    worker->addDevice({makeDev("10.0.0.1", "A")});
+    EXPECT_GE(spy.count(), 1);
+}
+
+// addDevice 将设备存入 allDeviceList (内部私有列表)
+TEST_F(SortFilterWorkerTest, AddDeviceStoresInAllList)
+{
+    worker->addDevice({makeDev("10.0.0.2", "B"), makeDev("10.0.0.3", "C")});
+    auto &all = access_private_field::SortFilterWorkerallDeviceList(*worker);
+    EXPECT_EQ(all.size(), 2);
+}
+
+// addDevice 同时把设备放入 visibleDeviceList (filter 为空时全部可见)
+TEST_F(SortFilterWorkerTest, AddDeviceStoresInVisibleList)
+{
+    worker->addDevice({makeDev("10.0.0.8", "Vis")});
+    auto &vis = access_private_field::SortFilterWorkervisibleDeviceList(*worker);
+    EXPECT_EQ(vis.size(), 1);
+}
+
+// addDevice 跳过 selfip 匹配的设备
+TEST_F(SortFilterWorkerTest, AddDeviceSkipsSelfIp)
+{
+    worker->addDevice({makeDev("127.0.0.1", "Self"), makeDev("10.0.0.9", "Other")});
+    auto &all = access_private_field::SortFilterWorkerallDeviceList(*worker);
+    EXPECT_EQ(all.size(), 1);
+    EXPECT_EQ(all.first()->ipAddress(), QString("10.0.0.9"));
+}
+
+// removeDevice 从 visibleDeviceList 找到设备并发出 deviceRemoved(index)
+TEST_F(SortFilterWorkerTest, RemoveDeviceEmitsDeviceRemoved)
+{
+    worker->addDevice({makeDev("10.0.0.4", "D")});
+    QSignalSpy spy(worker, &SortFilterWorker::deviceRemoved);
+    worker->removeDevice("10.0.0.4");
+    EXPECT_GE(spy.count(), 1);
+    // 验证删除后内部列表也同步移除
+    auto &all = access_private_field::SortFilterWorkerallDeviceList(*worker);
+    EXPECT_EQ(all.size(), 0);
+}
+
+// removeDevice 对不存在的 IP 不发信号
+TEST_F(SortFilterWorkerTest, RemoveDeviceNoSignalForUnknownIp)
+{
+    worker->addDevice({makeDev("10.0.0.10", "X")});
+    QSignalSpy spy(worker, &SortFilterWorker::deviceRemoved);
+    worker->removeDevice("192.168.99.99");
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// filterDevice 同步发出 sortFilterResult(匹配项) 和 filterFinished
+TEST_F(SortFilterWorkerTest, FilterDeviceEmitsFilterFinished)
+{
+    worker->addDevice({makeDev("10.0.0.5", "Alpha"), makeDev("10.0.0.6", "Beta")});
+    QSignalSpy sortSpy(worker, &SortFilterWorker::sortFilterResult);
+    QSignalSpy finishSpy(worker, &SortFilterWorker::filterFinished);
+    worker->filterDevice("Alpha");
+    // filterDevice 是同步的;直接检查 count
+    EXPECT_GE(finishSpy.count(), 1);
+    EXPECT_GE(sortSpy.count(), 1);
+    // visibleDeviceList 应只包含匹配 "Alpha" 的设备
+    auto &vis = access_private_field::SortFilterWorkervisibleDeviceList(*worker);
+    EXPECT_EQ(vis.size(), 1);
+    EXPECT_EQ(vis.first()->deviceName(), QString("Alpha"));
+}
+
+// filterDevice 空字符串匹配所有设备
+TEST_F(SortFilterWorkerTest, FilterDeviceEmptyMatchesAll)
+{
+    worker->addDevice({makeDev("10.0.0.11", "Foo"), makeDev("10.0.0.12", "Bar")});
+    QSignalSpy finishSpy(worker, &SortFilterWorker::filterFinished);
+    worker->filterDevice("");
+    EXPECT_GE(finishSpy.count(), 1);
+    auto &vis = access_private_field::SortFilterWorkervisibleDeviceList(*worker);
+    EXPECT_EQ(vis.size(), 2);
+}
+
+// clear 清空所有内部列表,不发信号
+TEST_F(SortFilterWorkerTest, ClearEmptiesAllList)
+{
+    worker->addDevice({makeDev("10.0.0.7", "E")});
+    QSignalSpy spy(worker, &SortFilterWorker::sortFilterResult);
+    worker->clear();
+    // clear 不发 sortFilterResult 信号
+    EXPECT_EQ(spy.count(), 0);
+    auto &all = access_private_field::SortFilterWorkerallDeviceList(*worker);
+    auto &vis = access_private_field::SortFilterWorkervisibleDeviceList(*worker);
+    EXPECT_EQ(all.size(), 0);
+    EXPECT_EQ(vis.size(), 0);
+}
+
+// stop 后 addDevice 不再处理设备
+TEST_F(SortFilterWorkerTest, StopBlocksAddDevice)
+{
+    worker->stop();
+    QSignalSpy spy(worker, &SortFilterWorker::sortFilterResult);
+    worker->addDevice({makeDev("10.0.0.20", "Stopped")});
+    EXPECT_EQ(spy.count(), 0);
+    auto &all = access_private_field::SortFilterWorkerallDeviceList(*worker);
+    EXPECT_EQ(all.size(), 0);
+}

--- a/tests/coop_gui/stub.h
+++ b/tests/coop_gui/stub.h
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef __STUB_H__
+#define __STUB_H__
+
+
+#ifdef _WIN32 
+//windows
+#include <windows.h>
+#include <processthreadsapi.h>
+#else
+//linux
+#include <unistd.h>
+#include <sys/mman.h>
+#endif
+//c
+#include <cstddef>
+#include <cstring>
+//c++
+#include <map>
+
+
+#define ADDR(CLASS_NAME,MEMBER_NAME) (&CLASS_NAME::MEMBER_NAME)
+
+/**********************************************************
+                  replace function
+**********************************************************/
+#ifdef _WIN32 
+#define CACHEFLUSH(addr, size) FlushInstructionCache(GetCurrentProcess(), addr, size)
+#else
+#define CACHEFLUSH(addr, size) __builtin___clear_cache(addr, addr + size)
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+    #define CODESIZE 16U
+    #define CODESIZE_MIN 16U
+    #define CODESIZE_MAX CODESIZE
+    // ldr x9, +8 
+    // br x9 
+    // addr 
+    #define REPLACE_FAR(t, fn, fn_stub)\
+        ((uint32_t*)fn)[0] = 0x58000040 | 9;\
+        ((uint32_t*)fn)[1] = 0xd61f0120 | (9 << 5);\
+        *(long long *)(fn + 8) = (long long )fn_stub;\
+        CACHEFLUSH((char *)fn, CODESIZE);
+    #define REPLACE_NEAR(t, fn, fn_stub) REPLACE_FAR(t, fn, fn_stub)
+#elif defined(__arm__) || defined(_M_ARM)
+    #define CODESIZE 8U
+    #define CODESIZE_MIN 8U
+    #define CODESIZE_MAX CODESIZE
+    // ldr pc, [pc, #-4]
+    #define REPLACE_FAR(t, fn, fn_stub)\
+        ((uint32_t*)fn)[0] = 0xe51ff004;\
+        ((uint32_t*)fn)[1] = (uint32_t)fn_stub;\
+        CACHEFLUSH((char *)fn, CODESIZE);
+    #define REPLACE_NEAR(t, fn, fn_stub) REPLACE_FAR(t, fn, fn_stub)
+#elif defined(__thumb__) || defined(_M_THUMB)
+    #error "Thumb is not supported"
+#else //__i386__ _x86_64__
+    #define CODESIZE 13U
+    #define CODESIZE_MIN 5U
+    #define CODESIZE_MAX CODESIZE
+    //13 byte(jmp m16:64)
+    //movabs $0x102030405060708,%r11
+    //jmpq   *%r11
+    #define REPLACE_FAR(t, fn, fn_stub)\
+        *fn = 0x49;\
+        *(fn + 1) = 0xbb;\
+        *(long long *)(fn + 2) = (long long)fn_stub;\
+        *(fn + 10) = 0x41;\
+        *(fn + 11) = 0xff;\
+        *(fn + 12) = 0xe3;\
+        //CACHEFLUSH((char *)fn, CODESIZE);
+
+    //5 byte(jmp rel32)
+    #define REPLACE_NEAR(t, fn, fn_stub)\
+        *fn = 0xE9;\
+        *(int *)(fn + 1) = (int)(fn_stub - fn - CODESIZE_MIN);\
+        //CACHEFLUSH((char *)fn, CODESIZE);
+#endif
+
+struct func_stub
+{
+    char *fn;
+    unsigned char code_buf[CODESIZE];
+    bool far_jmp;
+};
+
+class Stub
+{
+public:
+    Stub()
+    {
+#ifdef _WIN32
+        SYSTEM_INFO sys_info;  
+        GetSystemInfo(&sys_info);
+        m_pagesize = sys_info.dwPageSize;
+#else
+        m_pagesize = sysconf(_SC_PAGE_SIZE);
+#endif       
+
+        if (m_pagesize < 0)
+        {
+            m_pagesize = 4096;
+        }
+    }
+    ~Stub()
+    {
+        std::map<char*,func_stub*>::iterator iter;
+        struct func_stub *pstub;
+        for(iter=m_result.begin(); iter != m_result.end(); iter++)
+        {
+            pstub = iter->second;
+#ifdef _WIN32
+            DWORD lpflOldProtect;
+            if(0 != VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READWRITE, &lpflOldProtect))
+#else
+            if (0 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_WRITE | PROT_EXEC))
+#endif       
+            {
+
+                if(pstub->far_jmp)
+                {
+                    std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MAX);
+                }
+                else
+                {
+                    std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MIN);
+                }
+
+#ifdef _WIN32
+                VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READ, &lpflOldProtect);
+#else
+                mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_EXEC);
+#endif     
+            }
+
+            iter->second  = NULL;
+            delete pstub;        
+        }
+        
+        return;
+    }
+    template<typename T,typename S>
+    void set(T addr, S addr_stub)
+    {
+        char * fn;
+        char * fn_stub;
+        fn = addrof(addr);
+        fn_stub = addrof(addr_stub);
+        struct func_stub *pstub;
+        pstub = new func_stub;
+        //start
+        pstub->fn = fn;
+
+        if(distanceof(fn, fn_stub))
+        {
+            pstub->far_jmp = true;
+            std::memcpy(pstub->code_buf, fn, CODESIZE_MAX);
+        }
+        else
+        {
+            pstub->far_jmp = false;
+            std::memcpy(pstub->code_buf, fn, CODESIZE_MIN);
+        }
+
+#ifdef _WIN32
+        DWORD lpflOldProtect;
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READWRITE, &lpflOldProtect))
+#else
+        if (-1 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_WRITE | PROT_EXEC))
+#endif       
+        {
+            throw("stub set memory protect to w+r+x faild");
+        }
+
+        if(pstub->far_jmp)
+        {
+            REPLACE_FAR(this, fn, fn_stub);
+        }
+        else
+        {
+            REPLACE_NEAR(this, fn, fn_stub);
+        }
+
+
+#ifdef _WIN32
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READ, &lpflOldProtect))
+#else
+        if (-1 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_EXEC))
+#endif     
+        {
+            throw("stub set memory protect to r+x failed");
+        }
+        m_result.insert(std::pair<char*,func_stub*>(fn,pstub));
+        return;
+    }
+
+    template<typename T>
+    void reset(T addr)
+    {
+        char * fn;
+        fn = addrof(addr);
+        
+        std::map<char*,func_stub*>::iterator iter = m_result.find(fn);
+        
+        if (iter == m_result.end())
+        {
+            return;
+        }
+        struct func_stub *pstub;
+        pstub = iter->second;
+        
+#ifdef _WIN32
+        DWORD lpflOldProtect;
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READWRITE, &lpflOldProtect))
+#else
+        if (-1 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_WRITE | PROT_EXEC))
+#endif       
+        {
+            throw("stub reset memory protect to w+r+x faild");
+        }
+
+        if(pstub->far_jmp)
+        {
+            std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MAX);
+        }
+        else
+        {
+            std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MIN);
+        }
+
+
+#ifdef _WIN32
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READ, &lpflOldProtect))
+#else
+        if (-1 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_EXEC))
+#endif     
+        {
+            throw("stub reset memory protect to r+x failed");
+        }
+        m_result.erase(iter);
+        delete pstub;
+        
+        return;
+    }
+private:
+    char *pageof(char* addr)
+    { 
+#ifdef _WIN32
+        return (char *)((unsigned long long)addr & ~(m_pagesize - 1));
+#else
+        return (char *)((unsigned long)addr & ~(m_pagesize - 1));
+#endif   
+    }
+
+    template<typename T>
+    char* addrof(T addr)
+    {
+        union 
+        {
+          T _s;
+          char* _d;
+        }ut;
+        ut._s = addr;
+        return ut._d;
+    }
+
+    bool distanceof(char* addr, char* addr_stub)
+    {
+        std::ptrdiff_t diff = addr_stub >= addr ? addr_stub - addr : addr - addr_stub;
+        if((sizeof(addr) > 4) && (((diff >> 31) - 1) > 0))
+        {
+            return true;
+        }
+        return false;
+    }
+
+private:
+#ifdef _WIN32
+    //LLP64
+    long long m_pagesize;
+#else
+    //LP64
+    long m_pagesize;
+#endif   
+    std::map<char*, func_stub*> m_result;
+    
+};
+
+
+#endif


### PR DESCRIPTION
整合 phase1(基础设施+8文件)与 phase2A Task1-3(4文件)为单提交。

基础设施:
- tests/coop(logic)+tests/coop_gui(GUI)双二进制,GTest+Qt6::Test+stub.h+addr_pri.h
- 自定义 main.cpp(QApplication + __gcov_dump),修复 exit-134 abort 导致无 .gcda
- -fno-access-control + offscreen,深黑盒 GUI 测试(不 show/exec)

覆盖(coop_tests 130/130, coop_gui_tests 33/33 PASS):
- GUI: qt2keysym/CooperationGuiHelper/SortFilterWorker/DeviceListWidget/ FileChooserEdit
- logic: CooConfig/HistoryManager/CooperationUtil/ShareHelper/ TransferHelper(core)/CompatWrapper/TransferWrapper
- TransferWrapper 私有 slot 经 -fno-access-control 直接调用, transferwrapper.cpp 行覆盖近乎 100%