### PR TITLE
test(coop_gui): 覆盖 CooperationDialog/CooperationTaskDialog 页面切换

### DIFF
--- a/tests/coop_gui/CMakeLists.txt
+++ b/tests/coop_gui/CMakeLists.txt
@@ -45,7 +45,9 @@ add_executable(coop_gui_tests ${COOP_GUI_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/cooperationguihelper_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sortfilterworker_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/devicelistwidget_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/filechooseredit_test.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/filechooseredit_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cooperationdialog_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cooperationtaskdialog_test.cpp)
 target_compile_options(coop_gui_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_gui_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_gui_tests PRIVATE

--- a/tests/coop_gui/cooperationdialog_test.cpp
+++ b/tests/coop_gui/cooperationdialog_test.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QCloseEvent>
+#include <QCoreApplication>
+#include "net/helper/dialogs/cooperationdialog.h"
+
+using cooperation_core::ConfirmWidget;
+using cooperation_core::ProgressWidget;
+using cooperation_core::ResultWidget;
+using cooperation_core::WaitConfirmWidget;
+using cooperation_core::CooperationTransDialog;
+
+// ============ ConfirmWidget ============
+
+TEST(ConfirmWidgetTest, ConstructDoesNotCrash)
+{
+    ConfirmWidget w;
+    SUCCEED();
+}
+
+TEST(ConfirmWidgetTest, SetDeviceNameDoesNotCrash)
+{
+    ConfirmWidget w;
+    w.setDeviceName("TestDev");
+    SUCCEED();
+}
+
+// ============ ProgressWidget ============
+
+TEST(ProgressWidgetTest, SetTitleAndProgressDoNotCrash)
+{
+    ProgressWidget w;
+    w.setTitle("Transferring");
+    w.setProgress(42, "00:12");
+    SUCCEED();
+}
+
+TEST(ProgressWidgetTest, ProgressBoundaryValuesDoNotCrash)
+{
+    ProgressWidget w;
+    w.setProgress(0, "00:00");
+    w.setProgress(100, "00:30");
+    SUCCEED();
+}
+
+// ============ ResultWidget ============
+
+TEST(ResultWidgetTest, SetSuccessResultAndGetReturnsTrue)
+{
+    ResultWidget w;
+    w.setResult(true, "ok", true);
+    EXPECT_TRUE(w.getResult());
+}
+
+TEST(ResultWidgetTest, SetFailureResultAndGetReturnsFalse)
+{
+    ResultWidget w;
+    w.setResult(false, "fail", false);
+    EXPECT_FALSE(w.getResult());
+}
+
+TEST(ResultWidgetTest, SetSuccessWithoutViewDoesNotCrash)
+{
+    ResultWidget w;
+    w.setResult(true, "ok", false);
+    EXPECT_TRUE(w.getResult());
+}
+
+// ============ WaitConfirmWidget ============
+
+TEST(WaitConfirmWidgetTest, StartMovieDoesNotCrash)
+{
+    WaitConfirmWidget w;
+    w.startMovie();
+    SUCCEED();
+}
+
+// ============ CooperationTransDialog: show* / updateProgress ============
+
+TEST(CooperationTransDialogTest, ShowConfirmDialogDoesNotCrash)
+{
+    CooperationTransDialog dlg;
+    dlg.showConfirmDialog("DevA");
+    SUCCEED();
+}
+
+TEST(CooperationTransDialogTest, ShowWaitConfirmDialogDoesNotCrash)
+{
+    CooperationTransDialog dlg;
+    dlg.showWaitConfirmDialog();
+    SUCCEED();
+}
+
+TEST(CooperationTransDialogTest, ShowResultDialogSuccessAndFailure)
+{
+    CooperationTransDialog dlg;
+    dlg.showResultDialog(true, "ok", true);
+    dlg.showResultDialog(false, "fail", false);
+    SUCCEED();
+}
+
+TEST(CooperationTransDialogTest, ShowProgressDialogDoesNotCrash)
+{
+    CooperationTransDialog dlg;
+    dlg.showProgressDialog("Transferring");
+    SUCCEED();
+}
+
+// 首次 showProgressDialog 后 currentWidget 已是 progressWidget,
+// 再次调用走早返回分支 (cooperationdialog.cpp:240-241)。
+TEST(CooperationTransDialogTest, ShowProgressDialogTwiceHitsEarlyReturn)
+{
+    CooperationTransDialog dlg;
+    dlg.showProgressDialog("First");
+    dlg.showProgressDialog("Second");
+    SUCCEED();
+}
+
+TEST(CooperationTransDialogTest, UpdateProgressDoesNotCrash)
+{
+    CooperationTransDialog dlg;
+    dlg.showProgressDialog("Title");
+    dlg.updateProgress(55, "00:10");
+    SUCCEED();
+}
+
+// ============ CooperationTransDialog: closeEvent 三条安全分支 ============
+// 注:resultWidget 分支会调 qApp->exit()(onlyTransfer && success),会杀掉测试进程,
+// 故避开——不切到 resultWidget 后发关闭事件。
+
+TEST(CooperationTransDialogCloseEventTest, ClosingConfirmPageEmitsRejected)
+{
+    CooperationTransDialog dlg;
+    dlg.showConfirmDialog("Dev");
+    QSignalSpy spy(&dlg, &CooperationTransDialog::rejected);
+    QCloseEvent e;
+    QCoreApplication::sendEvent(&dlg, &e);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST(CooperationTransDialogCloseEventTest, ClosingProgressPageEmitsCancel)
+{
+    CooperationTransDialog dlg;
+    dlg.showProgressDialog("Transferring");
+    QSignalSpy spy(&dlg, &CooperationTransDialog::cancel);
+    QCloseEvent e;
+    QCoreApplication::sendEvent(&dlg, &e);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST(CooperationTransDialogCloseEventTest, ClosingWaitConfirmPageEmitsCancelApply)
+{
+    CooperationTransDialog dlg;
+    dlg.showWaitConfirmDialog();
+    QSignalSpy spy(&dlg, &CooperationTransDialog::cancelApply);
+    QCloseEvent e;
+    QCoreApplication::sendEvent(&dlg, &e);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// 未 show() 的对话框 isVisible()=false, 走 closeEvent 的 accept 分支
+// (cooperationdialog.cpp:257-260)。注: 源码该分支后无 return 会继续 fall-through
+// 到 currentWidget 判断, 默认 confirmWidget 仍会 emit rejected, 此处只验不崩。
+TEST(CooperationTransDialogCloseEventTest, ClosingUnshownDialogDoesNotCrash)
+{
+    CooperationTransDialog dlg;
+    QCloseEvent e;
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(&dlg, &e));
+}

--- a/tests/coop_gui/cooperationtaskdialog_test.cpp
+++ b/tests/coop_gui/cooperationtaskdialog_test.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "net/helper/dialogs/cooperationtaskdialog.h"
+
+using cooperation_core::CooperationTaskDialog;
+
+TEST(CooperationTaskDialogTest, ConstructDoesNotCrash)
+{
+    CooperationTaskDialog dlg;
+    SUCCEED();
+}
+
+TEST(CooperationTaskDialogTest, SwitchWaitPageDoesNotCrash)
+{
+    CooperationTaskDialog dlg;
+    dlg.switchWaitPage("Waiting");
+    SUCCEED();
+}
+
+// retry=true 让 retryBtn 可见,retry=false 隐藏 (cooperationtaskdialog.cpp:33)。
+TEST(CooperationTaskDialogTest, SwitchFailPageWithRetryToggleDoesNotCrash)
+{
+    CooperationTaskDialog dlg;
+    dlg.switchFailPage("Failed", "network error", true);
+    dlg.switchFailPage("Failed", "timeout", false);
+    SUCCEED();
+}
+
+TEST(CooperationTaskDialogTest, SwitchConfirmPageDoesNotCrash)
+{
+    CooperationTaskDialog dlg;
+    dlg.switchConfirmPage("Confirm?", "10.0.0.1 wants to connect");
+    SUCCEED();
+}
+
+TEST(CooperationTaskDialogTest, SwitchInfomationPageDoesNotCrash)
+{
+    CooperationTaskDialog dlg;
+    dlg.switchInfomationPage("Info", "transfer finished");
+    SUCCEED();
+}
+
+// 多次切换页面,覆盖 switchLayout->setCurrentIndex 不同分支。
+TEST(CooperationTaskDialogTest, SequentialPageSwitchesDoNotCrash)
+{
+    CooperationTaskDialog dlg;
+    dlg.switchWaitPage("W");
+    dlg.switchFailPage("F", "msg", true);
+    dlg.switchConfirmPage("C", "msg");
+    dlg.switchInfomationPage("I", "msg");
+    dlg.switchWaitPage("W2");
+    SUCCEED();
+}


### PR DESCRIPTION
新增 tests/coop_gui/cooperationdialog_test.cpp(18 用例,5 widget 类)与 cooperationtaskdialog_test.cpp(6 用例):

CooperationDialog 族:
- ConfirmWidget/ProgressWidget/ResultWidget/WaitConfirmWidget 构造+setter; ResultWidget setResult 真/假往返 + getResult;
- CooperationTransDialog showConfirmDialog/showWaitConfirmDialog/ showResultDialog/showProgressDialog/updateProgress,含 showProgressDialog 二次调用早返回分支;
- closeEvent 三条安全分支(confirm→rejected/progress→cancel/ waitConfirm→cancelApply)经 QCloseEvent + sendEvent 触发; 避开 resultWidget 分支(qApp->exit 会杀进程);补未显示对话框 accept 分支。

CooperationTaskDialog: switchWait/Fail/Confirm/Infomation 四页面切换, 含 retryBtn 可见性切换。

coop_gui_tests 57/57 PASS;cooperationdialog.cpp 174 可执行仅 9 未覆盖 (多属 DLOG 多行归属怪象 + 故意避开的 qApp->exit 分支),
cooperationtaskdialog.cpp 101 可执行仅 3 未覆盖(DLOG 怪象)。