### PR TITLE
test(coop): 覆盖 ShareCooperationService/Manager、DConfigManager/ConfigM…

### DIFF
--- a/tests/coop/CMakeLists.txt
+++ b/tests/coop/CMakeLists.txt
@@ -57,7 +57,10 @@ add_executable(coop_tests ${COOP_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/sharehelper_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/transferhelper_core_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compatwrapper_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/transferwrapper_test.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/transferwrapper_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sharecooperationservice_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dfmconfig_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/reportlog_test.cpp)
 target_compile_options(coop_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_tests PRIVATE

--- a/tests/coop/dfmconfig_test.cpp
+++ b/tests/coop/dfmconfig_test.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 注:dfmplugin 版与 src/configs 版的 dconfigmanager.h/configmanager.h 是相同
+// vendored 副本(同类名同 API 同 include guard)。coop_tests 已 glob src/configs 版,
+// 故此处测 src/configs 版(免 include guard 碰撞),覆盖率落在 src/configs 的 .cpp。
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QVariant>
+#include <QStringList>
+#include "configs/dconfig/dconfigmanager.h"
+#include "configs/settings/configmanager.h"
+
+// ============ DConfigManager ============
+
+TEST(DConfigManagerTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(DConfigManager::instance(), DConfigManager::instance());
+}
+
+TEST(DConfigManagerTest, KeysForUnknownConfigReturnsEmpty)
+{
+    EXPECT_TRUE(DConfigManager::instance()->keys("org.deepin.dde.nonexistent").isEmpty());
+}
+
+TEST(DConfigManagerTest, ContainsForUnknownConfigReturnsFalse)
+{
+    EXPECT_FALSE(DConfigManager::instance()->contains("org.deepin.dde.nonexistent", "anyKey"));
+}
+
+TEST(DConfigManagerTest, ContainsEmptyKeyReturnsFalse)
+{
+    // contains 在 key 为空时直接返回 false (dconfigmanager.cpp:103)。
+    EXPECT_FALSE(DConfigManager::instance()->contains("org.deepin.dde.cooperation", ""));
+}
+
+TEST(DConfigManagerTest, ValueForUnknownConfigReturnsFallback)
+{
+    QVariant fallback = "defaultVal";
+    QVariant v = DConfigManager::instance()->value("org.deepin.dde.nonexistent", "key", fallback);
+    EXPECT_EQ(v.toString().toStdString(), "defaultVal");
+}
+
+TEST(DConfigManagerTest, SetValueForUnknownConfigDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(
+        DConfigManager::instance()->setValue("org.deepin.dde.nonexistent", "key", QVariant(42)));
+}
+
+TEST(DConfigManagerTest, ValidateConfigsWithDefaultReturnsBool)
+{
+    QStringList invalid;
+    bool ok = DConfigManager::instance()->validateConfigs(invalid);
+    (void)ok;  // 默认 config 已加载则 true,offscreen 下 schema 可能无效则 false
+    SUCCEED();
+}
+
+TEST(DConfigManagerTest, AddUnknownConfigReturnsFalseWithError)
+{
+    QString err;
+    bool ok = DConfigManager::instance()->addConfig("org.deepin.dde.nonexistent", &err);
+    EXPECT_FALSE(ok);
+    EXPECT_FALSE(err.isEmpty());  // "cannot create config" 或 "config is not valid"
+}
+
+TEST(DConfigManagerTest, RemoveConfigReturnsTrue)
+{
+    EXPECT_TRUE(DConfigManager::instance()->removeConfig("org.deepin.dde.nonexistent"));
+}
+
+// ============ ConfigManager ============
+
+TEST(ConfigManagerTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(ConfigManager::instance(), ConfigManager::instance());
+}
+
+TEST(ConfigManagerTest, AppAttributeForUnknownReturnsInvalid)
+{
+    QVariant v = ConfigManager::instance()->appAttribute("UnknownGroup", "UnknownKey");
+    EXPECT_FALSE(v.isValid());
+}
+
+TEST(ConfigManagerTest, SetAppAttributeRoundTrip)
+{
+    ConfigManager::instance()->setAppAttribute("RoundGroup", "RoundKey", QVariant("roundVal"));
+    QVariant got = ConfigManager::instance()->appAttribute("RoundGroup", "RoundKey");
+    EXPECT_EQ(got.toString().toStdString(), "roundVal");
+}
+
+TEST(ConfigManagerTest, SyncAppAttributeDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ConfigManager::instance()->syncAppAttribute());
+}
+
+TEST(ConfigManagerTest, AppSettingReturnsNonNull)
+{
+    EXPECT_NE(ConfigManager::instance()->appSetting(), nullptr);
+}

--- a/tests/coop/reportlog_test.cpp
+++ b/tests/coop/reportlog_test.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 注:src/base/reportlog 与 dfmplugin/reportlog 是相同 vendored 副本(同 guard 同类)。
+// coop_tests 已 glob src/base 版,故测 src/base 版免 include guard 碰撞。
+// 不调 ReportLogManager::init()——它会 new ReportLogWorker 并加载 eventlog .so。
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QVariantMap>
+#include <QJsonObject>
+#include "base/reportlog/reportlogmanager.h"
+#include "base/reportlog/reportlogworker.h"
+#include "base/reportlog/datas/cooperationreportdata.h"
+
+using deepin_cross::ReportLogManager;
+using deepin_cross::ReportLogWorker;
+using deepin_cross::StatusReportData;
+using deepin_cross::FileDeliveryReportData;
+using deepin_cross::ConnectionReportData;
+
+// ============ StatusReportData ============
+
+TEST(StatusReportDataTest, TypeReturnsCooperationStatus)
+{
+    StatusReportData d;
+    EXPECT_EQ(d.type().toStdString(), "CooperationStatus");
+}
+
+TEST(StatusReportDataTest, PrepareDataInsertsTid)
+{
+    StatusReportData d;
+    QJsonObject obj = d.prepareData(QVariantMap{});
+    EXPECT_EQ(obj.value("tid").toInt(), 1000800000);
+    // mergeCommonAttributes 总会插入 sysTime/machineID。
+    EXPECT_FALSE(obj.value("sysTime").toString().isEmpty());
+}
+
+// ============ FileDeliveryReportData ============
+
+TEST(FileDeliveryReportDataTest, TypeReturnsFileDelivery)
+{
+    FileDeliveryReportData d;
+    EXPECT_EQ(d.type().toStdString(), "FileDelivery");
+}
+
+TEST(FileDeliveryReportDataTest, PrepareDataInsertsTid)
+{
+    FileDeliveryReportData d;
+    QJsonObject obj = d.prepareData(QVariantMap{});
+    EXPECT_EQ(obj.value("tid").toInt(), 1000800001);
+}
+
+// ============ ConnectionReportData ============
+
+TEST(ConnectionReportDataTest, TypeReturnsConnectionInfo)
+{
+    ConnectionReportData d;
+    EXPECT_EQ(d.type().toStdString(), "ConnectionInfo");
+}
+
+TEST(ConnectionReportDataTest, PrepareDataInsertsTid)
+{
+    ConnectionReportData d;
+    QJsonObject obj = d.prepareData(QVariantMap{});
+    EXPECT_EQ(obj.value("tid").toInt(), 1000800002);
+}
+
+// prepareData 应把调用方传入的 args 合并进结果。
+TEST(ConnectionReportDataTest, PrepareDataMergesCallerArgs)
+{
+    ConnectionReportData d;
+    QVariantMap args{{"customKey", "customVal"}};
+    QJsonObject obj = d.prepareData(args);
+    EXPECT_EQ(obj.value("customKey").toString().toStdString(), "customVal");
+}
+
+// ============ ReportLogManager ============
+
+TEST(ReportLogManagerTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(ReportLogManager::instance(), ReportLogManager::instance());
+}
+
+// commit() 同步 emit requestCommitLog(未 init 时信号无接收者,QSignalSpy 可捕获)。
+TEST(ReportLogManagerTest, CommitEmitsRequestCommitLog)
+{
+    QSignalSpy spy(ReportLogManager::instance(), &ReportLogManager::requestCommitLog);
+    QVariantMap args{{"k", "v"}};
+    ReportLogManager::instance()->commit("CooperationStatus", args);
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> payload = spy.takeFirst();
+    EXPECT_EQ(payload.at(0).toString().toStdString(), "CooperationStatus");
+}
+
+// ============ ReportLogWorker ============
+// 公有构造,可直接实例化;commitLog 未注册类型走 "not registed" 早返回。
+
+TEST(ReportLogWorkerTest, CommitLogWithUnregisteredTypeDoesNotCrash)
+{
+    ReportLogWorker worker;
+    worker.commitLog("UnregisteredType", QVariantMap{{"k", "v"}});
+    SUCCEED();
+}

--- a/tests/coop/sharecooperationservice_test.cpp
+++ b/tests/coop/sharecooperationservice_test.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QCoreApplication>
+#include "lib/cooperation/core/share/sharecooperationservice.h"
+#include "lib/cooperation/core/share/sharecooperationservicemanager.h"
+#include "lib/cooperation/core/discover/deviceinfo.h"
+
+using ::ShareCooperationService;
+using ::ShareCooperationServiceManager;
+using ::BarrierType;
+using ::ShareServerConfig;
+using ::DeviceInfoPointer;
+using cooperation_core::DeviceInfo;
+
+// ============ ShareCooperationService ============
+// Manager 构造时:client()->setBarrierType(Client),server()->setBarrierType(Server)。
+// 单例由 Manager 持有 QSharedPointer,经 client()/server() 取得。
+
+// getter:client 实例为 Client,server 实例为 Server(覆盖 barrierType + Manager 装配)。
+TEST(ShareCooperationServiceTest, ClientInstanceIsClientType)
+{
+    EXPECT_EQ(ShareCooperationServiceManager::instance()->client()->barrierType(), BarrierType::Client);
+}
+
+TEST(ShareCooperationServiceTest, ServerInstanceIsServerType)
+{
+    EXPECT_EQ(ShareCooperationServiceManager::instance()->server()->barrierType(), BarrierType::Server);
+}
+
+// setBarrierType 往返(注意:内部会调 terminateAllBarriers 跑 pkill,同步快速返回)。
+TEST(ShareCooperationServiceTest, SetBarrierTypeRoundTrip)
+{
+    auto svc = ShareCooperationServiceManager::instance()->server();
+    svc->setBarrierType(BarrierType::Server);
+    EXPECT_EQ(svc->barrierType(), BarrierType::Server);
+    svc->setBarrierType(BarrierType::Client);
+    EXPECT_EQ(svc->barrierType(), BarrierType::Client);
+    svc->setBarrierType(BarrierType::Server);  // 还原,保持 server 实例语义
+    EXPECT_EQ(svc->barrierType(), BarrierType::Server);
+}
+
+// 无进程时 isRunning() 必为 false。
+TEST(ShareCooperationServiceTest, IsRunningInitiallyFalse)
+{
+    EXPECT_FALSE(ShareCooperationServiceManager::instance()->server()->isRunning());
+}
+
+// 纯 setter:委托给 CooConfig,不崩即可。
+TEST(ShareCooperationServiceTest, SetClientTargetIpDoesNotCrash)
+{
+    ShareCooperationServiceManager::instance()->client()->setClientTargetIp("10.0.0.1");
+    SUCCEED();
+}
+
+TEST(ShareCooperationServiceTest, SetEnableCryptoDoesNotCrash)
+{
+    auto svc = ShareCooperationServiceManager::instance()->client();
+    svc->setEnableCrypto(true);
+    svc->setEnableCrypto(false);
+    SUCCEED();
+}
+
+// setBarrierProfile 传入不存在的深层子目录,触发 pdir.exists()==false → mkpath 分支。
+TEST(ShareCooperationServiceTest, SetBarrierProfileCreatesNonExistentDir)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QString deep = tmp.path() + "/sub/deep";  // 不存在
+    ShareCooperationServiceManager::instance()->server()->setBarrierProfile(deep);
+    EXPECT_TRUE(QDir(deep).exists());
+}
+
+// setServerConfig(ShareServerConfig) 三分支:
+// (a) client 实例(Client 类型)→ 立即 false。
+TEST(ShareCooperationServiceTest, SetServerConfigClientReturnsFalse)
+{
+    ShareServerConfig cfg;
+    EXPECT_FALSE(ShareCooperationServiceManager::instance()->client()->setServerConfig(cfg));
+}
+
+// (b) server 实例但 screen_left/right 空 → checkParam false → false。
+TEST(ShareCooperationServiceTest, SetServerConfigServerEmptyScreensReturnsFalse)
+{
+    ShareServerConfig cfg;  // screen_left/screen_right 默认空
+    EXPECT_FALSE(ShareCooperationServiceManager::instance()->server()->setServerConfig(cfg));
+}
+
+// (c) server 实例 + 有效 screen → 写文件成功 → true。
+// 连带执行 setScreen/setScreenLink/setScreenOptions(~90 行纯逻辑)。
+TEST(ShareCooperationServiceTest, SetServerConfigServerValidWritesFileReturnsTrue)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    auto svc = ShareCooperationServiceManager::instance()->server();
+    svc->setBarrierProfile(tmp.path());  // 保证 configFilename 落在可写临时目录
+    ShareServerConfig cfg;
+    cfg.screen_left = "10.0.0.1";
+    cfg.screen_right = "10.0.0.2";
+    EXPECT_TRUE(svc->setServerConfig(cfg));
+}
+
+// setServerConfig(DeviceInfoPointer, DeviceInfoPointer):据设备 linkMode 组装 config 再写文件。
+TEST(ShareCooperationServiceTest, SetServerConfigFromDevicesDoesNotCrash)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    auto svc = ShareCooperationServiceManager::instance()->server();
+    svc->setBarrierProfile(tmp.path());
+    DeviceInfoPointer self(new DeviceInfo("10.0.0.1", "Self"));
+    DeviceInfoPointer target(new DeviceInfo("10.0.0.2", "Target"));
+    EXPECT_NO_FATAL_FAILURE(svc->setServerConfig(self, target));
+}
+
+// stopBarrier 无进程时走 terminateAllBarriers(pkill) 分支。
+TEST(ShareCooperationServiceTest, StopBarrierNoProcessDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ShareCooperationServiceManager::instance()->server()->stopBarrier());
+}
+
+// terminateAllBarriers 在无 barrier 进程时同步快速返回。
+TEST(ShareCooperationServiceTest, TerminateAllBarriersDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ShareCooperationServiceManager::instance()->server()->terminateAllBarriers());
+}
+
+// ============ ShareCooperationServiceManager ============
+
+TEST(ShareCooperationServiceManagerTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(ShareCooperationServiceManager::instance(), ShareCooperationServiceManager::instance());
+}
+
+TEST(ShareCooperationServiceManagerTest, ClientReturnsNonNull)
+{
+    EXPECT_NE(ShareCooperationServiceManager::instance()->client(), nullptr);
+}
+
+TEST(ShareCooperationServiceManagerTest, ServerReturnsNonNull)
+{
+    EXPECT_NE(ShareCooperationServiceManager::instance()->server(), nullptr);
+}
+
+TEST(ShareCooperationServiceManagerTest, BarrierProfileReturnsNonEmpty)
+{
+    EXPECT_FALSE(ShareCooperationServiceManager::instance()->barrierProfile().isEmpty());
+}
+
+// stop():同步执行 client->stopBarrier + setClientTargetIp("") + emit stopShareServer(queued)。
+// 紧接 processEvents 触发排队槽 handleStopShareSever → _server->stopBarrier(pkill,无进程安全)。
+// 关键:此测试必须排在 StartServer 测试之前,否则 pending 的 startShareServer 会被一并触发。
+TEST(ShareCooperationServiceManagerTest, StopAndProcessEventsCoverHandleStopShareSever)
+{
+    EXPECT_NO_FATAL_FAILURE(ShareCooperationServiceManager::instance()->stop());
+    QCoreApplication::processEvents();  // flush 排队的 stopShareServer → handleStopShareSever
+    SUCCEED();
+}
+
+// stopServer() 仅 emit(queued)。
+TEST(ShareCooperationServiceManagerTest, StopServerDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ShareCooperationServiceManager::instance()->stopServer());
+}
+
+// startServer():同步 emit startShareServer(queued) + return true。
+// 排队槽 handleStartShareSever 会 spawn 进程,故本测试排在最后且不 spin 事件循环,
+// pending 事件在进程退出时被安全丢弃(gtest 不跑 Qt 事件循环)。
+TEST(ShareCooperationServiceManagerTest, StartServerEmitsAndReturnsTrue)
+{
+    EXPECT_TRUE(ShareCooperationServiceManager::instance()->startServer("msg"));
+}


### PR DESCRIPTION
…anager、reportlog

新增 3 个 logic 测试文件,覆盖 Phase 2A Task 5/7/8:

ShareCooperationService/Manager (sharecooperationservice_test.cpp, 20 用例):
- setServerConfig 三分支(Client→false / 空 screen→false / 有效→写文件 true), 连带 setScreen/setScreenLink/setScreenOptions;stop()+processEvents 触发排队槽 handleStopShareSever;barrierType/getter/setter/terminateAllBarriers。
- service 50.9% / manager 45.7% 覆盖率。

DConfigManager/ConfigManager (dfmconfig_test.cpp, 14 用例):
- dfmplugin 版与 src/configs 版同 guard 同类(vendored 副本),测 src/configs 版 免 include guard 碰撞。DConfigManager 未知 config 早返回;ConfigManager setAppAttribute RoundTrip;appAttributeEdited 经 file watcher 异步,不强制断言。

reportlog (reportlog_test.cpp, 10 用例):
- src/base/reportlog 与 dfmplugin 版同 guard,测 src/base 版。3 个数据类 type/prepareData(tid)+mergeCommonAttributes 100% 覆盖;ReportLogManager::commit 同步发 requestCommitLog;ReportLogWorker commitLog 未注册类型安全返回。 不调 init() 避免 .so 加载。

coop_tests 174/174 PASS。