### PR TITLE
test(coop_gui): 覆盖 DeviceItem、CooperationStateWidget、VncViewer 纯逻辑

### DIFF
--- a/tests/coop_gui/CMakeLists.txt
+++ b/tests/coop_gui/CMakeLists.txt
@@ -47,7 +47,10 @@ add_executable(coop_gui_tests ${COOP_GUI_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/devicelistwidget_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/filechooseredit_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cooperationdialog_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cooperationtaskdialog_test.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/cooperationtaskdialog_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/deviceitem_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cooperationstatewidget_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/vncviewer_test.cpp)
 target_compile_options(coop_gui_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_gui_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_gui_tests PRIVATE

--- a/tests/coop_gui/cooperationstatewidget_test.cpp
+++ b/tests/coop_gui/cooperationstatewidget_test.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include "gui/widgets/cooperationstatewidget.h"
+
+using cooperation_core::LookingForDeviceWidget;
+using cooperation_core::NoNetworkWidget;
+using cooperation_core::NoResultTipWidget;
+using cooperation_core::NoResultWidget;
+using cooperation_core::BottomLabel;
+
+// ============ LookingForDeviceWidget ============
+
+TEST(LookingForDeviceWidgetTest, ConstructDoesNotCrash)
+{
+    LookingForDeviceWidget w;
+    SUCCEED();
+}
+
+// seAnimationtEnabled 三分支:enable / disable / 相同早返回。
+TEST(LookingForDeviceWidgetTest, SeAnimationtEnabledTogglesTimer)
+{
+    LookingForDeviceWidget w;
+    w.seAnimationtEnabled(true);   // 启动
+    w.seAnimationtEnabled(true);   // 相同 → 早返回
+    w.seAnimationtEnabled(false);  // 停止
+    SUCCEED();
+}
+
+// paintEvent 在 isEnabled=true 时绘制动画梯度;offscreen 下 show+repaint 触发。
+TEST(LookingForDeviceWidgetTest, PaintEventWithAnimationDoesNotCrash)
+{
+    LookingForDeviceWidget w;
+    w.resize(300, 300);
+    w.seAnimationtEnabled(true);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}
+
+// ============ NoNetworkWidget ============
+
+TEST(NoNetworkWidgetTest, ConstructDoesNotCrash)
+{
+    NoNetworkWidget w;
+    SUCCEED();
+}
+
+// ============ NoResultTipWidget ============
+// ctor 4 种组合覆盖 useTipMode/isMobile 分支。
+
+TEST(NoResultTipWidgetTest, ConstructDefaultsDoesNotCrash)
+{
+    NoResultTipWidget w;
+    SUCCEED();
+}
+
+TEST(NoResultTipWidgetTest, ConstructTipModeDoesNotCrash)
+{
+    NoResultTipWidget w(nullptr, true);
+    SUCCEED();
+}
+
+TEST(NoResultTipWidgetTest, ConstructMobileDoesNotCrash)
+{
+    NoResultTipWidget w(nullptr, false, true);
+    SUCCEED();
+}
+
+TEST(NoResultTipWidgetTest, ConstructTipAndMobileDoesNotCrash)
+{
+    NoResultTipWidget w(nullptr, true, true);
+    SUCCEED();
+}
+
+TEST(NoResultTipWidgetTest, SetTitleVisibleDoesNotCrash)
+{
+    NoResultTipWidget w;
+    w.setTitleVisible(true);
+    w.setTitleVisible(false);
+    SUCCEED();
+}
+
+// onLinkActivated 调 QDesktopServices::openUrl;offscreen/headless 下通常无害。
+TEST(NoResultTipWidgetTest, OnLinkActivatedDoesNotCrash)
+{
+    NoResultTipWidget w;
+    EXPECT_NO_FATAL_FAILURE(w.onLinkActivated("https://example.com"));
+}
+
+// ============ NoResultWidget ============
+
+TEST(NoResultWidgetTest, ConstructDoesNotCrash)
+{
+    NoResultWidget w;
+    SUCCEED();
+}
+
+// ============ BottomLabel ============
+
+TEST(BottomLabelTest, ConstructDoesNotCrash)
+{
+    BottomLabel w;
+    SUCCEED();
+}
+
+TEST(BottomLabelTest, SetIpDoesNotCrash)
+{
+    BottomLabel w;
+    w.setIp("10.0.0.1");
+    SUCCEED();
+}
+
+// showDialog 非模态(Qt::Tool),offscreen 安全。
+TEST(BottomLabelTest, ShowDialogDoesNotCrash)
+{
+    BottomLabel w;
+    EXPECT_NO_FATAL_FAILURE(w.showDialog());
+}
+
+// onSwitchMode:page>1 早返回;0/1 走 setCurrentIndex。
+TEST(BottomLabelTest, OnSwitchModeValidAndInvalidDoesNotCrash)
+{
+    BottomLabel w;
+    w.onSwitchMode(0);
+    w.onSwitchMode(1);
+    w.onSwitchMode(2);  // >1 → 早返回
+    SUCCEED();
+}
+
+// paintEvent 画顶部分隔线;show+repaint 触发。
+TEST(BottomLabelTest, PaintEventDoesNotCrash)
+{
+    BottomLabel w;
+    w.resize(200, 40);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}

--- a/tests/coop_gui/deviceitem_test.cpp
+++ b/tests/coop_gui/deviceitem_test.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QEvent>
+#include <QShowEvent>
+#include <QCoreApplication>
+#include "gui/widgets/deviceitem.h"
+#include "discover/deviceinfo.h"
+#include "addr_pri.h"
+
+using cooperation_core::DeviceItem;
+using cooperation_core::DeviceInfo;
+using ::DeviceInfoPointer;
+
+// 访问私有 indexOperaMap,用于确定性触发 onButtonClicked 的 clickedCb 分支。
+using IndexOperaMap = QMap<int, DeviceItem::Operation>;
+ACCESS_PRIVATE_FIELD(DeviceItem, IndexOperaMap, indexOperaMap)
+
+// 构造一个最小 Operation(三类回调齐备)。
+static DeviceItem::Operation makeOp(const QString &id, bool *clickedFlag)
+{
+    DeviceItem::Operation op;
+    op.id = id;
+    op.description = id;
+    op.icon = "";
+    op.location = 0;
+    op.style = 0;
+    op.visibleCb = [](const QString &, const DeviceInfoPointer) { return true; };
+    op.clickableCb = [](const QString &, const DeviceInfoPointer) { return true; };
+    op.clickedCb = [clickedFlag](const QString &, const DeviceInfoPointer) {
+        if (clickedFlag) *clickedFlag = true;
+    };
+    return op;
+}
+
+// ============ StateLabel ============
+
+TEST(StateLabelTest, SetStateAndGetReturnsSame)
+{
+    cooperation_core::StateLabel label;
+    label.setState(DeviceInfo::Connected);
+    EXPECT_EQ(label.state(), DeviceInfo::Connected);
+    label.setState(DeviceInfo::Offline);
+    EXPECT_EQ(label.state(), DeviceInfo::Offline);
+}
+
+// paintEvent 三分支(Connected/Connectable/Offline)。offscreen 下需 show 进入可见态
+// 才能让 repaint 真正触发 paintEvent。
+TEST(StateLabelTest, PaintEventAllStatusesDoNotCrash)
+{
+    cooperation_core::StateLabel label;
+    label.resize(80, 24);
+    label.setText("connected");
+    label.show();
+    QTest::qWait(20);
+    for (auto s : {DeviceInfo::Connected, DeviceInfo::Connectable, DeviceInfo::Offline}) {
+        label.setState(s);
+        EXPECT_NO_FATAL_FAILURE(label.repaint());
+    }
+}
+
+// ============ DeviceItem ============
+
+TEST(DeviceItemTest, IsAliveInitiallyTrue)
+{
+    DeviceItem item;
+    EXPECT_TRUE(item.isAlive());
+}
+
+TEST(DeviceItemTest, SetDeviceInfoAndGetReturnsSame)
+{
+    DeviceItem item;
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.1", "DevA"));
+    item.setDeviceInfo(info);
+    auto got = item.deviceInfo();
+    ASSERT_NE(got, nullptr);
+    EXPECT_EQ(got->ipAddress().toStdString(), "10.0.0.1");
+    EXPECT_EQ(got->deviceName().toStdString(), "DevA");
+}
+
+// setDeviceStatus 三分支(Connected/Connectable/Offline)经 setDeviceInfo 触发,
+// 覆盖 setDeviceStatus + QIcon::fromTheme + stateLabel setText。
+TEST(DeviceItemTest, SetDeviceInfoWithAllConnectStatusesDoesNotCrash)
+{
+    for (auto status : {DeviceInfo::Connected, DeviceInfo::Connectable, DeviceInfo::Offline}) {
+        DeviceItem item;
+        DeviceInfoPointer info(new DeviceInfo("10.0.0.2", "DevS"));
+        info->setConnectStatus(status);
+        EXPECT_NO_FATAL_FAILURE(item.setDeviceInfo(info));
+    }
+}
+
+TEST(DeviceItemTest, SetOperationsAndUpdateOperationsDoNotCrash)
+{
+    DeviceItem item;
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.3", "DevO"));
+    item.setDeviceInfo(info);
+    bool clicked = false;
+    item.setOperations({makeOp("op1", &clicked)});
+    EXPECT_NO_FATAL_FAILURE(item.updateOperations());
+}
+
+// onButtonClicked 无效 index → 早返回不崩。
+TEST(DeviceItemTest, OnButtonClickedInvalidIndexDoesNotCrash)
+{
+    DeviceItem item;
+    EXPECT_NO_FATAL_FAILURE(item.onButtonClicked(-1));
+    EXPECT_NO_FATAL_FAILURE(item.onButtonClicked(999));
+}
+
+// onButtonClicked 有效 index → clickedCb 被调用(经 ACCESS_PRIVATE_FIELD 取真实 key)。
+TEST(DeviceItemTest, OnButtonClickedValidIndexInvokesClickedCb)
+{
+    DeviceItem item;
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.4", "DevC"));
+    item.setDeviceInfo(info);
+    bool clicked = false;
+    item.setOperations({makeOp("op-click", &clicked)});
+
+    auto &map = access_private_field::DeviceItemindexOperaMap(item);
+    QList<int> keys = map.keys();
+    ASSERT_FALSE(keys.isEmpty());
+    EXPECT_NO_FATAL_FAILURE(item.onButtonClicked(keys.first()));
+    EXPECT_TRUE(clicked);
+}
+
+// 长设备名经 QFontMetrics::elidedText 截断,触发 setToolTip 分支。
+TEST(DeviceItemTest, SetDeviceInfoWithLongNameTruncates)
+{
+    DeviceItem item;
+    QString longName(200, QChar('X'));
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.5", longName));
+    EXPECT_NO_FATAL_FAILURE(item.setDeviceInfo(info));
+}
+
+// 多个 operation 触发 setOperations 的 sort 比较器。
+TEST(DeviceItemTest, SetOperationsMultipleTriggersSort)
+{
+    DeviceItem item;
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.6", "DevM"));
+    item.setDeviceInfo(info);
+    bool c1 = false, c2 = false;
+    DeviceItem::Operation opA = makeOp("opA", &c1);
+    opA.location = 1;
+    DeviceItem::Operation opB = makeOp("opB", &c2);
+    opB.location = 0;
+    EXPECT_NO_FATAL_FAILURE(item.setOperations({opA, opB}));
+}
+
+// operation 无回调时 updateOperations 走 continue 分支(visibleCb/clickableCb 为空)。
+TEST(DeviceItemTest, UpdateOperationsWithNullCallbacksDoesNotCrash)
+{
+    DeviceItem item;
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.7", "DevN"));
+    item.setDeviceInfo(info);
+    DeviceItem::Operation op;  // 三回调默认构造为空
+    op.id = "null-op";
+    op.location = 0;
+    op.style = 0;
+    item.setOperations({op});
+    EXPECT_NO_FATAL_FAILURE(item.updateOperations());
+}
+
+// leaveEvent(QEvent)/showEvent(QShowEvent) 经 sendEvent 触发覆盖。
+TEST(DeviceItemTest, LeaveAndShowEventsDoNotCrash)
+{
+    DeviceItem item;
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.8", "DevE"));
+    item.setDeviceInfo(info);
+    QEvent leave(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(&item, &leave));
+    QShowEvent show;
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(&item, &show));
+}

--- a/tests/coop_gui/vncviewer_test.cpp
+++ b/tests/coop_gui/vncviewer_test.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 只测 VncViewer 纯逻辑(translateMouseButton/setMobileRealSize/onSizeChange/onShortcutAction),
+// 跳过 socket/线程方法(start/stop/frameTimerTimeout/updateImage/paintEvent/mouse*)。
+// BACK/HOME/RECENTS 枚举值在 vncviewer.cpp 匿名命名空间(BACK=0/HOME=1/RECENTS=2),用字面量。
+// PORTRAIT=0/LANDSCAPE=1。SendKeyEvent 经 stub.h 替换避免真实 rfb 调用。
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QSize>
+#include <rfb/rfbclient.h>
+#include <rfb/keysym.h>
+#include "gui/phone/vncviewer.h"
+#include "addr_pri.h"
+#include "stub.h"
+
+using cooperation_core::VncViewer;
+
+// 访问私有成员,用于注入 m_connected/m_realSize/m_phoneScale/m_phoneMode/m_rfbCli。
+ACCESS_PRIVATE_FIELD(VncViewer, bool, m_connected)
+ACCESS_PRIVATE_FIELD(VncViewer, QSize, m_realSize)
+ACCESS_PRIVATE_FIELD(VncViewer, qreal, m_phoneScale)
+ACCESS_PRIVATE_FIELD(VncViewer, int, m_phoneMode)
+ACCESS_PRIVATE_FIELD(VncViewer, rfbClient *, m_rfbCli)
+
+// translateMouseButton 是 protected,经子类 wrapper 暴露。
+class VncViewerAccessor : public VncViewer
+{
+public:
+    using VncViewer::translateMouseButton;
+};
+
+// ============ translateMouseButton ============
+
+TEST(VncViewerTranslateMouseButtonTest, LeftMapsToRfbButton1)
+{
+    VncViewerAccessor v;
+    EXPECT_EQ(v.translateMouseButton(Qt::LeftButton), rfbButton1Mask);
+}
+
+TEST(VncViewerTranslateMouseButtonTest, MiddleMapsToRfbButton2)
+{
+    VncViewerAccessor v;
+    EXPECT_EQ(v.translateMouseButton(Qt::MiddleButton), rfbButton2Mask);
+}
+
+TEST(VncViewerTranslateMouseButtonTest, RightMapsToRfbButton3)
+{
+    VncViewerAccessor v;
+    EXPECT_EQ(v.translateMouseButton(Qt::RightButton), rfbButton3Mask);
+}
+
+TEST(VncViewerTranslateMouseButtonTest, UnknownReturnsZero)
+{
+    VncViewerAccessor v;
+    EXPECT_EQ(v.translateMouseButton(Qt::NoButton), 0);
+}
+
+// ============ setMobileRealSize ============
+
+TEST(VncViewerTest, SetMobileRealSizeKeepsPortraitWhenWH)
+{
+    VncViewer v;
+    v.setMobileRealSize(1080, 2400);  // w<h 保持
+    auto &real = access_private_field::VncViewerm_realSize(v);
+    EXPECT_EQ(real.width(), 1080);
+    EXPECT_EQ(real.height(), 2400);
+}
+
+TEST(VncViewerTest, SetMobileRealSizeSwapsWhenWGreaterThanH)
+{
+    VncViewer v;
+    v.setMobileRealSize(2400, 1080);  // w>h 交换成竖屏
+    auto &real = access_private_field::VncViewerm_realSize(v);
+    EXPECT_EQ(real.width(), 1080);
+    EXPECT_EQ(real.height(), 2400);
+}
+
+// ============ onSizeChange ============
+
+// m_connected=false → 早返回,不发 sizeChanged。
+TEST(VncViewerTest, OnSizeChangeReturnsEarlyWhenNotConnected)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = false;
+    QSignalSpy spy(&v, &VncViewer::sizeChanged);
+    v.onSizeChange(100, 200);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// m_connected=true + 模式从 LANDSCAPE 变 PORTRAIT → emit sizeChanged。
+TEST(VncViewerTest, OnSizeChangeEmitsWhenConnectedAndRotated)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = true;
+    access_private_field::VncViewerm_realSize(v) = QSize(1080, 2400);
+    access_private_field::VncViewerm_phoneScale(v) = 0.5;
+    access_private_field::VncViewerm_phoneMode(v) = 1;  // LANDSCAPE,触发模式切换
+    QSignalSpy spy(&v, &VncViewer::sizeChanged);
+    v.onSizeChange(100, 200);  // 100<200 → PORTRAIT,与 LANDSCAPE 不同
+    EXPECT_GE(spy.count(), 1);
+}
+
+// ============ onShortcutAction ============
+// BACK=0/HOME=1/RECENTS=2(匿名命名空间枚举值)。
+
+// m_connected=false → 早返回。
+TEST(VncViewerTest, OnShortcutActionReturnsEarlyWhenNotConnected)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = false;
+    EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(0));  // BACK
+    SUCCEED();
+}
+
+// m_connected=true + 未知 action → switch default,key=0,不调 SendKeyEvent。
+TEST(VncViewerTest, OnShortcutActionUnknownActionDoesNotCallSendKey)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = true;
+    EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(999));  // 未知 → default → key=0
+    SUCCEED();
+}
+
+// stub SendKeyEvent(libvncclient 自由函数),覆盖 BACK/HOME/RECENTS switch 分支。
+static rfbBool stub_SendKeyEvent(rfbClient *, uint32_t, rfbBool) { return true; }
+
+TEST(VncViewerTest, OnShortcutActionBackHomeRecentsWithStubbedSendKey)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = true;
+    access_private_field::VncViewerm_rfbCli(v) = reinterpret_cast<rfbClient *>(0x1);  // 非空占位
+
+    Stub stub;
+    stub.set(SendKeyEvent, stub_SendKeyEvent);
+    EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(0));  // BACK → Escape
+    EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(1));  // HOME → Home
+    EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(2));  // RECENTS → PageUp
+}


### PR DESCRIPTION
新增 3 个 GUI 测试文件,覆盖 Phase 2A Task 9/10/11:

DeviceItem (deviceitem_test.cpp, 12 用例):
- StateLabel setState/state + paintEvent 三分支(show+qWait+repaint);
- DeviceItem setDeviceInfo round-trip、setDeviceStatus 三分支、 setOperations+updateOperations、onButtonClicked 有效/无效 index(经 ACCESS_PRIVATE_FIELD 取 indexOperaMap key 确定性触发 clickedCb);
- 长名截断、多 op 排序、null 回调 continue、leave/show 事件。
- deviceitem.cpp ~81% 覆盖。

CooperationStateWidget (cooperationstatewidget_test.cpp, 16 用例):
- 5 widget 类:LookingForDeviceWidget(seAnimationtEnabled 三分支+paintEvent)、 NoNetworkWidget、NoResultTipWidget(4 ctor 组合+onLinkActivated+setTitleVisible)、 NoResultWidget、BottomLabel(setIp+showDialog+onSwitchMode 有效/无效+paintEvent)。
- cooperationstatewidget.cpp ~92% 覆盖。

VncViewer (vncviewer_test.cpp, 11 用例):
- 只测纯逻辑:translateMouseButton(子类 wrapper,4 case)、setMobileRealSize、 onSizeChange(guard+rotation)、onShortcutAction(guard+unknown+BACK/HOME/RECENTS);
- ACCESS_PRIVATE_FIELD 注入 m_connected/m_realSize/m_phoneScale/m_phoneMode/m_rfbCli, stub.h 替换 SendKeyEvent 覆盖 3 个 switch case。socket/线程方法按计划跳过。
- 4 目标方法 ~90% 覆盖。

coop_gui_tests 96/96 PASS。