### PR TITLE
test(coop_gui): 覆盖 WorkspaceWidget、SettingItem、FirstTipWidget

### DIFF
--- a/tests/coop_gui/CMakeLists.txt
+++ b/tests/coop_gui/CMakeLists.txt
@@ -50,7 +50,10 @@ add_executable(coop_gui_tests ${COOP_GUI_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/cooperationtaskdialog_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/deviceitem_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cooperationstatewidget_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/vncviewer_test.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/vncviewer_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/workspacewidget_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/settingitem_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/firsttipwidget_test.cpp)
 target_compile_options(coop_gui_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_gui_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_gui_tests PRIVATE

--- a/tests/coop_gui/firsttipwidget_test.cpp
+++ b/tests/coop_gui/firsttipwidget_test.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QEvent>
+#include <QHideEvent>
+#include <QResizeEvent>
+#include <QCoreApplication>
+#include "gui/widgets/firsttipwidget.h"
+
+using cooperation_core::FirstTipWidget;
+using cooperation_core::LineWidget;
+using cooperation_core::ElidedLabel;
+
+TEST(FirstTipWidgetTest, ConstructDoesNotCrash)
+{
+    FirstTipWidget w;
+    SUCCEED();
+}
+
+// themeTypeChanged() 公共方法,读 isDarkTheme 切换明暗分支。
+TEST(FirstTipWidgetTest, ThemeTypeChangedDoesNotCrash)
+{
+    FirstTipWidget w;
+    EXPECT_NO_FATAL_FAILURE(w.themeTypeChanged());
+}
+
+// showEvent 调 drawLine + 定位 close 按钮;hideEvent/resizeEvent 经 show/sendEvent。
+TEST(FirstTipWidgetTest, ShowHideResizeEventsDoNotCrash)
+{
+    FirstTipWidget w;
+    w.resize(400, 300);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+
+    QHideEvent hide;
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(&w, &hide));
+
+    QResizeEvent resize(QSize(500, 400), QSize(400, 300));
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(&w, &resize));
+}
+
+// ============ LineWidget ============
+
+TEST(LineWidgetTest, PaintEventDoesNotCrash)
+{
+    LineWidget w;
+    w.resize(200, 4);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}
+
+// ============ ElidedLabel ============
+
+TEST(ElidedLabelTest, ConstructAndPaintDoesNotCrash)
+{
+    ElidedLabel label("some long text here", 100);
+    label.resize(120, 20);
+    label.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(label.repaint());
+}
+
+TEST(ElidedLabelTest, ShortTextPaintDoesNotCrash)
+{
+    ElidedLabel label("hi", 200);
+    label.resize(120, 20);
+    EXPECT_NO_FATAL_FAILURE(label.repaint());
+}

--- a/tests/coop_gui/settingitem_test.cpp
+++ b/tests/coop_gui/settingitem_test.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QLabel>
+#include "gui/widgets/settingitem.h"
+
+using cooperation_core::SettingItem;
+
+TEST(SettingItemTest, ConstructDoesNotCrash)
+{
+    SettingItem item;
+    SUCCEED();
+}
+
+TEST(SettingItemTest, SetItemInfoShortTextDoesNotCrash)
+{
+    SettingItem item;
+    QLabel w;
+    item.setItemInfo("short", &w);
+    SUCCEED();
+}
+
+// 长文本触发 QFontMetrics::elidedText 截断 + setToolTip 分支。
+TEST(SettingItemTest, SetItemInfoLongTextTruncates)
+{
+    SettingItem item;
+    QLabel w;
+    QString longText(200, QChar('X'));
+    EXPECT_NO_FATAL_FAILURE(item.setItemInfo(longText, &w));
+}
+
+// paintEvent 圆角路径填充;show+repaint 触发。
+TEST(SettingItemTest, PaintEventDoesNotCrash)
+{
+    SettingItem item;
+    item.resize(200, 48);
+    item.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(item.repaint());
+}

--- a/tests/coop_gui/workspacewidget_test.cpp
+++ b/tests/coop_gui/workspacewidget_test.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QCoreApplication>
+#include <QVariantMap>
+#include "gui/widgets/workspacewidget.h"
+#include "gui/widgets/workspacewidget_p.h"  // QScopedPointer<Private> 析构需完整类型
+#include "discover/deviceinfo.h"
+
+using cooperation_core::WorkspaceWidget;
+using cooperation_core::DeviceInfo;
+using ::DeviceInfoPointer;
+
+// WorkspaceWidget 构造时启动 SortFilterWorker 后台线程(处理 addDevice/filterDevice 等
+// queued 信号)。每个用例的 widget 析构时 quit+wait 该线程,清理干净。
+
+TEST(WorkspaceWidgetTest, ConstructAndInitialItemCountZero)
+{
+    WorkspaceWidget w;
+    EXPECT_EQ(w.itemCount(), 0);
+}
+
+// switchWidget 各页面分支:kLookignForDeviceWidget(动画+hide tip)/kNoNetworkWidget/
+// kNoResultWidget/kDeviceListWidget(show label+refresh)。
+TEST(WorkspaceWidgetTest, SwitchWidgetAllPagesDoesNotCrash)
+{
+    WorkspaceWidget w;
+    w.switchWidget(WorkspaceWidget::kLookignForDeviceWidget);
+    w.switchWidget(WorkspaceWidget::kNoNetworkWidget);
+    w.switchWidget(WorkspaceWidget::kNoResultWidget);
+    w.switchWidget(WorkspaceWidget::kDeviceListWidget);
+    SUCCEED();
+}
+
+// kUnknownPage → 早返回。
+TEST(WorkspaceWidgetTest, SwitchWidgetUnknownPageEarlyReturns)
+{
+    WorkspaceWidget w;
+    w.switchWidget(WorkspaceWidget::kUnknownPage);
+    SUCCEED();
+}
+
+// 切到同一页面 → 早返回(currentPage == page)。
+TEST(WorkspaceWidgetTest, SwitchWidgetSamePageEarlyReturns)
+{
+    WorkspaceWidget w;
+    w.switchWidget(WorkspaceWidget::kNoNetworkWidget);
+    w.switchWidget(WorkspaceWidget::kNoNetworkWidget);  // 同页 → 早返回
+    SUCCEED();
+}
+
+TEST(WorkspaceWidgetTest, FindDeviceInfoUnknownIpReturnsNull)
+{
+    WorkspaceWidget w;
+    EXPECT_EQ(w.findDeviceInfo("10.0.0.99"), nullptr);
+}
+
+TEST(WorkspaceWidgetTest, ClearWhenEmptyDoesNotCrash)
+{
+    WorkspaceWidget w;
+    EXPECT_NO_FATAL_FAILURE(w.clear());
+    EXPECT_EQ(w.itemCount(), 0);
+}
+
+TEST(WorkspaceWidgetTest, SetFirstStartTipDoesNotCrash)
+{
+    WorkspaceWidget w;
+    w.setFirstStartTip(true);
+    w.setFirstStartTip(false);
+    SUCCEED();
+}
+
+TEST(WorkspaceWidgetTest, AddDeviceOperationEmptyMapDoesNotCrash)
+{
+    WorkspaceWidget w;
+    EXPECT_NO_FATAL_FAILURE(w.addDeviceOperation(QVariantMap{}));
+    SUCCEED();
+}
+
+// addDeviceInfos/removeDeviceInfos 经 queued 连接到 SortFilterWorker 线程,
+// 这里只验不崩 + 排空事件循环,不强断言异步结果。
+TEST(WorkspaceWidgetTest, AddAndRemoveDeviceInfosDoesNotCrash)
+{
+    WorkspaceWidget w;
+    QList<DeviceInfoPointer> list{DeviceInfoPointer(new DeviceInfo("10.0.0.1", "DevA"))};
+    EXPECT_NO_FATAL_FAILURE(w.addDeviceInfos(list));
+    QCoreApplication::processEvents();
+    QTest::qWait(50);
+    EXPECT_NO_FATAL_FAILURE(w.removeDeviceInfos("10.0.0.1"));
+    QCoreApplication::processEvents();
+    QTest::qWait(50);
+    SUCCEED();
+}


### PR DESCRIPTION
新增 3 个 GUI 测试文件,Phase 2B 拓宽(均为 core/gui/widgets,0% 起步):

WorkspaceWidget (workspacewidget_test.cpp, 9 用例):
- 构造启 SortFilterWorker 后台线程;switchWidget 多分支 (kLookignForDevice/kNoNetwork/kNoResult/kDeviceList/kUnknownPage 早返回/ 同页早返回);itemCount/findDeviceInfo/clear/setFirstStartTip/addDeviceOperation; addDeviceInfos/removeDeviceInfos(queued,processEvents)。
- 测试 include 私有头 workspacewidget_p.h 解决 QScopedPointer<Private> 析构 incomplete type。0%→~76%。

SettingItem (settingitem_test.cpp, 4 用例):
- setItemInfo 短/长文本(截断+setToolTip 分支);paintEvent 圆角填充。0%→~98%。

FirstTipWidget (firsttipwidget_test.cpp, 6 用例):
- themeTypeChanged;show/hide/resize 事件(sendEvent);LineWidget paintEvent; ElidedLabel 构造+paint。0%→~89%。

coop_gui_tests 115/115 PASS。