### PR TITLE
test(coop_gui): 覆盖 MainWindow/PhoneWidget/SettingDialog 等 Phase 2B 第二批

### DIFF
--- a/tests/coop_gui/CMakeLists.txt
+++ b/tests/coop_gui/CMakeLists.txt
@@ -53,7 +53,12 @@ add_executable(coop_gui_tests ${COOP_GUI_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/vncviewer_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/workspacewidget_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/settingitem_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/firsttipwidget_test.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/firsttipwidget_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/phonewidget_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/settingdialog_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/discovercontroller_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/backgroundwidget_test.cpp)
 target_compile_options(coop_gui_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_gui_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_gui_tests PRIVATE

--- a/tests/coop_gui/backgroundwidget_test.cpp
+++ b/tests/coop_gui/backgroundwidget_test.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include "gui/widgets/backgroundwidget.h"
+
+// BackgroundWidget 在全局命名空间(QFrame)。
+
+// paintEvent 按 RoundRole(NoRole/Top/Bottom/TopAndBottom)走不同圆角路径;
+// 经 setBackground 设 role + show + repaint 触发各分支。
+
+TEST(BackgroundWidgetTest, setBackgroundTopAndBottomPaintDoesNotCrash)
+{
+    BackgroundWidget w;
+    w.setBackground(8, BackgroundWidget::NoType, BackgroundWidget::TopAndBottom);
+    w.resize(100, 40);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}
+
+TEST(BackgroundWidgetTest, setBackgroundTopPaintDoesNotCrash)
+{
+    BackgroundWidget w;
+    w.setBackground(8, BackgroundWidget::NoType, BackgroundWidget::Top);
+    w.resize(100, 40);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}
+
+TEST(BackgroundWidgetTest, setBackgroundBottomPaintDoesNotCrash)
+{
+    BackgroundWidget w;
+    w.setBackground(8, BackgroundWidget::NoType, BackgroundWidget::Bottom);
+    w.resize(100, 40);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}
+
+TEST(BackgroundWidgetTest, setBackgroundNoRolePaintDoesNotCrash)
+{
+    BackgroundWidget w;
+    w.setBackground(8, BackgroundWidget::NoType, BackgroundWidget::NoRole);
+    w.resize(100, 40);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}
+
+// ItemBackground 颜色类型分支。
+TEST(BackgroundWidgetTest, setBackgroundItemBackgroundPaintDoesNotCrash)
+{
+    BackgroundWidget w;
+    w.setBackground(17, BackgroundWidget::ItemBackground, BackgroundWidget::TopAndBottom);
+    w.resize(100, 40);
+    w.show();
+    QTest::qWait(20);
+    EXPECT_NO_FATAL_FAILURE(w.repaint());
+}

--- a/tests/coop_gui/discovercontroller_test.cpp
+++ b/tests/coop_gui/discovercontroller_test.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QVariantMap>
+#include <QMap>
+#include <QVariant>
+#include "discover/discovercontroller.h"
+#include "discover/deviceinfo.h"
+
+using cooperation_core::DiscoverController;
+using ::DeviceInfoPointer;
+
+// 只测非网络方法;init/publish/refresh/startDiscover 等 ZeroConf 网络操作跳过。
+
+TEST(DiscoverControllerTest, InstanceReturnsSameSingleton)
+{
+    EXPECT_EQ(DiscoverController::instance(), DiscoverController::instance());
+}
+
+TEST(DiscoverControllerTest, SelfInfoReturnsNonNull)
+{
+    DeviceInfoPointer info = DiscoverController::selfInfo();
+    EXPECT_NE(info, nullptr);
+}
+
+TEST(DiscoverControllerTest, IsZeroConfDaemonActiveReturnsBool)
+{
+    EXPECT_NO_FATAL_FAILURE({ bool v = DiscoverController::isZeroConfDaemonActive(); (void)v; });
+}
+
+// 空在线列表 → 未知 IP 返回 null。
+TEST(DiscoverControllerTest, FindDeviceByUnknownIpReturnsNull)
+{
+    EXPECT_EQ(DiscoverController::instance()->findDeviceByIP("0.0.0.0"), nullptr);
+}
+
+// 非匹配 group → 早返回。
+TEST(DiscoverControllerTest, OnAppAttributeChangedWrongGroupDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(
+        DiscoverController::instance()->onAppAttributeChanged("WrongGroup", "key", QVariant()));
+}
+
+TEST(DiscoverControllerTest, OnConnectHistoryUpdatedDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(DiscoverController::instance()->onConnectHistoryUpdated());
+}
+
+TEST(DiscoverControllerTest, UpdateHistoryDevicesEmptyMapDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(
+        DiscoverController::instance()->updateHistoryDevices(QMap<QString, QString>{}));
+}

--- a/tests/coop_gui/mainwindow_test.cpp
+++ b/tests/coop_gui/mainwindow_test.cpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QVariantMap>
+#include <QStringList>
+#include <QScopedPointer>
+#include <QCloseEvent>
+#include <QDialog>
+#include <QTimer>
+#include <QCoreApplication>
+#include "gui/mainwindow.h"
+#include "gui/mainwindow_p.h"
+#include "addr_pri.h"
+#include "discover/deviceinfo.h"
+
+using cooperation_core::MainWindow;
+using cooperation_core::MainWindowPrivate;
+using cooperation_core::DeviceInfo;
+using ::DeviceInfoPointer;
+
+// d 是 QScopedPointer<MainWindowPrivate>,含逗号需 typedef 消歧。
+using MWPrivatePtr = QScopedPointer<MainWindowPrivate>;
+ACCESS_PRIVATE_FIELD(MainWindow, MWPrivatePtr, d)
+
+// MainWindow 构造重(PIMPL + titlebar + moveCenter + initConnect 连 DiscoverController),
+// 用 EXPECT_NO_FATAL_FAILURE 包裹;slot 多委托 workspaceWidget/phoneWidget。
+
+class MainWindowTest : public ::testing::Test {
+protected:
+    MainWindow *w {nullptr};
+    void SetUp() override { w = new MainWindow(); }
+    void TearDown() override { delete w; }
+};
+
+TEST_F(MainWindowTest, ConstructDoesNotCrash)
+{
+    ASSERT_NE(w, nullptr);
+}
+
+TEST_F(MainWindowTest, SetFirstTipVisibleDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->setFirstTipVisible());
+}
+
+TEST_F(MainWindowTest, OnFindDeviceEmitsSearchDevice)
+{
+    QSignalSpy spy(w, &MainWindow::searchDevice);
+    w->onFindDevice("10.0.0.1");
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// onDiscoveryFinished:无发现 + 先前 onFindDevice 置 _userAction=true → 切 NoResult 页。
+TEST_F(MainWindowTest, OnDiscoveryFinishedNotFoundAfterUserActionDoesNotCrash)
+{
+    w->onFindDevice("10.0.0.2");  // 置 _userAction
+    EXPECT_NO_FATAL_FAILURE(w->onDiscoveryFinished(false));
+}
+
+TEST_F(MainWindowTest, OnDiscoveryFinishedFoundDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->onDiscoveryFinished(true));
+}
+
+TEST_F(MainWindowTest, OnSwitchModePcAndMobileDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->onSwitchMode(kPC));
+    EXPECT_NO_FATAL_FAILURE(w->onSwitchMode(kMobile));
+}
+
+TEST_F(MainWindowTest, RemoveDeviceDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->removeDevice("10.0.0.3"));
+}
+
+TEST_F(MainWindowTest, OnRegistOperationsEmptyMapDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->onRegistOperations(QVariantMap{}));
+}
+
+TEST_F(MainWindowTest, AddDeviceEmptyListDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->addDevice(QList<DeviceInfoPointer>{}));
+}
+
+// onLookingForDevices 查 CooperationUtil::localIPAddress 后切页。
+TEST_F(MainWindowTest, OnLookingForDevicesDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->onLookingForDevices());
+}
+
+TEST_F(MainWindowTest, OnlineStateChangedDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->onlineStateChanged("10.0.0.5"));
+    EXPECT_NO_FATAL_FAILURE(w->onlineStateChanged(""));  // 无效 IP 分支
+}
+
+TEST_F(MainWindowTest, AddMobileDeviceDoesNotCrash)
+{
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.6", "PhoneA"));
+    EXPECT_NO_FATAL_FAILURE(w->addMobileDevice(info));
+}
+
+TEST_F(MainWindowTest, MinimizedAPPDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->minimizedAPP());
+}
+
+// ENABLE_PHONE 下 public slot。
+TEST_F(MainWindowTest, DisconnectMobileDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->disconnectMobile());
+}
+
+TEST_F(MainWindowTest, OnSetQRCodeDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->onSetQRCode("some-qrcode-payload"));
+}
+
+// ============ MainWindowPrivate 私有方法深挖(经 ACCESS d 指针) ============
+
+static MainWindowPrivate *priv(MainWindow *w)
+{
+    return access_private_field::MainWindowd(*w).data();
+}
+
+// handleSettingMenuTriggered(kSettings):首次创建 SettingDialog;再次因 SettingDialogShown
+// 属性早返回。两个分支都覆盖。SettingDialog 父对象是 q,TearDown 随 MainWindow 析构。
+TEST_F(MainWindowTest, HandleSettingMenuSettingsCreatesDialogThenEarlyReturn)
+{
+    auto *p = priv(w);
+    EXPECT_NO_FATAL_FAILURE(p->handleSettingMenuTriggered(kSettings));   // 创建
+    EXPECT_NO_FATAL_FAILURE(p->handleSettingMenuTriggered(kSettings));   // 早返回
+}
+
+TEST_F(MainWindowTest, HandleSettingMenuDownloadWindowClientDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(priv(w)->handleSettingMenuTriggered(kDownloadWindowClient));
+}
+
+TEST_F(MainWindowTest, HandleSettingMenuDownloadMobileClientDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(priv(w)->handleSettingMenuTriggered(kDownloadMobileClient));
+}
+
+TEST_F(MainWindowTest, HandleSettingMenuUnknownActionDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(priv(w)->handleSettingMenuTriggered(999));
+}
+
+TEST_F(MainWindowTest, PrivateSetIPDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(priv(w)->setIP("10.0.0.7"));
+}
+
+TEST_F(MainWindowTest, PrivateMoveCenterDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(priv(w)->moveCenter());
+}
+
+// addMobileOperation(ENABLE_PHONE public)委托 phoneWidget->addOperation。
+TEST_F(MainWindowTest, AddMobileOperationDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(w->addMobileOperation(QVariantMap{}));
+}
+
+// closeEvent(onlyTransfer=false 默认)→ showCloseDialog → CooperationDialog::exec 阻塞。
+// 用 QTimer::singleShot 在 exec 事件循环内 reject 活动模态对话框,使 exec 返回 Rejected
+// (跳过 accept 分支,不 quit),closeEvent 继续 event->ignore。强制 onlyTransfer=false 防 quit。
+TEST_F(MainWindowTest, CloseEventShowsDialogAutoRejectedDoesNotCrash)
+{
+    qApp->setProperty("onlyTransfer", false);
+    QTimer::singleShot(50, []() {
+        if (auto *modal = qobject_cast<QDialog *>(qApp->activeModalWidget()))
+            modal->reject();
+    });
+    QCloseEvent e;
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(w, &e));
+}

--- a/tests/coop_gui/phonewidget_test.cpp
+++ b/tests/coop_gui/phonewidget_test.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QPixmap>
+#include <QVariantMap>
+#include "gui/phone/phonewidget.h"
+#include "discover/deviceinfo.h"
+
+using cooperation_core::PhoneWidget;
+using cooperation_core::QRCodeWidget;
+using cooperation_core::DeviceInfo;
+using ::DeviceInfoPointer;
+
+// ============ PhoneWidget ============
+
+TEST(PhoneWidgetTest, ConstructDoesNotCrash)
+{
+    PhoneWidget w;
+    SUCCEED();
+}
+
+TEST(PhoneWidgetTest, SwitchWidgetAllPagesDoesNotCrash)
+{
+    PhoneWidget w;
+    w.switchWidget(PhoneWidget::kDeviceListWidget);
+    w.switchWidget(PhoneWidget::kNoNetworkWidget);
+    w.switchWidget(PhoneWidget::kQRCodeWidget);
+    SUCCEED();
+}
+
+TEST(PhoneWidgetTest, SwitchWidgetUnknownPageEarlyReturns)
+{
+    PhoneWidget w;
+    w.switchWidget(PhoneWidget::kUnknownPage);
+    SUCCEED();
+}
+
+TEST(PhoneWidgetTest, SetDeviceInfoDoesNotCrash)
+{
+    PhoneWidget w;
+    DeviceInfoPointer info(new DeviceInfo("10.0.0.1", "DevA"));
+    EXPECT_NO_FATAL_FAILURE(w.setDeviceInfo(info));
+}
+
+TEST(PhoneWidgetTest, AddOperationEmptyMapDoesNotCrash)
+{
+    PhoneWidget w;
+    EXPECT_NO_FATAL_FAILURE(w.addOperation(QVariantMap{}));
+}
+
+TEST(PhoneWidgetTest, OnSetQRcodeInfoDoesNotCrash)
+{
+    PhoneWidget w;
+    EXPECT_NO_FATAL_FAILURE(w.onSetQRcodeInfo("some qrcode payload"));
+}
+
+// ============ QRCodeWidget::generateQRCode (纯逻辑,qrencode 库) ============
+
+TEST(QRCodeWidgetTest, GenerateQRCodeEmptyTextReturnsNullPixmap)
+{
+    QRCodeWidget w;
+    QPixmap pm = w.generateQRCode("", 7);
+    EXPECT_TRUE(pm.isNull());  // 空文本 QRcode_encodeString 失败 → 返回空 QPixmap
+}
+
+TEST(QRCodeWidgetTest, GenerateQRCodeValidTextReturnsPixmap)
+{
+    QRCodeWidget w;
+    QPixmap pm = w.generateQRCode("https://example.com", 7);
+    EXPECT_FALSE(pm.isNull());
+}
+
+TEST(QRCodeWidgetTest, SetQRcodeInfoValidTextDoesNotCrash)
+{
+    QRCodeWidget w;
+    EXPECT_NO_FATAL_FAILURE(w.setQRcodeInfo("payload data"));
+}

--- a/tests/coop_gui/settingdialog_test.cpp
+++ b/tests/coop_gui/settingdialog_test.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QEvent>
+#include <QShowEvent>
+#include <QKeyEvent>
+#include <QCoreApplication>
+#include "gui/dialogs/settingdialog.h"
+
+using cooperation_core::SettingDialog;
+
+// SettingDialog 公开 API 极简(ctor + eventFilter/showEvent/keyPressEvent);
+// 710 行主体在 SettingDialogPrivate::initWindow(构造时执行,覆盖 UI 搭建)。
+// 依赖 ConfigManager/DConfigManager/CooperationUtil/ReportLogManager 单例。
+
+TEST(SettingDialogTest, ConstructDoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({ SettingDialog dlg; });
+}
+
+TEST(SettingDialogTest, ShowEventLoadsConfigDoesNotCrash)
+{
+    SettingDialog dlg;
+    QShowEvent show;
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(&dlg, &show));
+}
+
+// keyPressEvent:linux 下基本转发;非 linux 处理 Enter。发 Escape 不崩。
+TEST(SettingDialogTest, KeyPressEventDoesNotCrash)
+{
+    SettingDialog dlg;
+    QKeyEvent key(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(QCoreApplication::sendEvent(&dlg, &key));
+}
+
+// eventFilter 处理 ContentWidget/MainWidget 的 Paint 事件。
+TEST(SettingDialogTest, EventFilterPaintOnUnnamedWidgetReturnsFalse)
+{
+    SettingDialog dlg;
+    QWidget child;
+    child.setObjectName("RandomName");
+    QEvent paint(QEvent::Paint);
+    // 非 ContentWidget/MainWidget → 不消费,返回 base eventFilter(此处只验不崩)
+    EXPECT_NO_FATAL_FAILURE(dlg.eventFilter(&child, &paint));
+}
+
+// eventFilter 对 ContentWidget 的 Paint 走绘制圆角/矩形分支。
+TEST(SettingDialogTest, EventFilterPaintOnContentWidgetDoesNotCrash)
+{
+    SettingDialog dlg;
+    QWidget child;
+    child.setObjectName("ContentWidget");
+    child.resize(100, 100);
+    QEvent paint(QEvent::Paint);
+    EXPECT_NO_FATAL_FAILURE(dlg.eventFilter(&child, &paint));
+}


### PR DESCRIPTION
新增 5 个 GUI 测试文件(均 0% 或低覆盖起步):

MainWindow (mainwindow_test.cpp, 23 用例) 0%→80%:
- public slot 构造/setFirstTipVisible/onFindDevice/onDiscoveryFinished/onSwitchMode/ removeDevice/onRegistOperations/addDevice/onLookingForDevices/onlineStateChanged/ addMobileDevice/minimizedAPP/disconnectMobile/onSetQRCode/addMobileOperation;
- 私有深挖(ACCESS d 指针):handleSettingMenuTriggered 四分支(含 SettingDialog 创建+ SettingDialogShown 早返回)/setIP/moveCenter;
- closeEvent + showCloseDialog(QTimer auto-reject 解 exec 阻塞)。

PhoneWidget (phonewidget_test.cpp, 9 用例) 0%→98%:
- switchWidget 各页;setDeviceInfo/addOperation/onSetQRcodeInfo;
- QRCodeWidget::generateQRCode 纯逻辑(qrencode):空文本→null/有效→pixmap。

SettingDialog (settingdialog_test.cpp, 5 用例) 0%→77%:
- 构造覆盖 SettingDialogPrivate::initWindow 主体;show/keyPressEvent/eventFilter(Paint ContentWidget)。

DiscoverController (discovercontroller_test.cpp, 7 用例) 0%→9%:
- 非网络方法:instance/selfInfo/isZeroConfDaemonActive/findDeviceByIP/ onAppAttributeChanged/onConnectHistoryUpdated/updateHistoryDevices;跳过 ZeroConf 网络。

BackgroundWidget (backgroundwidget_test.cpp, 5 用例) 13%→97%:
- setBackground 各 RoundRole/ColorType + paintEvent 四分支(show+repaint)。

coop_gui_tests 164/164 PASS。