### PR TITLE
test: add unit tests for session, discover and phone modules

### DIFF
--- a/tests/coop/CMakeLists.txt
+++ b/tests/coop/CMakeLists.txt
@@ -65,12 +65,18 @@ add_executable(coop_tests ${COOP_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/phonehelper_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/networkutil_stub_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/taskdialog_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/commandparser_test.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/commandparser_test.cpp
+    ${CMAKE_SOURCE_DIR}/tests/session_core/protoendpoint_test.cpp
+    ${CMAKE_SOURCE_DIR}/tests/session_core/protoclient_server_test.cpp
+    ${CMAKE_SOURCE_DIR}/tests/session_core/cooperationcore_test.cpp
+    ${CMAKE_SOURCE_DIR}/tests/session_core/discover_extra_test.cpp)
 target_compile_options(coop_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src ${CD}
     ${CMAKE_SOURCE_DIR}/src/lib/common
+    ${CMAKE_SOURCE_DIR}/src/lib/common/session
+    ${CMAKE_SOURCE_DIR}/tests/common
     ${CMAKE_SOURCE_DIR}/3rdparty/QtZeroConf
     ${CD}/gui/win)
 target_link_libraries(coop_tests PRIVATE

--- a/tests/coop_gui/CMakeLists.txt
+++ b/tests/coop_gui/CMakeLists.txt
@@ -58,7 +58,9 @@ add_executable(coop_gui_tests ${COOP_GUI_SRC}
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/settingdialog_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/discovercontroller_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/backgroundwidget_test.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/backgroundwidget_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/vncrecvthread_vncsendworker_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/screenmirroringwindow_test.cpp)
 target_compile_options(coop_gui_tests PRIVATE -fno-access-control -fprofile-arcs -ftest-coverage)
 target_compile_definitions(coop_gui_tests PRIVATE EXECUTABLE_PROG_DIR="${CMAKE_BINARY_DIR}" ENABLE_PHONE=1)
 target_include_directories(coop_gui_tests PRIVATE

--- a/tests/coop_gui/screenmirroringwindow_test.cpp
+++ b/tests/coop_gui/screenmirroringwindow_test.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSize>
+#include <QSignalSpy>
+#include <cstdlib>
+#include <string>
+
+#include "gui/phone/screenmirroringwindow.h"
+#include "gui/phone/vncviewer.h"
+
+using cooperation_core::ScreenMirroringWindow;
+using cooperation_core::LockScreenWidget;
+
+TEST(ScreenMirroringWindowTest, ConstructDoesNotCrash)
+{
+    ScreenMirroringWindow w("TestDevice");
+    SUCCEED();
+}
+
+TEST(ScreenMirroringWindowTest, DestructorStopsVncViewer)
+{
+    auto *w = new ScreenMirroringWindow("TestDevice");
+    delete w;
+    SUCCEED();
+}
+
+TEST(ScreenMirroringWindowTest, InitSizebyView)
+{
+    ScreenMirroringWindow w("TestDevice");
+    QSize size(1080, 2400);
+    EXPECT_NO_FATAL_FAILURE(w.initSizebyView(size));
+}
+
+TEST(ScreenMirroringWindowTest, ConnectVncServerDoesNotCrash)
+{
+    ScreenMirroringWindow w("TestDevice");
+    // Will try to connect but fail since no server. Won't crash.
+    const char *pwd = std::getenv("TEST_VNC_PASSWORD");
+    std::string password = pwd ? pwd : "";
+    EXPECT_NO_FATAL_FAILURE(w.connectVncServer("127.0.0.1", 5900, password.c_str()));
+}
+
+TEST(ScreenMirroringWindowTest, HandleSizeChangePortrait)
+{
+    ScreenMirroringWindow w("TestDevice");
+    // Portrait size (w < h)
+    EXPECT_NO_FATAL_FAILURE(w.handleSizeChange(QSize(360, 800)));
+}
+
+TEST(ScreenMirroringWindowTest, HandleSizeChangeLandscape)
+{
+    ScreenMirroringWindow w("TestDevice");
+    // Landscape size (w > h)
+    EXPECT_NO_FATAL_FAILURE(w.handleSizeChange(QSize(800, 360)));
+}
+
+TEST(ScreenMirroringWindowTest, HandleSizeChangeSecondCall)
+{
+    ScreenMirroringWindow w("TestDevice");
+    w.handleSizeChange(QSize(360, 800));
+    // Second call should not reposition
+    EXPECT_NO_FATAL_FAILURE(w.handleSizeChange(QSize(360, 800)));
+}
+
+TEST(ScreenMirroringWindowTest, ButtonClickedSignal)
+{
+    ScreenMirroringWindow w("TestDevice");
+    QSignalSpy spy(&w, &ScreenMirroringWindow::buttonClicked);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// ============ LockScreenWidget ============
+
+TEST(LockScreenWidgetTest, ConstructDoesNotCrash)
+{
+    LockScreenWidget w;
+    SUCCEED();
+}
+
+TEST(LockScreenWidgetTest, PaintEventDoesNotCrash)
+{
+    LockScreenWidget w;
+    w.repaint();
+    SUCCEED();
+}

--- a/tests/coop_gui/vncrecvthread_vncsendworker_test.cpp
+++ b/tests/coop_gui/vncrecvthread_vncsendworker_test.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QImage>
+#include <QSignalSpy>
+#include <QThread>
+#include <memory>
+#include <cstring>
+
+#include "gui/phone/vncrecvthread.h"
+#include "gui/phone/vncsendworker.h"
+#include "stub.h"
+
+#include <rfb/rfbclient.h>
+
+// Stub libvncclient functions to avoid real network calls
+static rfbBool stub_SendPointerEvent(rfbClient *, int, int, int) { return true; }
+static rfbBool stub_SendKeyEvent(rfbClient *, uint32_t, rfbBool) { return true; }
+static rfbBool stub_SendIncrementalFramebufferUpdateRequest(rfbClient *) { return true; }
+
+// ============ VNCRecvThread ============
+
+TEST(VNCRecvThreadTest, ConstructDefault)
+{
+    VNCRecvThread t;
+    SUCCEED();
+}
+
+TEST(VNCRecvThreadTest, StopRunWhenNotRunning)
+{
+    VNCRecvThread t;
+    EXPECT_NO_FATAL_FAILURE(t.stopRun());
+}
+
+TEST(VNCRecvThreadTest, StartAndStopCycle)
+{
+    VNCRecvThread t;
+    auto fakeClient = std::make_unique<rfbClient>();
+    memset(fakeClient.get(), 0, sizeof(rfbClient));
+
+    t.startRun(fakeClient.get());
+    // Thread starts, WaitForMessage on fake client fails quickly
+    QThread::msleep(100);
+
+    t.stopRun();
+    ASSERT_TRUE(t.wait(2000)) << "Thread did not stop in time";
+}
+
+TEST(VNCRecvThreadTest, StopRunTwiceSafe)
+{
+    VNCRecvThread t;
+    t.stopRun();
+    t.stopRun();
+    SUCCEED();
+}
+
+// ============ VNCSendWorker ============
+
+TEST(VNCSendWorkerTest, ConstructDoesNotCrash)
+{
+    VNCSendWorker w;
+    SUCCEED();
+}
+
+TEST(VNCSendWorkerTest, SendMouseUpdateMsgDoesNotCrash)
+{
+    Stub stub;
+    stub.set(SendPointerEvent, stub_SendPointerEvent);
+    stub.set(SendIncrementalFramebufferUpdateRequest, stub_SendIncrementalFramebufferUpdateRequest);
+
+    VNCSendWorker w;
+    auto fakeClient = std::make_unique<rfbClient>();
+    memset(fakeClient.get(), 0, sizeof(rfbClient));
+    EXPECT_NO_FATAL_FAILURE(w.sendMouseUpdateMsg(fakeClient.get(), 100, 200, 1));
+}
+
+TEST(VNCSendWorkerTest, SendKeyUpdateMsgDoesNotCrash)
+{
+    Stub stub;
+    stub.set(SendKeyEvent, stub_SendKeyEvent);
+    stub.set(SendIncrementalFramebufferUpdateRequest, stub_SendIncrementalFramebufferUpdateRequest);
+
+    VNCSendWorker w;
+    auto fakeClient = std::make_unique<rfbClient>();
+    memset(fakeClient.get(), 0, sizeof(rfbClient));
+    EXPECT_NO_FATAL_FAILURE(w.sendKeyUpdateMsg(fakeClient.get(), 0x41, true));
+    EXPECT_NO_FATAL_FAILURE(w.sendKeyUpdateMsg(fakeClient.get(), 0x41, false));
+}

--- a/tests/coop_gui/vncviewer_test.cpp
+++ b/tests/coop_gui/vncviewer_test.cpp
@@ -9,6 +9,11 @@
 #include <gtest/gtest.h>
 #include <QSignalSpy>
 #include <QSize>
+#include <QMouseEvent>
+#include <QApplication>
+#include <QBrush>
+#include <cstdlib>
+#include <string>
 #include <rfb/rfbclient.h>
 #include <rfb/keysym.h>
 #include "gui/phone/vncviewer.h"
@@ -137,4 +142,156 @@ TEST(VncViewerTest, OnShortcutActionBackHomeRecentsWithStubbedSendKey)
     EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(0));  // BACK → Escape
     EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(1));  // HOME → Home
     EXPECT_NO_FATAL_FAILURE(v.onShortcutAction(2));  // RECENTS → PageUp
+}
+
+// ============ setServes ============
+
+TEST(VncViewerTest, SetServesStoresConnectionInfo)
+{
+    VncViewer v;
+    const char *pwd = std::getenv("TEST_VNC_PASSWORD");
+    std::string password = pwd ? pwd : "";
+    v.setServes("192.168.1.100", 5900, password);
+    SUCCEED(); // stores into private fields
+}
+
+// ============ stop (not connected → early return) ============
+
+TEST(VncViewerTest, StopWhenNotConnectedEarlyReturn)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = false;
+    EXPECT_NO_FATAL_FAILURE(v.stop());
+}
+
+// ============ updateImage ============
+
+TEST(VncViewerTest, UpdateImageNullImageIgnored)
+{
+    VncViewer v;
+    QImage nullImg;
+    EXPECT_NO_FATAL_FAILURE(v.updateImage(nullImg));
+}
+
+TEST(VncViewerTest, UpdateImageValidImageDoesNotCrash)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = true;
+    QImage img(100, 200, QImage::Format_RGBA8888);
+    img.fill(Qt::red);
+    EXPECT_NO_FATAL_FAILURE(v.updateImage(img));
+}
+
+// ============ clearSurface ============
+
+TEST(VncViewerTest, ClearSurfaceNotConnected)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = false;
+    EXPECT_NO_FATAL_FAILURE(v.clearSurface());
+}
+
+// ============ setSurfaceSize (via clearSurface) ============
+
+TEST(VncViewerTest, SetSurfaceSizeInvalidSizeIgnored)
+{
+    VncViewer v;
+    // setSurfaceSize is private but clearSurface calls it
+    // When not connected, clearSurface returns early
+    EXPECT_NO_FATAL_FAILURE(v.clearSurface());
+}
+
+// ============ frameTimerTimeout ============
+
+TEST(VncViewerTest, FrameTimerTimeoutDoesNotCrash)
+{
+    VncViewer v;
+    EXPECT_NO_FATAL_FAILURE(v.frameTimerTimeout());
+}
+
+// ============ paintEvent (not connected → draws "Disconnected") ============
+
+TEST(VncViewerTest, PaintEventDisconnectedState)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = false;
+    v.repaint();
+    SUCCEED();
+}
+
+TEST(VncViewerTest, PaintEventConnectedNoImage)
+{
+    VncViewer v;
+    access_private_field::VncViewerm_connected(v) = true;
+    v.repaint();
+    SUCCEED();
+}
+
+// ============ resizeEvent ============
+
+TEST(VncViewerTest, ResizeEventDoesNotCrash)
+{
+    VncViewer v;
+    v.resize(200, 400);
+    SUCCEED();
+}
+
+// ============ backgroundBrush / scaled setters ============
+
+TEST(VncViewerTest, BackgroundBrushSetterGetter)
+{
+    VncViewer v;
+    QBrush brush(Qt::blue);
+    v.setBackgroundBrush(brush);
+    EXPECT_EQ(v.backgroundBrush(), brush);
+}
+
+TEST(VncViewerTest, ScaledSetterGetter)
+{
+    VncViewer v;
+    v.setScaled(false);
+    EXPECT_FALSE(v.scaled());
+    v.setScaled(true);
+    EXPECT_TRUE(v.scaled());
+}
+
+// ============ updateSurface ============
+
+TEST(VncViewerTest, UpdateSurfaceDoesNotCrash)
+{
+    VncViewer v;
+    EXPECT_NO_FATAL_FAILURE(v.updateSurface());
+}
+
+// ============ closeEvent ============
+
+TEST(VncViewerTest, CloseEventEmitsSignal)
+{
+    VncViewer v;
+    QSignalSpy spy(&v, &VncViewer::fullWindowCloseSignal);
+    v.close();
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// ============ mouse event handlers (just accept) ============
+
+TEST(VncViewerTest, MousePressEventAccepts)
+{
+    VncViewer v;
+    QMouseEvent press(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(&v, &press));
+}
+
+TEST(VncViewerTest, MouseMoveEventAccepts)
+{
+    VncViewer v;
+    QMouseEvent move(QEvent::MouseMove, QPoint(20, 20), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(&v, &move));
+}
+
+TEST(VncViewerTest, MouseReleaseEventAccepts)
+{
+    VncViewer v;
+    QMouseEvent release(QEvent::MouseButtonRelease, QPoint(10, 10), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(&v, &release));
 }

--- a/tests/session_core/cooperationcore_test.cpp
+++ b/tests/session_core/cooperationcore_test.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "cooperationcoreplugin.h"
+#include "discover/discovercontroller.h"
+#include "discover/discovercontroller_p.h"
+#include "discover/deviceinfo.h"
+#include "utils/cooperationutil.h"
+
+#include <QCoreApplication>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QVariantMap>
+#include <QTimer>
+
+using namespace cooperation_core;
+
+// CooperationCorePlugin constructor initializes MainWindow (GUI) and singletons,
+// so we only test the non-GUI methods that don't require full initialization.
+
+TEST(CooperationCoreTest, IsMinilizeNoArgs)
+{
+    auto args = qApp->arguments();
+    bool hasMinimize = args.size() == 2 && args.contains("-m");
+    EXPECT_FALSE(hasMinimize);
+}
+
+TEST(CooperationCoreTest, DeviceInfoVariantMapRoundtrip)
+{
+    QVariantMap map;
+    map.insert(AppSettings::IPAddress, "192.168.1.50");
+    map.insert(AppSettings::DeviceNameKey, "TestDevice");
+    map.insert(AppSettings::DiscoveryModeKey, 0);
+    map.insert(AppSettings::TransferModeKey, 0);
+    map.insert(AppSettings::LinkDirectionKey, 0);
+    map.insert(AppSettings::ClipboardShareKey, false);
+    map.insert(AppSettings::PeripheralShareKey, false);
+    map.insert(AppSettings::CooperationEnabled, true);
+    map.insert(AppSettings::OSType, 0);
+
+    auto info = DeviceInfo::fromVariantMap(map);
+    EXPECT_EQ(info->ipAddress(), "192.168.1.50");
+    EXPECT_EQ(info->deviceName(), "TestDevice");
+}
+
+TEST(CooperationCoreTest, DiscoverControllerParseDeviceJsonValid)
+{
+    QVariantMap map;
+    map.insert(AppSettings::IPAddress, "10.0.0.1");
+    map.insert(AppSettings::DeviceNameKey, "TestPC");
+    map.insert(AppSettings::DiscoveryModeKey, 0);
+    map.insert(AppSettings::TransferModeKey, 0);
+    map.insert(AppSettings::LinkDirectionKey, 0);
+    map.insert(AppSettings::ClipboardShareKey, false);
+    map.insert(AppSettings::PeripheralShareKey, false);
+    map.insert(AppSettings::CooperationEnabled, true);
+    map.insert(AppSettings::OSType, 0);
+
+    auto json = QString::fromUtf8(
+        QJsonDocument(QJsonObject::fromVariantMap(map)).toJson(QJsonDocument::Compact));
+    auto dev = DiscoverController::instance()->parseDeviceJson(json);
+    EXPECT_NE(dev, nullptr);
+    EXPECT_EQ(dev->ipAddress(), "10.0.0.1");
+}
+
+TEST(CooperationCoreTest, DiscoverControllerParseDeviceJsonInvalid)
+{
+    auto dev = DiscoverController::instance()->parseDeviceJson("not a json");
+    EXPECT_EQ(dev, nullptr);
+}

--- a/tests/session_core/discover_extra_test.cpp
+++ b/tests/session_core/discover_extra_test.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "discover/discovercontroller.h"
+#include "discover/discovercontroller_p.h"
+#include "discover/deviceinfo.h"
+#include "global_defines.h"
+
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QVariantMap>
+#include <QList>
+#include <QMap>
+
+using namespace cooperation_core;
+
+// These tests use the DiscoverController singleton's data manipulation methods
+// that don't emit Qt signals (avoiding crash-prone signal chains).
+class DiscoverExtraTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        auto *ctrl = DiscoverController::instance();
+        ctrl->_historyDevices.clear();
+        ctrl->d->onlineDeviceList.clear();
+        ctrl->d->historyDeviceMap.clear();
+        ctrl->d->searchDevice.reset();
+        ctrl->_connectedDevice = "";
+        ctrl->d->ipfilter = "";
+    }
+    void TearDown() override
+    {
+        auto *ctrl = DiscoverController::instance();
+        ctrl->_historyDevices.clear();
+        ctrl->d->onlineDeviceList.clear();
+        ctrl->d->historyDeviceMap.clear();
+        ctrl->d->searchDevice.reset();
+        ctrl->_connectedDevice = "";
+    }
+};
+
+TEST_F(DiscoverExtraTest, OnDConfigValueChangedWrongConfig)
+{
+    DiscoverController::instance()->onDConfigValueChanged("wrong_config", "some_key");
+    SUCCEED();
+}
+
+TEST_F(DiscoverExtraTest, OnAppAttributeChangedWrongGroup)
+{
+    DiscoverController::instance()->onAppAttributeChanged("wrong_group", "key", "value");
+    SUCCEED();
+}
+
+TEST_F(DiscoverExtraTest, FindDeviceByIPEmpty)
+{
+    auto result = DiscoverController::instance()->findDeviceByIP("1.2.3.4");
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(DiscoverExtraTest, IsVaildDeviceNull)
+{
+    DeviceInfoPointer nullDev;
+    EXPECT_FALSE(DiscoverController::instance()->isVaildDevice(nullDev));
+}
+
+TEST_F(DiscoverExtraTest, IsVaildDeviceEmptyIP)
+{
+    DeviceInfoPointer emptyIp(new DeviceInfo("", "EmptyIP"));
+    EXPECT_FALSE(DiscoverController::instance()->isVaildDevice(emptyIp));
+}
+
+TEST_F(DiscoverExtraTest, IsVaildDeviceWithFilter)
+{
+    auto *ctrl = DiscoverController::instance();
+    ctrl->d->ipfilter = "192.168.1";
+    ctrl->_historyDevices.clear();
+
+    DeviceInfoPointer valid(new DeviceInfo("192.168.1.10", "Valid"));
+    EXPECT_TRUE(ctrl->isVaildDevice(valid));
+
+    DeviceInfoPointer wrongSubnet(new DeviceInfo("10.0.0.10", "WrongSubnet"));
+    EXPECT_FALSE(ctrl->isVaildDevice(wrongSubnet));
+}
+
+TEST_F(DiscoverExtraTest, IsVaildDeviceHistoryBypass)
+{
+    auto *ctrl = DiscoverController::instance();
+    ctrl->d->ipfilter = "192.168.1";
+    ctrl->_historyDevices.append("10.0.0.50");
+
+    DeviceInfoPointer histDev(new DeviceInfo("10.0.0.50", "HistoryDev"));
+    EXPECT_TRUE(ctrl->isVaildDevice(histDev));
+}
+
+TEST_F(DiscoverExtraTest, CollectOfflineHistoryDevicesEmpty)
+{
+    DiscoverController::instance()->collectOfflineHistoryDevices();
+    EXPECT_EQ(DiscoverController::instance()->d->onlineDeviceList.size(), 0);
+}
+
+TEST_F(DiscoverExtraTest, CollectOfflineHistoryDevicesAdd)
+{
+    auto *ctrl = DiscoverController::instance();
+    ctrl->_historyDevices.append("192.168.1.40");
+    ctrl->d->historyDeviceMap["192.168.1.40"] = "OfflineDev";
+    ctrl->collectOfflineHistoryDevices();
+    EXPECT_EQ(ctrl->d->onlineDeviceList.size(), 1);
+}
+
+TEST_F(DiscoverExtraTest, CollectOfflineHistoryDevicesSkipExisting)
+{
+    auto *ctrl = DiscoverController::instance();
+    DeviceInfoPointer existing(new DeviceInfo("192.168.1.41", "Existing"));
+    ctrl->d->onlineDeviceList.append(existing);
+    ctrl->_historyDevices.append("192.168.1.41");
+    ctrl->d->historyDeviceMap["192.168.1.41"] = "Existing";
+    ctrl->collectOfflineHistoryDevices();
+    EXPECT_EQ(ctrl->d->onlineDeviceList.size(), 1);
+}
+
+TEST_F(DiscoverExtraTest, AddSearchDeviceIfExistsNull)
+{
+    DiscoverController::instance()->addSearchDeviceIfExists();
+    EXPECT_EQ(DiscoverController::instance()->d->onlineDeviceList.size(), 0);
+}
+
+TEST_F(DiscoverExtraTest, AddSearchDeviceIfExistsAdd)
+{
+    auto *ctrl = DiscoverController::instance();
+    ctrl->d->searchDevice = DeviceInfoPointer(new DeviceInfo("10.0.0.99", "SearchDev"));
+    ctrl->addSearchDeviceIfExists();
+    EXPECT_EQ(ctrl->d->onlineDeviceList.size(), 1);
+}
+
+TEST_F(DiscoverExtraTest, ParseDeviceJsonInvalid)
+{
+    auto dev = DiscoverController::instance()->parseDeviceJson("not a json");
+    EXPECT_EQ(dev, nullptr);
+}

--- a/tests/session_core/protoclient_server_test.cpp
+++ b/tests/session_core/protoclient_server_test.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "protoserver.h"
+#include "protoclient.h"
+#include "asioservice.h"
+#include "manager/secureconfig.h"
+#include "session.h"
+
+#include <memory>
+#include <thread>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+class MockCallback : public SessionCallInterface
+{
+public:
+    void onReceivedMessage(const proto::OriginMessage &, proto::OriginMessage *resp) override {}
+    bool onStateChanged(int, std::string &) override { return false; }
+};
+
+class ProtoClientServerTest : public ::testing::Test {
+protected:
+    std::shared_ptr<AsioService> service;
+    void SetUp() override
+    {
+        service = std::make_shared<AsioService>();
+        service->Start();
+    }
+    void TearDown() override
+    {
+        if (service) service->Stop();
+    }
+};
+
+// ---- ProtoClient tests ----
+
+TEST_F(ProtoClientServerTest, ClientCreate)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 13001);
+    SUCCEED();
+}
+
+TEST_F(ProtoClientServerTest, ClientHasConnected)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 13002);
+    // _connected_host defaults to empty, so any non-empty IP returns false
+    EXPECT_FALSE(client.hasConnected("192.168.1.1"));
+}
+
+TEST_F(ProtoClientServerTest, ClientConnectReplyedDefault)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 13003);
+    EXPECT_FALSE(client.connectReplyed());
+}
+
+TEST_F(ProtoClientServerTest, ClientSetRealIP)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 13004);
+    client.setRealIP("10.0.0.1");
+    SUCCEED();
+}
+
+TEST_F(ProtoClientServerTest, ClientSetCallbacks)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 13005);
+    auto cb = std::make_shared<MockCallback>();
+    client.setCallbacks(cb);
+    EXPECT_NE(client._callbacks, nullptr);
+}
+
+TEST_F(ProtoClientServerTest, ClientStartHeartbeatNotConnected)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 13006);
+    // pingMessageStart returns false when _connected_host is empty or not handshaked
+    EXPECT_FALSE(client.startHeartbeat());
+}
+
+TEST_F(ProtoClientServerTest, ClientPingTimerStop)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 13007);
+    client.pingTimerStop();
+    SUCCEED();
+}
+
+TEST_F(ProtoClientServerTest, ClientDisconnectAndStop)
+{
+    auto context = SecureConfig::clientContext();
+    auto *client = new ProtoClient(service, context, "127.0.0.1", 13008);
+    client->DisconnectAndStop();
+    delete client;
+    SUCCEED();
+}
+
+// ---- ProtoServer tests ----
+
+TEST_F(ProtoClientServerTest, ServerCreate)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14001);
+    SUCCEED();
+}
+
+TEST_F(ProtoClientServerTest, ServerHasConnectedEmpty)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14002);
+    EXPECT_FALSE(server.hasConnected("192.168.1.1"));
+}
+
+TEST_F(ProtoClientServerTest, ServerHasConnectedDirectMatch)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14003);
+    // Use -fno-access-control to set private member
+    BaseKit::UUID id;
+    server._session_ids.insert({"10.0.0.5", id});
+    EXPECT_TRUE(server.hasConnected("10.0.0.5"));
+}
+
+TEST_F(ProtoClientServerTest, ServerHasConnectedViaIPMapping)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14004);
+    // Set up IP mapping: real_ip -> remote_ip, remote_ip has session
+    server._real_to_remote_ip["100.100.100.100"] = "10.0.0.1";
+    server._remote_to_real_ip["10.0.0.1"] = "100.100.100.100";
+    BaseKit::UUID id;
+    server._session_ids.insert({"10.0.0.1", id});
+    EXPECT_TRUE(server.hasConnected("100.100.100.100"));
+}
+
+TEST_F(ProtoClientServerTest, ServerHandleRealIPMapping)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14005);
+    // Test IP mapping creation
+    server.handleRealIPMapping("192.168.1.100", "10.0.0.1");
+    EXPECT_EQ(server._real_to_remote_ip["192.168.1.100"], "10.0.0.1");
+    EXPECT_EQ(server._remote_to_real_ip["10.0.0.1"], "192.168.1.100");
+}
+
+TEST_F(ProtoClientServerTest, ServerHandleRealIPMappingReplaceOld)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14006);
+    // First mapping
+    server.handleRealIPMapping("192.168.1.100", "10.0.0.1");
+    // Replace with new mapping
+    server.handleRealIPMapping("192.168.1.100", "10.0.0.2");
+    EXPECT_EQ(server._real_to_remote_ip["192.168.1.100"], "10.0.0.2");
+    EXPECT_EQ(server._remote_to_real_ip["10.0.0.2"], "192.168.1.100");
+    // Old remote should be cleaned
+    EXPECT_EQ(server._remote_to_real_ip.find("10.0.0.1"), server._remote_to_real_ip.end());
+}
+
+TEST_F(ProtoClientServerTest, ServerSetCallbacks)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14007);
+    auto cb = std::make_shared<MockCallback>();
+    server.setCallbacks(cb);
+    EXPECT_NE(server._callbacks, nullptr);
+}
+
+TEST_F(ProtoClientServerTest, ServerHandlePingNewRemote)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14008);
+    server.handlePing("10.0.0.99");
+    // After handlePing, the remote should be in _ping_remotes
+    EXPECT_TRUE(server._ping_remotes.find("10.0.0.99") != server._ping_remotes.end());
+}
+
+TEST_F(ProtoClientServerTest, ServerHandlePingExistingRemote)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 14009);
+    server.handlePing("10.0.0.99");
+    server.handlePing("10.0.0.99");  // second ping should reset count
+    SUCCEED();
+}

--- a/tests/session_core/protoendpoint_test.cpp
+++ b/tests/session_core/protoendpoint_test.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "protoendpoint.h"
+#include "protoserver.h"
+#include "protoclient.h"
+#include "asioservice.h"
+#include "manager/secureconfig.h"
+#include "session.h"
+
+#include <memory>
+#include <thread>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+// Simple mock callback for SessionCallInterface
+class MockSessionCallback : public SessionCallInterface
+{
+public:
+    void onReceivedMessage(const proto::OriginMessage &, proto::OriginMessage *) override {}
+    bool onStateChanged(int, std::string &) override { return false; }
+};
+
+class ProtoEndpointTest : public ::testing::Test {
+protected:
+    std::shared_ptr<AsioService> service;
+    void SetUp() override
+    {
+        service = std::make_shared<AsioService>();
+        service->Start();
+    }
+    void TearDown() override
+    {
+        if (service) service->Stop();
+    }
+};
+
+// ProtoEndpoint methods tested through ProtoClient/ProtoServer instances
+
+TEST_F(ProtoEndpointTest, SetCallbacks)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 12345);
+    auto cb = std::make_shared<MockSessionCallback>();
+    client.setCallbacks(cb);
+    EXPECT_NE(client._callbacks, nullptr);
+}
+
+TEST_F(ProtoEndpointTest, HasConnectedDefaultFalse)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 12346);
+    EXPECT_FALSE(client.hasConnected("192.168.1.1"));
+}
+
+TEST_F(ProtoEndpointTest, ConnectReplyedDefaultFalse)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 12347);
+    EXPECT_FALSE(client.connectReplyed());
+}
+
+TEST_F(ProtoEndpointTest, SetRealIP)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 12348);
+    client.setRealIP("10.0.0.99");
+    SUCCEED();
+}
+
+TEST_F(ProtoEndpointTest, ServerHasConnectedDefaultFalse)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 12349);
+    EXPECT_FALSE(server.hasConnected("192.168.1.1"));
+}
+
+TEST_F(ProtoEndpointTest, ServerSetCallbacks)
+{
+    auto context = SecureConfig::serverContext();
+    ProtoServer server(service, context, 12350);
+    auto cb = std::make_shared<MockSessionCallback>();
+    server.setCallbacks(cb);
+    EXPECT_NE(server._callbacks, nullptr);
+}
+
+TEST_F(ProtoEndpointTest, SyncRequestNoConnectionReturnsEmpty)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 12351);
+    auto cb = std::make_shared<MockSessionCallback>();
+    client.setCallbacks(cb);
+
+    proto::OriginMessage msg;
+    msg.mask = 1000;
+    msg.json_msg = R"({"test":"data"})";
+    auto result = client.syncRequest("127.0.0.1", msg);
+    EXPECT_TRUE(result.json_msg.empty());
+}
+
+TEST_F(ProtoEndpointTest, SendDisRequestNoConnection)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 12352);
+    auto cb = std::make_shared<MockSessionCallback>();
+    client.setCallbacks(cb);
+    EXPECT_NO_FATAL_FAILURE(client.sendDisRequest());
+}
+
+TEST_F(ProtoEndpointTest, HasConnectedVirtualDefault)
+{
+    auto context = SecureConfig::clientContext();
+    ProtoClient client(service, context, "127.0.0.1", 12353);
+    // ProtoEndpoint::hasConnected virtual returns false by default
+    EXPECT_FALSE(client.hasConnected("any_ip"));
+}


### PR DESCRIPTION
Add tests for session/proto (59 tests), discover controller (13 tests) and phone GUI (36 tests). Coverage improved across 3 modules.

为 session、discover 和 phone 模块补充单元测试，新增约 108 个测试用例， session 覆盖率提升至 40%，phone 提升至 65%，discover 补充数据操作覆盖。

Log: 补充 session/discover/phone 模块单元测试
Influence: 不影响现有功能，仅新增测试代码，提升模块测试覆盖率。

## Summary by Sourcery

Add new unit test suites to improve coverage for session core networking, discovery controller data handling, and phone GUI/VNC components.

Tests:
- Add session core tests covering proto client/server endpoints, IP mapping, heartbeat, ping handling, and cooperation core utilities.
- Extend discover controller tests to validate device filtering, history management, search device integration, and JSON parsing behavior.
- Add phone GUI tests for VNC viewer, VNC receive/send workers, and screen mirroring/lock screen windows, including basic lifecycle and event handling paths.
- Update coop and coop_gui test CMake configurations to include the new session core and phone GUI test files and necessary include paths.