### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/apps/data-transfer/res/linux/deepin-data-transfer.desktop
+++ b/src/apps/data-transfer/res/linux/deepin-data-transfer.desktop
@@ -30,8 +30,8 @@ GenericName[zh_TW]=資料遷移
 Name[bo]=Deepinགཞི་གྲངས་སྤོ་བ།
 Name[fr]=Deepin Transfert de données
 Name[ug]=UOS سانلىق مەلۇمات يۆتكەش قورالى
-Name[zh_CN]=深度数据迁移
-Name[zh_HK]=深度數據遷移
+Name[zh_CN]=数据迁移
+Name[zh_HK]=數據遷移
 Name[lo]=ການໂອນຂໍ້ມູນ
-Name[zh_TW]=深度資料遷移
+Name[zh_TW]=資料遷移
 

--- a/src/apps/dde-cooperation/res/linux/dde-cooperation.desktop
+++ b/src/apps/dde-cooperation/res/linux/dde-cooperation.desktop
@@ -31,7 +31,7 @@ Name[bo]=Deepinམཉམ་སྒྲུབ།
 Name[fr]=Deepin Coopération
 Name[lo]=Deepin ການຮ່ວມມື
 Name[ug]=تېرمىنال ھالقىپ ھەمكارلىشىش
-Name[zh_CN]=深度跨端协同
-Name[zh_HK]=深度跨端協同
-Name[zh_TW]=深度跨端協同
+Name[zh_CN]=跨端协同
+Name[zh_HK]=跨端協同
+Name[zh_TW]=跨端協同
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese zh_CN/zh_HK/zh_TW desktop entry translations by removing unnecessary Deepin/深度 prefixes from Name and Comment fields.