### PR TITLE
fix(coost): disable syscall hooks in test build to fix gcov crash

### DIFF
--- a/3rdparty/coost/src/co/hook.h
+++ b/3rdparty/coost/src/co/hook.h
@@ -18,6 +18,28 @@ void hook_sleep(bool x);
 #ifdef _CO_DISABLE_HOOK
 #define __sys_api(x) ::x
 
+// __sys_api(x) 解析为 ::x 时, 仍需保证这些原生 syscall 的声明可见。
+// 开启 hook 时下方 #else 分支会引入这些头文件; 关闭 hook 时该分支被跳过,
+// 故在此补齐, 否则 co 自身源码(sock.cc 等用到 __sys_api(fcntl/ioctl/...))
+// 会因缺少 <fcntl.h>/<sys/ioctl.h> 等而编译失败。
+#ifndef _WIN32
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <poll.h>
+#include <sys/select.h>
+#include <sys/ioctl.h>
+#ifdef __linux__
+#include <sys/epoll.h>
+#else
+#include <time.h>
+#include <sys/event.h>
+#endif
+#endif
+
 #else
 // We have to hook some native APIs, as third-party network libraries may block the 
 // coroutine schedulers.

--- a/modules/compat.cmake
+++ b/modules/compat.cmake
@@ -48,6 +48,17 @@ include_directories(${COOST_DIR}/include)
 # coost 打开SSL和动态库
 # cmake .. -DWITH_LIBCURL=ON -DWITH_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
 set(BUILD_SHARED_LIBS ON)
+
+# 单元测试/覆盖率构建: 关闭 coost 的系统调用 hook。
+# coost 通过符号介入 interpose 了 open/fcntl/close 等; 进程退出时 gcov 落盘
+# (__gcov_exit -> __gcov_open) 会调用这些被 hook 的 syscall, 进而触发 co::gHook()
+# 的惰性分配, 而此刻 coost 静态分配器正处于 teardown 之中 -> SIGSEGV, 并留下损坏
+# 的 .gcda 导致 lcov 中途 abort、覆盖率大幅丢失。测试不依赖协程 socket hook,
+# 关闭后这些调用直接走 libc, 从根上消除该崩溃。须在 add_subdirectory(coost) 之前
+# 设置, 以覆盖 coost 自带 option(DISABLE_HOOK ... OFF) 的默认值。
+if(DOTEST OR BUILD_TESTS)
+    set(DISABLE_HOOK ON)
+endif()
 add_subdirectory("${COOST_DIR}" coost)
 
 # 单元测试构建：禁用 coost 在静态初始化阶段预热 hook（详见 log.cc 注释）。


### PR DESCRIPTION
coost interposes open/fcntl/close; gcov flush at exit calls these, hitting a half-destroyed co::MemBlocks allocator -> SIGSEGV in 3 test binaries, leaving corrupt .gcda that aborts lcov mid-run and drops coverage to ~39%.

coost 通过符号介入拦截 open/fcntl/close 等；进程退出时 gcov 落盘调用
这些 syscall，触发已半析构的 co::MemBlocks 分配器，导致 3 个测试二进制
SIGSEGV，并留下损坏的 .gcda 使 lcov 中途中止、覆盖率跌至 ~39%。

- compat.cmake: 测试构建(DOTEST/BUILD_TESTS)前置 DISABLE_HOOK ON
- hook.h: _CO_DISABLE_HOOK 分支补齐 POSIX 头文件，否则 sock.cc 编译失败

Log: 修复测试退出阶段 coost hook 导致的段错误
Influence: 修复 commonstruct/zrpc/daemon 测试二进制退出段错误；单元测试 覆盖率从 ~39% 恢复至 ~80%；仅影响测试构建，生产构建行为不变。