### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/src/apps/data-transfer/res/linux/deepin-data-transfer.desktop
+++ b/src/apps/data-transfer/res/linux/deepin-data-transfer.desktop
@@ -10,6 +10,7 @@ Terminal=false
 Type=Application
 X-Deepin-DEComponent=true
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!

--- a/src/apps/dde-cooperation/res/linux/dde-cooperation.desktop
+++ b/src/apps/dde-cooperation/res/linux/dde-cooperation.desktop
@@ -10,6 +10,7 @@ Terminal=false
 Type=Application
 X-Deepin-DEComponent=true
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add X-Deepin-Singleton=true to the desktop files for data-transfer and dde-cooperation to declare them as singleton apps.