### PR TITLE
fix(coverage): force DISABLE_HOOK cache var to fix fresh-configure crash

### DIFF
--- a/modules/compat.cmake
+++ b/modules/compat.cmake
@@ -57,7 +57,12 @@ set(BUILD_SHARED_LIBS ON)
 # 关闭后这些调用直接走 libc, 从根上消除该崩溃。须在 add_subdirectory(coost) 之前
 # 设置, 以覆盖 coost 自带 option(DISABLE_HOOK ... OFF) 的默认值。
 if(DOTEST OR BUILD_TESTS)
-    set(DISABLE_HOOK ON)
+    # 必须用 CACHE+FORCE: coost 子目录自带 cmake_minimum_required(VERSION 3.12),
+    # 进入子作用域后 CMake policy CMP0077 退化为 OLD/WARN, option(DISABLE_HOOK OFF)
+    # 会无视父级 set() 设置的 normal 变量, 直接写 cache 为 OFF, 导致
+    # _CO_DISABLE_HOOK 编译宏不会生效。用 FORCE 强制写 cache 可确保子目录的
+    # option() 看到已存在的 cache 值而不覆盖, 从而让 if(DISABLE_HOOK) 为真。
+    set(DISABLE_HOOK ON CACHE BOOL "disable hooks for system APIs" FORCE)
 endif()
 add_subdirectory("${COOST_DIR}" coost)
 


### PR DESCRIPTION
Previous fix set DISABLE_HOOK as a normal variable, but coost's subdirectory has its own cmake_minimum_required(VERSION 3.12), causing CMP0077 to fall back to OLD where option() ignores normal variables and overwrites the cache with OFF on fresh configure.

Coost 子目录自带 cmake_minimum_required(VERSION 3.12), 进入子作用域后 CMP0077 退化为 OLD, option() 会无视父级 normal 变量并覆写 cache, 导致 全新配置时 _CO_DISABLE_HOOK 编译宏缺失, 测试退出阶段 coost hook 触发 SIGSEGV, 覆盖率从 ~80% 跌至 ~32%。改用 set(... CACHE BOOL ... FORCE) 强制写 cache, option() 见到已存在值不再覆盖。

Log: 修复全新配置时 coost hook 未禁用导致覆盖率崩溃
Influence: 全新 clone 后跑 test-prj-running.sh 不再出现测试退出段错误, 覆盖率从 ~32% 恢复至 ~80.6%; 增量构建行为不变。