### PR TITLE
fix: push clipboard data to remote clients on primary screen grab

### DIFF
--- a/3rdparty/barrier/src/lib/server/Server.cpp
+++ b/3rdparty/barrier/src/lib/server/Server.cpp
@@ -1265,6 +1265,25 @@ Server::handleClipboardGrabbed(const Event& event, void* vclient)
 			client->grabClipboard(info->m_id);
 		}
 	}
+
+	// if the primary screen grabbed the clipboard (i.e. the user copied
+	// on the server side), read the actual clipboard data now and push
+	// it to all other clients.  without this the data would only be
+	// transferred when the mouse crosses the screen boundary (via
+	// switchScreen), leaving remote clients without clipboard content
+	// when the user never moves the mouse off the primary screen.
+	if (grabber == m_primaryClient) {
+		if (grabber->getClipboard(info->m_id, &clipboard.m_clipboard)) {
+			clipboard.m_clipboardData = clipboard.m_clipboard.marshall();
+			for (ClientList::iterator index = m_clients.begin();
+								index != m_clients.end(); ++index) {
+				BaseClientProxy* client = index->second;
+				if (client != grabber) {
+					client->setClipboard(info->m_id, &clipboard.m_clipboard);
+				}
+			}
+		}
+	}
 }
 
 void


### PR DESCRIPTION
When the primary screen (server side) grabs the clipboard, handleClipboardGrabbed only marked ownership and notified other screens to grab — it never read or sent the actual clipboard data. Real data was only transferred during screen switches (switchScreen/onClipboardChanged), so if the user copied text on the server side without moving the mouse to a client screen, remote clients never received the clipboard content.

Fix: in handleClipboardGrabbed, when the grabber is the primary client, read the clipboard data via getClipboard and push it to all non-grabber clients via setClipboard. This mirrors the client-side pattern in Client::handleClipboardGrabbed which sends clipboard data immediately when not active.

Log: PMS Bug 341993 — 协同后复制文本接收端剪贴板未显示

## Summary by Sourcery

Bug Fixes:
- Push clipboard contents to all remote clients immediately when the primary screen captures the clipboard, ensuring copied data is available without a screen switch.